### PR TITLE
Update docs to fix kubernates typos

### DIFF
--- a/site/content/installation/installing-nic/installation-with-helm.md
+++ b/site/content/installation/installing-nic/installation-with-helm.md
@@ -210,9 +210,9 @@ The steps you should follow depend on the Helm release name:
 
 2. Checkout the latest available tag using `git checkout v{{< nic-version >}}`
 
-3. Navigate to `/kubernates-ingress/charts/nginx-ingress`
+3. Navigate to `/kubernetes-ingress/charts/nginx-ingress`
 
-4. Update the `selectorLabels: {}` field in the `values.yaml` file located at `/kubernates-ingress/charts/nginx-ingress` with the copied `Selector` value.
+4. Update the `selectorLabels: {}` field in the `values.yaml` file located at `/kubernetes-ingress/charts/nginx-ingress` with the copied `Selector` value.
     ```shell
     selectorLabels: {app: nginx-ingress-nginx-ingress}
     ```
@@ -255,9 +255,9 @@ The steps you should follow depend on the Helm release name:
 
 2. Checkout the latest available tag using `git checkout v{{< nic-version >}}`
 
-3. Navigate to `/kubernates-ingress/charts/nginx-ingress`
+3. Navigate to `/kubernetes-ingress/charts/nginx-ingress`
 
-4. Update the `selectorLabels: {}` field in the `values.yaml` file located at `/kubernates-ingress/charts/nginx-ingress` with the copied `Selector` value.
+4. Update the `selectorLabels: {}` field in the `values.yaml` file located at `/kubernetes-ingress/charts/nginx-ingress` with the copied `Selector` value.
 
     ```shell
     selectorLabels: {app: <helm_release_name>-nginx-ingress}


### PR DESCRIPTION
Issue reported by Fabrizio Fiorucci in Slack.

### Proposed changes

Replaces every instance of `kubernates` with `kubernetes` in the installation documentation.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
