### PR TITLE
temporarily disable builds failing for NAP WAF v4 on UBI

### DIFF
--- a/.github/config/config-gcr-retag
+++ b/.github/config/config-gcr-retag
@@ -1,7 +1,7 @@
 export TARGET_REGISTRY=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev
 declare -a PLUS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine" "-alpine-fips" "-mktpl")
-declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "-ubi8" "-mktpl" "-alpine-fips")
+declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-mktpl" "-alpine-fips")
 declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "-ubi8" "-alpine-fips")
 declare -a NAP_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl")
-declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl")
+declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-mktpl")
 declare -a ADDITIONAL_TAGS=()

--- a/.github/config/config-plus-gcr-release
+++ b/.github/config/config-plus-gcr-release
@@ -1,8 +1,8 @@
 export TARGET_REGISTRY=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release
 declare -a PLUS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine" "-alpine-fips" "-mktpl")
-declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "-ubi8" "-alpine-fips" "-mktpl")
+declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-alpine-fips" "-mktpl")
 declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "-alpine-fips" "-ubi8")
 declare -a NAP_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl")
-declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl")
+declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-mktpl")
 declare -a ADDITIONAL_TAGS=("latest" "${ADDITIONAL_TAG}")
 export PUBLISH_OSS=false

--- a/.github/config/config-plus-nginx
+++ b/.github/config/config-plus-nginx
@@ -1,8 +1,8 @@
 export TARGET_REGISTRY=docker-mgmt.nginx.com
 export TARGET_NAP_WAF_DOS_IMAGE_PREFIX="nginx-ic-nap-dos/nginx-plus-ingress"
 declare -a PLUS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine" "-alpine-fips")
-declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "-ubi8" "-alpine-fips")
+declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-alpine-fips")
 declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "-ubi8" "-alpine-fips")
 declare -a NAP_DOS_TAG_POSTFIX_LIST=("" "-ubi")
-declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-ubi")
+declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("")
 export PUBLISH_OSS=false

--- a/.github/data/matrix-images-nap.json
+++ b/.github/data/matrix-images-nap.json
@@ -16,12 +16,6 @@
   ],
   "include": [
     {
-      "image": "ubi-8-plus-nap",
-      "target": "goreleaser",
-      "platforms": "linux/amd64",
-      "nap_modules": "waf"
-    },
-    {
       "image": "ubi-8-plus-nap-v5",
       "target": "goreleaser",
       "platforms": "linux/amd64",
@@ -31,19 +25,7 @@
       "image": "ubi-9-plus-nap",
       "target": "goreleaser",
       "platforms": "linux/amd64",
-      "nap_modules": "waf"
-    },
-    {
-      "image": "ubi-9-plus-nap",
-      "target": "goreleaser",
-      "platforms": "linux/amd64",
       "nap_modules": "dos"
-    },
-    {
-      "image": "ubi-9-plus-nap",
-      "target": "goreleaser",
-      "platforms": "linux/amd64",
-      "nap_modules": "waf,dos"
     },
     {
       "image": "alpine-plus-nap-fips",

--- a/.github/data/matrix-smoke-nap.json
+++ b/.github/data/matrix-smoke-nap.json
@@ -2,7 +2,7 @@
   "images": [
     {
       "label": "AP_WAF 1/4",
-      "image": "ubi-8-plus-nap",
+      "image": "debian-plus-nap",
       "type": "plus",
       "nap_modules": "waf",
       "marker": "appprotect_waf_policies_allow",
@@ -10,7 +10,7 @@
     },
     {
       "label": "AP_WAF 2/4",
-      "image": "ubi-9-plus-nap",
+      "image": "debian-plus-nap",
       "type": "plus",
       "nap_modules": "waf",
       "marker": "'appprotect_waf_policies and not appprotect_waf_policies_allow and not appprotect_waf_policies_vsr'",


### PR DESCRIPTION
### Proposed changes

Disable failing image builds to allow release generation to progress.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
