### PR TITLE
Update WAF v5 docs to reference WAF Compiler

### DIFF
--- a/site/content/installation/integrations/app-protect-waf-v5/configuration.md
+++ b/site/content/installation/integrations/app-protect-waf-v5/configuration.md
@@ -11,7 +11,7 @@ This document explains how to use F5 NGINX Ingress Controller to configure [NGIN
 
 {{< note >}} There are complete NGINX Ingress Controller with NGINX App Protect WAF [example resources on GitHub](https://github.com/nginx/kubernetes-ingress/tree/v{{< nic-version >}}/examples/custom-resources/app-protect-waf-v5).
 
-F5 recommends recompiling your NGINX AppProtect WAF Policy Bundles with each release of NGINX Ingress Controller. This ensures Policies remain compatible and are compiled with the latest attack signatures, bot signatures, and Ttreat campaigns.{{< /note >}}
+F5 recommends compiling/recompiling your NGINX AppProtect WAF Policy Bundles using the [NGINX App Protect Compiler](https://docs.nginx.com/nginx-app-protect-waf/v5/admin-guide/compiler/) with each release of NGINX Ingress Controller. This ensures Policies remain compatible and are compiled with the latest attack signatures, bot signatures, and Threat campaigns.{{< /note >}}
 
 ## Global configuration
 


### PR DESCRIPTION
### Proposed changes

This change updates our WAF v5 docs go guide users to the NGINX App Protect Compiler docs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
