### PR TITLE
cherry pick to chosen branch

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -22,6 +22,18 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.NGINX_PAT }}
 
+      - name: Check if Actor is a Member of one of the teams
+        uses: im-open/is-actor-team-member@v1.2.0
+        with:
+          github-actor: ${{ github.actor }}
+          github-organization: ${{ github.repository_owner}}
+          github-team-slugs: |
+            [
+              "nic",
+              "nginx-docs"
+            ]
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set release branch variable
         id: branch
         env:

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -20,10 +20,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.NGINX_PAT }}
 
       - name: Check if Actor is a Member of one of the teams
-        uses: im-open/is-actor-team-member@v1.2.0
+        uses: im-open/is-actor-team-member@6633b6e4d9bd2a6917f976b14c64626902e13805 # v1.2.0
         with:
           github-actor: ${{ github.actor }}
           github-organization: ${{ github.repository_owner}}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -28,10 +28,10 @@ jobs:
           github-organization: ${{ github.repository_owner}}
           github-team-slugs: |
             [
-              "nic",
+              "kic",
               "nginx-docs"
             ]
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.NGINX_PAT }}
 
       - name: Set release branch variable
         id: branch

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,9 +1,8 @@
 name: "Cherry-pick dependencies to release branch"
 on:
-  pull_request:
-    branches:
-      - main
-    types: ["closed"]
+  issue_comment:
+    types:
+      - created
 
 permissions:
   contents: read
@@ -15,7 +14,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-22.04
     name: Cherry pick into release branch
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'dependencies') || contains(github.event.pull_request.labels.*.name, 'needs cherry pick')) && github.event.pull_request.merged == true }}
+    if: ${{ github.event.issue.pull_request.merged_at != null }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -25,13 +24,21 @@ jobs:
 
       - name: Set release branch variable
         id: branch
+        env:
+          comment_body: ${{ github.event.comment.body }}
         run: |
-          branch=$(git branch -a | egrep '^\s+remotes/origin/release' | awk '{print $1}' | sort -u | tail -n 1)
-          release_branch=$(basename ${branch})
-          echo "branch=${release_branch}" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+          regex="/cherry-pick to (release-[2-9]+\.[0-9]+)"
+          if [[ "${comment_body}" =~ $regex ]]; then
+            branch=${BASH_REMATCH[1]}
+            if git branch -a | egrep '^\s+remotes/origin/release' | grep -q "${branch}"; then
+              echo "branch=${branch}" >> $GITHUB_OUTPUT
+            else
+              echo "branch=" >> $GITHUB_OUTPUT
+            fi
+          fi
 
       - name: Cherry pick into ${{ steps.branch.outputs.branch }}
+        if: ${{ steps.branch.outputs.branch }}
         uses: carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3 # v1.0.10
         with:
           branch: ${{ steps.branch.outputs.branch }}


### PR DESCRIPTION
### Proposed changes

Change cherry-pick logic to be based off comments from authorised users.  Only works on already merged PR's.  Users can choose which release branch to cherry pick to and can comment for additional release branches as well as the current release branch.

### Usage
```
/cherry-pick to release-4.0
/cherry-pick to release-5.0
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
