### PR TITLE
Move basic auth policy validation to CRD

### DIFF
--- a/config/crd/bases/k8s.nginx.org_policies.yaml
+++ b/config/crd/bases/k8s.nginx.org_policies.yaml
@@ -90,9 +90,16 @@ spec:
                 description: BasicAuth holds HTTP Basic authentication configuration
                 properties:
                   realm:
+                    description: The realm for basic authentication
+                    pattern: ^([^"$\\]|\\[^$])*$
                     type: string
                   secret:
+                    description: The name of the Kubernetes secret that stores the
+                      Htpasswd configuration
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
+                required:
+                - secret
                 type: object
               egressMTLS:
                 description: EgressMTLS defines an Egress MTLS policy.

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -252,9 +252,16 @@ spec:
                 description: BasicAuth holds HTTP Basic authentication configuration
                 properties:
                   realm:
+                    description: The realm for basic authentication
+                    pattern: ^([^"$\\]|\\[^$])*$
                     type: string
                   secret:
+                    description: The name of the Kubernetes secret that stores the
+                      Htpasswd configuration
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
+                required:
+                - secret
                 type: object
               egressMTLS:
                 description: EgressMTLS defines an Egress MTLS policy.

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -623,7 +623,13 @@ type JWTAuth struct {
 
 // BasicAuth holds HTTP Basic authentication configuration
 type BasicAuth struct {
-	Realm  string `json:"realm"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern=`^([^"$\\]|\\[^$])*$`
+	// The realm for basic authentication
+	Realm string `json:"realm,omitempty"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// The name of the Kubernetes secret that stores the Htpasswd configuration
 	Secret string `json:"secret"`
 }
 

--- a/pkg/apis/configuration/validation/policy.go
+++ b/pkg/apis/configuration/validation/policy.go
@@ -45,7 +45,6 @@ func validatePolicySpec(spec *v1.PolicySpec, fieldPath *field.Path, isPlus, enab
 	}
 
 	if spec.BasicAuth != nil {
-		allErrs = append(allErrs, validateBasic(spec.BasicAuth, fieldPath.Child("basicAuth"))...)
 		fieldCount++
 	}
 
@@ -204,18 +203,6 @@ func validateJWT(jwt *v1.JWTAuth, fieldPath *field.Path) field.ErrorList {
 		return allErrs
 	}
 	return allErrs
-}
-
-func validateBasic(basic *v1.BasicAuth, fieldPath *field.Path) field.ErrorList {
-	if basic.Secret == "" {
-		return field.ErrorList{field.Required(fieldPath.Child("secret"), "")}
-	}
-
-	allErrs := field.ErrorList{}
-	if basic.Realm != "" {
-		allErrs = append(allErrs, validateRealm(basic.Realm, fieldPath.Child("realm"))...)
-	}
-	return append(allErrs, validateSecretName(basic.Secret, fieldPath.Child("secret"))...)
 }
 
 func validateIngressMTLS(ingressMTLS *v1.IngressMTLS, fieldPath *field.Path) field.ErrorList {

--- a/pkg/apis/configuration/validation/policy_test.go
+++ b/pkg/apis/configuration/validation/policy_test.go
@@ -1982,24 +1982,6 @@ func TestValidateWAF_FailsOnInvalidApPolicy(t *testing.T) {
 	}
 }
 
-func TestValidateBasic_PassesOnNotEmptySecret(t *testing.T) {
-	t.Parallel()
-
-	errList := validateBasic(&v1.BasicAuth{Realm: "", Secret: "secret"}, field.NewPath("secret"))
-	if len(errList) != 0 {
-		t.Errorf("want no errors, got %v", errList)
-	}
-}
-
-func TestValidateBasic_FailsOnMissingSecret(t *testing.T) {
-	t.Parallel()
-
-	errList := validateBasic(&v1.BasicAuth{Realm: "realm", Secret: ""}, field.NewPath("secret"))
-	if len(errList) == 0 {
-		t.Error("want error on invalid input")
-	}
-}
-
 func TestValidateWAF_FailsOnPresentBothApLogBundleAndApLogConf(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Proposed changes

This change moved the basic auth policy validation to the CRD level, this ensures that the NIC process does not need to be involved in the Policy validation.

Tested with 
valid full spec:
```
apiVersion: k8s.nginx.org/v1
kind: Policy
metadata:
  name: basic-auth-policy
spec:
  basicAuth:
    secret: abc123
    realm: "f f f"
```

missing required field:
```
apiVersion: k8s.nginx.org/v1
kind: Policy
metadata:
  name: basic-auth-policy
spec:
  basicAuth:
    realm: "a.b.c"
```
missing optional field:
```
apiVersion: k8s.nginx.org/v1
kind: Policy
metadata:
  name: basic-auth-policy
spec:
  basicAuth:
    secret: mysecret
```
invalid secret name:
```
apiVersion: k8s.nginx.org/v1
kind: Policy
metadata:
  name: basic-auth-policy
spec:
  basicAuth:
    secret: ABC123
    realm: "a.b.c"
```
invalid realm name:
```
apiVersion: k8s.nginx.org/v1
kind: Policy
metadata:
  name: basic-auth-policy
spec:
  basicAuth:
    secret: abc123
    realm: a.b.ci$
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
