### PR TITLE
Remove kind 1.32.1 from available kind versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       docs_only: ${{ github.event.pull_request && steps.docs.outputs.docs_only == 'true' }}
       some_docs: ${{ github.event.pull_request && steps.docs.outputs.some_docs == 'true' }}
-      k8s_latest: "1.32.0"
+      k8s_latest: ${{ steps.vars.outputs.k8s_latest }}
       go_path: ${{ steps.vars.outputs.go_path }}
       go_code_md5: ${{ steps.vars.outputs.go_code_md5 }}
       binary_cache_hit: ${{ steps.binary-cache.outputs.cache-hit }}
@@ -88,10 +88,10 @@ jobs:
         id: vars
         run: |
           kindest_latest=$(curl -s "https://hub.docker.com/v2/repositories/kindest/node/tags" \
-            | grep -o '"name": *"[^"]*' \
-            | grep -o '[^"]*$' \
+            | jq -r .results.[].name \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
             | sort -rV \
+            | grep -v v1.32.1 \
             | head -n 1 \
             | sed 's/^.\{1\}//' \
             | tr -d '\n')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       docs_only: ${{ github.event.pull_request && steps.docs.outputs.docs_only == 'true' }}
       some_docs: ${{ github.event.pull_request && steps.docs.outputs.some_docs == 'true' }}
-      k8s_latest: ${{ steps.vars.outputs.k8s_latest }}
+      k8s_latest: "1.32.0"
       go_path: ${{ steps.vars.outputs.go_path }}
       go_code_md5: ${{ steps.vars.outputs.go_code_md5 }}
       binary_cache_hit: ${{ steps.binary-cache.outputs.cache-hit }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -44,19 +44,19 @@ jobs:
         id: vars
         run: |
           kindest_latest=$(curl -s "https://hub.docker.com/v2/repositories/kindest/node/tags" \
-            | grep -o '"name": *"[^"]*' \
-            | grep -o '[^"]*$' \
+            | jq -r .results.[].name \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
             | sort -rV \
+            | grep -v v1.32.1 \
             | head -n 1 \
             | sed 's/^.\{1\}//' \
             | tr -d '\n')
           echo "k8s_latest=$kindest_latest" >> $GITHUB_OUTPUT
           kindest_versions=$(curl -s "https://hub.docker.com/v2/repositories/kindest/node/tags/?page_size=50" \
-            | grep -o '"name": *"[^"]*' \
-            | grep -o '[^"]*$' \
+            | jq -r .results.[].name \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
             | sort -rV \
+            | grep -v v1.32.1 \
             | awk -F. '!seen[$1"."$2]++' \
             | head -n 8 \
             | sort -V \


### PR DESCRIPTION
### Proposed changes

Kind 1.32.1 is not compatible with how we use kind, for now we will skip this version

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
