### PR TITLE
Bump Go version to 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginx/kubernetes-ingress
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.0


### PR DESCRIPTION
### Proposed changes

This PR brings Go version 1.23.5. The release addresses following CVEs and [other fixes](https://github.com/golang/go/issues?q=milestone%3AGo1.23.5+label%3ACherryPickApproved):

```shell
net/http: sensitive headers incorrectly sent after cross-domain redirect [CVE-2024-45336]
crypto/x509: usage of IPv6 zone IDs can bypass URI name constraints [CVE-2024-45341]
```





### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
