### PR TITLE
Update 4.0.1 release note to 2025 from 2024

### DIFF
--- a/site/content/releases.md
+++ b/site/content/releases.md
@@ -8,7 +8,7 @@ docs: DOCS-616
 ---
 ## 4.0.1
 
-07 Feb 2024
+07 Feb 2025 
 
 ### <i class="fa-solid fa-bug-slash"></i> Fixes
 - [7295](https://github.com/nginx/kubernetes-ingress/pull/7295) Clean up and fix for NIC Pod failing to bind when NGINX exits unexpectedly


### PR DESCRIPTION
### Proposed changes

This pull request updates the release note for 4.0.1 to mention the year 2025 instead of 2024 for the most recent release.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
