### PR TITLE
Use pod labels as headless selector labels

### DIFF
--- a/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/nginx-ingress/templates/_helpers.tpl
@@ -58,7 +58,6 @@ helm.sh/chart: {{ include "nginx-ingress.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-zone-sync.nginx.com/name: {{ .Chart.Name }}
 {{- end }}
 
 {{/*
@@ -87,7 +86,6 @@ Selector labels
 {{ toYaml .Values.controller.selectorLabels }}
 {{- else -}}
 app.kubernetes.io/name: {{ include "nginx-ingress.name" . }}
-zone-sync.nginx.com/name: {{ include "nginx-ingress.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}

--- a/charts/tests/__snapshots__/helmunit_test.snap
+++ b/charts/tests/__snapshots__/helmunit_test.snap
@@ -10,11 +10,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -25,11 +23,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -43,11 +39,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   license-token-secret-name: license-token
 /-/-/-/
@@ -60,11 +54,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -74,11 +66,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -200,11 +190,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: appprotect-dos-nginx-ingress
@@ -222,11 +210,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: appprotect-dos
 rules:
 - apiGroups:
@@ -284,11 +270,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: appprotect-dos
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -308,11 +292,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -329,7 +311,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -341,23 +322,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: appprotect-dos
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: appprotect-dos
       annotations:
         prometheus.io/scrape: "true"
@@ -474,11 +451,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -491,11 +466,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-dos
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/appProtectWAF - 1]
@@ -509,11 +482,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -524,11 +495,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -542,11 +511,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   license-token-secret-name: license-token
 /-/-/-/
@@ -559,11 +526,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -573,11 +538,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -699,11 +662,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: appprotect-waf-nginx-ingress
@@ -721,11 +682,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: appprotect-waf
 rules:
 - apiGroups:
@@ -783,11 +742,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: appprotect-waf
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -807,11 +764,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -828,7 +783,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -840,23 +794,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: appprotect-waf
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: appprotect-waf
       annotations:
         prometheus.io/scrape: "true"
@@ -968,11 +918,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -985,11 +933,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-waf
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/appProtectWAFV5 - 1]
@@ -1003,11 +949,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -1018,11 +962,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -1036,11 +978,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   license-token-secret-name: license-token
 /-/-/-/
@@ -1053,11 +993,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -1067,11 +1005,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -1193,11 +1129,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: appprotect-wafv5-nginx-ingress
@@ -1215,11 +1149,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: appprotect-wafv5
 rules:
 - apiGroups:
@@ -1277,11 +1209,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: appprotect-wafv5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1301,11 +1231,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -1322,7 +1250,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -1334,23 +1261,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: appprotect-wafv5
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: appprotect-wafv5
       annotations:
         prometheus.io/scrape: "true"
@@ -1509,11 +1432,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -1526,11 +1447,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: appprotect-wafv5
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/customResources - 1]
@@ -1544,11 +1463,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -1559,11 +1476,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -1576,11 +1491,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -1590,11 +1503,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -1685,11 +1596,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: custom-resources-nginx-ingress
@@ -1707,11 +1616,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: custom-resources
 rules:
 - apiGroups:
@@ -1769,11 +1676,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: custom-resources
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1793,11 +1698,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -1814,7 +1717,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -1826,23 +1728,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: custom-resources
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: custom-resources
       annotations:
         prometheus.io/scrape: "true"
@@ -1947,11 +1845,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -1967,11 +1863,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: custom-resources
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/daemonset - 1]
@@ -1985,11 +1879,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -2000,11 +1892,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -2017,11 +1907,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -2031,11 +1919,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -2147,11 +2033,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: daemonset-nginx-ingress
@@ -2169,11 +2053,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 rules:
 - apiGroups:
@@ -2231,11 +2113,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2255,11 +2135,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -2276,7 +2154,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
 /-/-/-/
 # Source: nginx-ingress/templates/controller-daemonset.yaml
@@ -2288,22 +2165,18 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: daemonset
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: daemonset
       annotations:
         prometheus.io/scrape: "true"
@@ -2415,11 +2288,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -2435,11 +2306,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: daemonset
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/default_values_file - 1]
@@ -2453,11 +2322,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -2468,11 +2335,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -2485,11 +2350,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -2499,11 +2362,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -2615,11 +2476,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: default-nginx-ingress
@@ -2637,11 +2496,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 rules:
 - apiGroups:
@@ -2699,11 +2556,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2723,11 +2578,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -2744,7 +2597,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -2756,23 +2608,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: default
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: default
       annotations:
         prometheus.io/scrape: "true"
@@ -2883,11 +2731,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -2903,11 +2749,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/globalConfig - 1]
@@ -2921,11 +2765,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -2936,11 +2778,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -2953,11 +2793,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -2967,11 +2805,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -3083,11 +2919,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: global-configuration-nginx-ingress
@@ -3105,11 +2939,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: gc
 rules:
 - apiGroups:
@@ -3167,11 +2999,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: gc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3191,11 +3021,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -3212,7 +3040,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -3224,23 +3051,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: global-configuration
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: global-configuration
       annotations:
         prometheus.io/scrape: "true"
@@ -3352,11 +3175,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -3372,11 +3193,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   listeners:
   - name: dns-udp
@@ -3395,11 +3214,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: global-configuration
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/ingressClass - 1]
@@ -3413,11 +3230,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -3428,11 +3243,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -3445,11 +3258,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -3459,11 +3270,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -3575,11 +3384,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: ingress-class-nginx-ingress
@@ -3597,11 +3404,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 rules:
 - apiGroups:
@@ -3659,11 +3464,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3683,11 +3486,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -3704,7 +3505,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -3716,23 +3516,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: ingress-class
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: ingress-class
       annotations:
         prometheus.io/scrape: "true"
@@ -3843,11 +3639,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
 spec:
@@ -3865,11 +3659,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: ingress-class
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/namespace - 1]
@@ -3883,11 +3675,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -3898,11 +3688,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -3915,11 +3703,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -3929,11 +3715,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -4045,11 +3829,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: namespace-nginx-ingress
@@ -4067,11 +3849,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: nginx-ingress
 rules:
 - apiGroups:
@@ -4129,11 +3909,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: nginx-ingress
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -4153,11 +3931,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -4174,7 +3950,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -4186,23 +3961,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: namespace
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: namespace
       annotations:
         prometheus.io/scrape: "true"
@@ -4313,11 +4084,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -4333,11 +4102,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: namespace
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/plus - 1]
@@ -4351,11 +4118,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -4366,11 +4131,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -4384,11 +4147,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   license-token-secret-name: license-token
 /-/-/-/
@@ -4401,11 +4162,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -4415,11 +4174,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -4531,11 +4288,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: plus-nginx-ingress
@@ -4553,11 +4308,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 rules:
 - apiGroups:
@@ -4615,11 +4368,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -4639,11 +4390,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -4660,7 +4409,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -4672,23 +4420,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: plus
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: plus
       annotations:
         prometheus.io/scrape: "true"
@@ -4800,11 +4544,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -4817,11 +4559,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/plus-debug - 1]
@@ -4835,11 +4575,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -4850,11 +4588,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -4868,11 +4604,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   license-token-secret-name: license-token
 /-/-/-/
@@ -4885,11 +4619,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -4899,11 +4631,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -5015,11 +4745,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: plus-debug-nginx-ingress
@@ -5037,11 +4765,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 rules:
 - apiGroups:
@@ -5099,11 +4825,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -5123,11 +4847,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -5144,7 +4866,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -5156,23 +4877,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: plus-debug
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: plus-debug
       annotations:
         prometheus.io/scrape: "true"
@@ -5294,11 +5011,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -5311,11 +5026,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-debug
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/plus-mgmt - 1]
@@ -5329,11 +5042,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -5344,11 +5055,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -5362,11 +5071,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   license-token-secret-name: license
   ssl-verify: "false"
@@ -5389,11 +5096,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -5403,11 +5108,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -5519,11 +5222,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: plus-mgmt-nginx-ingress
@@ -5541,11 +5242,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 rules:
 - apiGroups:
@@ -5603,11 +5302,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -5627,11 +5324,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -5648,7 +5343,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -5660,23 +5354,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: plus-mgmt
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: plus-mgmt
       annotations:
         prometheus.io/scrape: "true"
@@ -5798,11 +5488,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -5815,11 +5503,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/plus-mgmt-custom-endpoint - 1]
@@ -5833,11 +5519,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -5848,11 +5532,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -5866,11 +5548,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   license-token-secret-name: license-token
   usage-report-endpoint: "11.22.33.44"
@@ -5884,11 +5564,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -5898,11 +5576,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -6014,11 +5690,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: plus-mgmt-custom-endpoint-nginx-ingress
@@ -6036,11 +5710,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 rules:
 - apiGroups:
@@ -6098,11 +5770,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6122,11 +5792,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -6143,7 +5811,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -6155,23 +5822,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: plus-mgmt-custom-endpoint
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: plus-mgmt-custom-endpoint
       annotations:
         prometheus.io/scrape: "true"
@@ -6283,11 +5946,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -6300,11 +5961,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-custom-endpoint
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/plus-mgmt-proxy-host - 1]
@@ -6318,11 +5977,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -6333,11 +5990,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -6351,11 +6006,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   license-token-secret-name: license-token
   usage-report-proxy-host: "44.55.66.77:88"
@@ -6369,11 +6022,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -6383,11 +6034,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -6499,11 +6148,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: plus-mgmt-proxy-host-nginx-ingress
@@ -6521,11 +6168,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 rules:
 - apiGroups:
@@ -6583,11 +6228,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6607,11 +6250,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -6628,7 +6269,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -6640,23 +6280,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: plus-mgmt-proxy-host
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: plus-mgmt-proxy-host
       annotations:
         prometheus.io/scrape: "true"
@@ -6768,11 +6404,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -6785,11 +6419,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---
 
 [TestHelmNICTemplate/plus-mgmt-proxy-host-auth - 1]
@@ -6803,11 +6435,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/controller-configmap.yaml
 apiVersion: v1
@@ -6818,11 +6448,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   {}
 /-/-/-/
@@ -6836,11 +6464,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 data:
   license-token-secret-name: license-token
   usage-report-proxy-host: "44.55.66.77:88"
@@ -6854,11 +6480,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 /-/-/-/
 # Source: nginx-ingress/templates/clusterrole.yaml
 kind: ClusterRole
@@ -6868,11 +6492,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 rules:
 - apiGroups:
   - ""
@@ -6984,11 +6606,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 subjects:
 - kind: ServiceAccount
   name: plus-mgmt-proxy-host-auth-nginx-ingress
@@ -7006,11 +6626,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 rules:
 - apiGroups:
@@ -7068,11 +6686,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7092,11 +6708,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -7113,7 +6727,6 @@ spec:
     nodePort: 
   selector:
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
 /-/-/-/
 # Source: nginx-ingress/templates/controller-deployment.yaml
@@ -7125,23 +6738,19 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
       app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
   template:
     metadata:
       labels:
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
         app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
       annotations:
         prometheus.io/scrape: "true"
@@ -7263,11 +6872,9 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 spec:
   controller: nginx.org/ingress-controller
 /-/-/-/
@@ -7280,9 +6887,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-ingress-2.1.0
     app.kubernetes.io/name: nginx-ingress
-    zone-sync.nginx.com/name: nginx-ingress
     app.kubernetes.io/instance: plus-mgmt-proxy-host-auth
     app.kubernetes.io/version: "4.1.0"
     app.kubernetes.io/managed-by: Helm
-    zone-sync.nginx.com/name: nginx-ingress
 ---

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -1091,14 +1091,14 @@ func createAndValidateHeadlessService(ctx context.Context, kubeClient *kubernete
 	}
 	combinedDeployment := fmt.Sprintf("%s-%s", name, strings.ToLower(owner.Kind))
 	cfgParams.ZoneSync.Domain = combinedDeployment
-	err := createHeadlessService(l, kubeClient, controllerNamespace, fmt.Sprintf("%s-hl", combinedDeployment), *nginxConfigMaps)
+	err := createHeadlessService(l, kubeClient, controllerNamespace, fmt.Sprintf("%s-hl", combinedDeployment), *nginxConfigMaps, pod)
 	if err != nil {
 		return fmt.Errorf("failed to create headless Service: %w", err)
 	}
 	return nil
 }
 
-func createHeadlessService(l *slog.Logger, kubeClient *kubernetes.Clientset, controllerNamespace string, svcName string, configMapNamespacedName string) error {
+func createHeadlessService(l *slog.Logger, kubeClient *kubernetes.Clientset, controllerNamespace string, svcName string, configMapNamespacedName string, pod *api_v1.Pod) error {
 	existing, err := kubeClient.CoreV1().Services(controllerNamespace).Get(context.Background(), svcName, meta_v1.GetOptions{})
 	if err == nil && existing != nil {
 		nl.Infof(l, "headless service %s/%s already exists, skipping creating.", controllerNamespace, svcName)
@@ -1133,9 +1133,7 @@ func createHeadlessService(l *slog.Logger, kubeClient *kubernetes.Clientset, con
 		},
 		Spec: api_v1.ServiceSpec{
 			ClusterIP: api_v1.ClusterIPNone,
-			Selector: map[string]string{
-				"zone-sync.nginx.com/name": "nginx-ingress",
-			},
+			Selector:  pod.Labels,
 		},
 	}
 

--- a/deployments/daemon-set/nginx-plus-ingress.yaml
+++ b/deployments/daemon-set/nginx-plus-ingress.yaml
@@ -7,13 +7,11 @@ spec:
   selector:
     matchLabels:
       app: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
   template:
     metadata:
       labels:
         app: nginx-ingress
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
      #annotations:
        #prometheus.io/scrape: "true"
        #prometheus.io/port: "9113"

--- a/deployments/deployment/nginx-plus-ingress.yaml
+++ b/deployments/deployment/nginx-plus-ingress.yaml
@@ -8,13 +8,11 @@ spec:
   selector:
     matchLabels:
       app: nginx-ingress
-      zone-sync.nginx.com/name: nginx-ingress
   template:
     metadata:
       labels:
         app: nginx-ingress
         app.kubernetes.io/name: nginx-ingress
-        zone-sync.nginx.com/name: nginx-ingress
      #annotations:
        #prometheus.io/scrape: "true"
        #prometheus.io/port: "9113"

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -161,9 +161,7 @@ func (lbc *LoadBalancerController) syncZoneSyncHeadlessService(svcName string) e
 			},
 			Spec: v1.ServiceSpec{
 				ClusterIP: v1.ClusterIPNone,
-				Selector: map[string]string{
-					"zone-sync.nginx.com/name": "nginx-ingress",
-				},
+				Selector:  lbc.metadata.pod.Labels,
 			},
 		}
 

--- a/internal/telemetry/cluster_test.go
+++ b/internal/telemetry/cluster_test.go
@@ -577,9 +577,8 @@ var (
 				},
 			},
 			Labels: map[string]string{
-				"app":                      "nginx-ingress",
-				"zone-sync.nginx.com/name": "nginx-ingress",
-				"app.kubernetes.io/name":   "nginx-ingress",
+				"app":                    "nginx-ingress",
+				"app.kubernetes.io/name": "nginx-ingress",
 			},
 		},
 		Spec: apiCoreV1.PodSpec{
@@ -613,9 +612,8 @@ var (
 			Name:      "nginx-ingress",
 			Namespace: "nginx-ingress",
 			Labels: map[string]string{
-				"app":                      "nginx-ingress",
-				"zone-sync.nginx.com/name": "nginx-ingress",
-				"app.kubernetes.io/name":   "nginx-ingress",
+				"app":                    "nginx-ingress",
+				"app.kubernetes.io/name": "nginx-ingress",
 			},
 			OwnerReferences: []metaV1.OwnerReference{
 				{
@@ -652,9 +650,8 @@ var (
 				},
 			},
 			Labels: map[string]string{
-				"app":                      "nginx-ingress",
-				"zone-sync.nginx.com/name": "nginx-ingress",
-				"app.kubernetes.io/name":   "nginx-ingress",
+				"app":                    "nginx-ingress",
+				"app.kubernetes.io/name": "nginx-ingress",
 			},
 		},
 		Spec: apiCoreV1.PodSpec{
@@ -688,7 +685,7 @@ var (
 			Name:      "nginx-ingress",
 			Namespace: "nginx-ingress",
 			UID:       types.UID(installationIDDaemonSet),
-			Labels:    map[string]string{"app": "nginx-ingress", "zone-sync.nginx.com/name": "nginx-ingress"},
+			Labels:    map[string]string{"app": "nginx-ingress"},
 		},
 		Spec: appsV1.DaemonSetSpec{},
 		Status: appsV1.DaemonSetStatus{


### PR DESCRIPTION
### Proposed changes

Update the headless service generation for `zone-sync` to use the pods labels as the selector labels for the headless service.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
