### PR TITLE
Update build instruction link, remove EoS versions from specifications

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,3 +1,3 @@
 # NGINX Ingress Controller
 
-This doc is now available at <https://docs.nginx.com/nginx-ingress-controller/installation/building-nginx-ingress-controller/>
+For instructions, read the [Build NGINX Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/installation/build-nginx-ingress-controller/>) documentation.

--- a/site/content/technical-specifications.md
+++ b/site/content/technical-specifications.md
@@ -1,10 +1,10 @@
 ---
-docs: DOCS-617
-doctypes:
-- concept
 title: Technical specifications
 toc: true
 weight: 200
+doctype: reference
+product: NIC
+docs: DOCS-617
 ---
 
 This page describes technical specifications for F5 NGINX Ingress Controller, such as its version compatibility with Kubernetes and other NGINX software.
@@ -37,8 +37,6 @@ We test NGINX Ingress Controller on a range of Kubernetes platforms for each rel
 | 3.2.1 | 1.22 - 1.27 | 0.18.1 | 1.5.1 | 1.25.2 / R30 |
 | 3.1.1 | 1.22 - 1.26 | 0.17.1 | 1.4.2 | 1.23.4 / R29 |
 | 3.0.2 | 1.21 - 1.26 | 0.16.2 | 1.3.1 | 1.23.3 / R28 |
-| 2.4.2 | 1.19 - 1.25 | 0.15.2 | 1.2.1 | 1.23.2 / R28 |
-| 2.3.1 | 1.19 - 1.24 | 0.14.1 | 1.1.0 | 1.23.1 / R27 |
 {{% /bootstrap-table %}}
 
 ---


### PR DESCRIPTION
### Proposed changes

This commit updates the README in the build subfolder to point to the latest version of the build documentation, as the link was updated as part of previous documentation changes.

It also removes the last two entries from the supported Kubernetes versions table of the Technical specifications page, as they are now out of software and technical support.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
