### PR TITLE
Add helm knob to control `ClusterRoleBinding` creation

### DIFF
--- a/charts/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/charts/nginx-ingress/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.rbac.clusterrolebinding.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -602,6 +602,10 @@ rbac:
     ## Create ClusterRole
     create: true
 
+  clusterrolebinding:
+    ## Create ClusterRoleBinding
+    create: true
+
 prometheus:
   ## Expose NGINX or NGINX Plus metrics in the Prometheus format.
   create: true

--- a/site/content/installation/installing-nic/installation-with-helm.md
+++ b/site/content/installation/installing-nic/installation-with-helm.md
@@ -464,6 +464,7 @@ The following tables lists the configurable parameters of the NGINX Ingress Cont
 | **controller.enableWeightChangesDynamicReload** | Enable weight changes without reloading the NGINX configuration. May require increasing `map_hash_bucket_size`, `map_hash_max_size`, `variable_hash_bucket_size`, and `variable_hash_max_size` in the [ConfigMap](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource/) if there are many two-way splits. Requires `controller.nginxplus` | false |
 | **rbac.create** | Configures RBAC. | true |
 | **rbac.clusterrole.create** | Configures creation of ClusterRole. Creation can be disabled when more fine-grained control over RBAC is required. For example when controller.watchNamespace is used. | true |
+| **rbac.clusterrolebinding.create** | Configures creation of ClusterRoleBinding. Creation can be disabled when more fine-grained control over RBAC is required. For example when controller.watchNamespace is used. | true |
 | **prometheus.create** | Expose NGINX or NGINX Plus metrics in the Prometheus format. | true |
 | **prometheus.port** | Configures the port to scrape the metrics. | 9113 |
 | **prometheus.scheme** | Configures the HTTP scheme to use for connections to the Prometheus endpoint. | http |


### PR DESCRIPTION
### Proposed changes

Adds a knob to toggle creation of the `ClusterRoleBinding`, closing #7577. This is a follow-up to #5228. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
