### PR TITLE
update operator owner for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,7 +315,7 @@ jobs:
           github-token: ${{ secrets.NGINX_PAT }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
+              owner: 'nginxinc',
               repo: 'nginx-ingress-helm-operator',
               workflow_id: 'sync-chart.yml',
               ref: 'main',


### PR DESCRIPTION
### Proposed changes

Since the migration to the `nginx` github org, the trigger to start the operator release process is failing due to NIC & the operator repo no longer being in the same org.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
