### PR TITLE
docs: Adds installation guide for NIC and waf

### DIFF
--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -21,31 +21,18 @@ This is accomplished with the following steps:
 
 ## Prepare Secrets and credentials
 
-Download the following files from your [MyF5 Portal](https://my.f5.com):
+1. Download your NGINX Ingress Controller subscription's JSON Web Token, SSL Certificate, and Private Key from MyF5. 
+   You can use the same JSON Web Token, Certificate, and Key as NGINX Plus in your MyF5 portal.
+2. Rename the files to the following:
+   - `nginx-repo.crt`
+   - `nginx-repo.key`
+   - `nginx-repo.jwt`
+3. Log in to the Docker registry using the contents of the JSON Web Token file:
+   ```shell
+   $ docker login private-registry.nginx.com --username=$(cat nginx-repo.jwt) --password=none
+   ```
 
-- `nginx-repo.crt`
-- `nginx-repo.key`
-- `nginx-jwt.token`
-
-Store these files locally:
-
-```
-├── nginx-repo.crt
-├── nginx-repo.key
-└── nginx-repo.jwt
-```
-
-
-## Step 2: Pull the NGINX App Protect WAF Compiler image
-
-Log into the nginx private registry using your jwt file and the password `none` which you will have to type in when 
-asked:
-
-```shell
-$ docker login private-registry.nginx.com --username=$(cat nginx-repo.jwt)
-
-i Info → A Personal Access Token (PAT) can be used instead.
-         To create a PAT, visit https://app.docker.com/settings
+---
 
 
 Password:

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -9,7 +9,9 @@ docs: DOCS-609
 
 ## How To: Build and Use a Local NGINX App Protect Docker Image to Compile WAF Policies and Integrate with NGINX Plus Ingress Controller
 
-This document outlines how to:
+This document describes how to build a local NGINX App Protect WAF Docker image with NGINX Plus Ingress Controller, which can be used to compile WAF policies.
+
+This is accomplished with the following steps:
 
 - Set up license secrets to enable deployment into kubernetes
 - Use a WAF docker image to compile a policy JSON file into a compiled bundle

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -73,7 +73,7 @@ After this command, your workspace should contain:
 
 ## Create the persistent volume and claim to store the policy bundle
 
-Save the following configuration data as `pvc.yml` in the same directory.
+Save the following configuration data as `pvc.yaml` in the same directory.
 
 ```yaml
 apiVersion: v1

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -11,10 +11,10 @@ This document describes how to build a local NGINX App Protect WAF Docker image 
 
 This is accomplished with the following steps:
 
-- Set up license secrets to enable deployment into kubernetes
-- Use a WAF docker image to compile a policy JSON file into a compiled bundle
-- Set up PersistentVolumes that the deployed WAF instance can access to read the bundle from
-- Deploy NGINX Plus Ingress Controller with NAP in Kubernetes
+- Prepare license secrets to enable a Kubernetes deployment
+- Use a NGINX App Protect WAF Docker image to transform a policy JSON file into a compiled bundle
+- Configure PersistentVolumes so the deployed NGINX App Protect WAF instance can access the compiled bundle
+- Deploy NGINX Plus Ingress Controller with NGINX App Protect
 - Test example services to validate that the WAF policies work
 
 ---

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy NIC and WAF to Kubernetes using Helm
+title: Install NGINX Ingress Controller and NGINX App Protect WAF with Docker and Helm
 toc: true
 weight: 500
 type: how-to

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -7,8 +7,6 @@ product: NIC
 docs: DOCS-609
 ---
 
-## How To: Build and Use a Local NGINX App Protect Docker Image to Compile WAF Policies and Integrate with NGINX Plus Ingress Controller
-
 This document describes how to build a local NGINX App Protect WAF Docker image with NGINX Plus Ingress Controller, which can be used to compile WAF policies.
 
 This is accomplished with the following steps:

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -153,17 +153,21 @@ kubectl apply -f https://raw.githubusercontent.com/nginx/kubernetes-ingress/v5.0
 Using helm, install NGINX Ingress Controller
 
 ```shell
-helm upgrade nic nginx-stable/nginx-ingress \
-    --set controller.image.repository="private-registry.nginx.com/nginx-ic-nap-v5/nginx-plus-ingress" \
-    --set controller.image.tag="5.0.0-alpine-fips" \
-    --set controller.nginxplus=true \
-    --set controller.appprotect.enable=true \
-    --set controller.appprotect.v5=true \
-    --set controller.appprotect.volumes[2].persistentVolumeClaim.claimName="task-pv-claim" \
-    --set controller.serviceAccount.imagePullSecretName="regcred" \
-    --set controller.volumeMounts[0].name="app-protect-bundles" \
-    --set controller.volumeMounts[0].mountPath="/etc/app_protect/bundles/" \
-    --install
+helm upgrade --install nic nginx-stable/nginx-ingress \
+   --set controller.image.repository="private-registry.nginx.com/nginx-ic-nap-v5/nginx-plus-ingress" \
+   --set controller.image.tag="5.0.0-alpine-fips" \
+   --set controller.nginxplus=true \
+   --set controller.appprotect.enable=true \
+   --set controller.appprotect.v5=true \
+   --set-json 'controller.appprotect.volumes=[
+      {"name":"app-protect-bd-config","emptyDir":{}},
+      {"name":"app-protect-config","emptyDir":{}},
+      {"name":"app-protect-bundles","persistentVolumeClaim":{"claimName":"task-pv-claim"}}
+   ]' \
+   --set controller.serviceAccount.imagePullSecretName=regcred \
+   --set 'controller.volumeMounts[0].name=app-protect-bundles' \
+   --set 'controller.volumeMounts[0].mountPath=/etc/app_protect/bundles/'
+
 ```
 
 Verify deployment success:
@@ -265,6 +269,17 @@ spec:
       name: http
   selector:
     app: webapp
+```
+
+Create the services with
+```shell
+kubectl apply -f webapp.yaml
+```
+
+Confirm that the services have started with
+
+```shell
+kubectl get pods
 ```
 
 ### Save the public IP and PORT in environment variables

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -7,7 +7,7 @@ product: NIC
 docs: DOCS-609
 ---
 
-This document describes how to build a local NGINX App Protect WAF Docker image with NGINX Plus Ingress Controller, which can be used to compile WAF policies.
+This document describes how to build a local F5 NGINX App Protect WAF Docker image with NGINX Plus Ingress Controller, which can be used to compile WAF policies.
 
 This is accomplished with the following steps:
 
@@ -23,13 +23,13 @@ This is accomplished with the following steps:
 
 1. Download your NGINX Ingress Controller subscription's JSON Web Token, SSL Certificate, and Private Key from MyF5. 
    You can use the same JSON Web Token, Certificate, and Key as NGINX Plus in your MyF5 portal.
-2. Rename the files to the following:
+1. Rename the files to the following:
    - `nginx-repo.crt`
    - `nginx-repo.key`
    - `nginx-repo.jwt`
-3. Log in to the Docker registry using the contents of the JSON Web Token file:
+1. Log in to the Docker registry using the contents of the JSON Web Token file:
    ```shell
-   $ docker login private-registry.nginx.com --username=$(cat nginx-repo.jwt) --password=none
+   docker login private-registry.nginx.com --username=$(cat nginx-repo.jwt) --password=none
    ```
 
 ---
@@ -39,7 +39,7 @@ This is accomplished with the following steps:
 Pull the `waf-compiler` image with:
 
 ```shell
-$ docker pull private-registry.nginx.com/nap/waf-compiler:5.6.0
+docker pull private-registry.nginx.com/nap/waf-compiler:5.6.0
 ```
 
 Download the [provided WAF Policy JSON](https://raw.githubusercontent.com/nginx/kubernetes-ingress/main/tests/data/ap-waf-v5/wafv5.json):
@@ -105,9 +105,10 @@ spec:
       storage: 1Gi
 ```
 
-This sets up a 1Gi disk and attaches a claim to it that you will reference in the NIC deployment chart.
+This sets up a 1Gi disk and attaches a claim to it that you will reference in the deployment chart.
 
 Create these with:
+
 ```shell
 kubectl apply -f pvc.yaml
 ```
@@ -125,6 +126,7 @@ kubectl get pvc
 ## Deploy NGINX Plus NIC Controller with NAP Enabled using Helm
 
 Add the official NGINX Helm repository:
+
 ```shell
 helm repo add nginx-stable https://helm.nginx.com/stable
 helm repo update
@@ -150,7 +152,7 @@ Install the required CRDs for NGINX Ingress Controller:
 kubectl apply -f https://raw.githubusercontent.com/nginx/kubernetes-ingress/v5.0.0/deploy/crds.yaml
 ```
 
-Using helm, install NGINX Ingress Controller
+Using Helm, install NGINX Ingress Controller
 
 ```shell
 helm upgrade --install nic nginx-stable/nginx-ingress \
@@ -171,6 +173,7 @@ helm upgrade --install nic nginx-stable/nginx-ingress \
 ```
 
 Verify deployment success:
+
 ```shell
 kubectl get pods
 ```
@@ -284,13 +287,13 @@ kubectl get pods
 
 ### Save the public IP and PORT in environment variables
 
-Find out what they are with this:
+Get the public IP and port of your instance with the following command:
 
 ```shell
 kubectl get svc
 ```
-Take note of the external IP of the `nic-nginx-ingress-controller` service and the port. Save them in the following 
-environment variables:
+
+Save them in the following environment variables:
 
 ```shell
 IC_IP=XXX.YYY.ZZZ.III
@@ -328,4 +331,6 @@ administrator.<br><br>Your support ID is: 11241918873745059631<br><br>
 This is mostly the same as the [examples/custom_resources/app-protect-waf-v5](https://github.com/nginx/kubernetes-ingress/tree/main/examples/custom-resources/app-protect-waf-v5)
 deployment in a single file with the policy bundle already set.
 
-You now have a fully operational NIC with NAP deployed in your Kubernetes environment. For further details, troubleshooting, or support, refer to the [official NGINX documentation](https://docs.nginx.com) or reach out directly to your F5/NGINX account team.
+You now have a fully operational NGINX Ingress Controller instance with NGINX App Protect deployed in your Kubernetes environment. 
+
+For further details, troubleshooting, or support, refer to the [official NGINX documentation](https://docs.nginx.com) or reach out directly to your F5/NGINX account team.

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -1,0 +1,335 @@
+---
+title: Deploy NIC and WAF to Kubernetes using Helm
+toc: true
+weight: 500
+type: how-to
+product: NIC
+docs: DOCS-609
+---
+
+## How To: Build and Use a Local NGINX App Protect Docker Image to Compile WAF Policies and Integrate with NGINX Plus Ingress Controller
+
+This document outlines how to:
+
+- Set up license secrets to enable deployment into kubernetes
+- Use a WAF docker image to compile a policy JSON file into a compiled bundle
+- Set up PersistentVolumes that the deployed WAF instance can access to read the bundle from
+- Deploy NGINX Plus Ingress Controller with NAP in Kubernetes
+- Test example services to validate that the WAF policies work
+
+---
+
+## Step 1: Prepare Secrets and Credentials (From MyF5 Portal)
+
+Download the following files from your [MyF5 Portal](https://my.f5.com):
+
+- `nginx-repo.crt`
+- `nginx-repo.key`
+- `nginx-jwt.token`
+
+Store these files locally:
+
+```
+├── nginx-repo.crt
+├── nginx-repo.key
+└── nginx-repo.jwt
+```
+
+## Step 2: Pull the NGINX App Protect WAF Compiler image
+
+Log into the nginx private registry using your jwt file and the password `none` which you will have to type in when 
+asked:
+
+```bash
+$ docker login private-registry.nginx.com --username=$(cat nginx-repo.jwt)
+
+i Info → A Personal Access Token (PAT) can be used instead.
+         To create a PAT, visit https://app.docker.com/settings
+
+
+Password:
+Login Succeeded
+```
+
+Once that's done, pull the `waf-compiler` image with:
+
+```bash
+$ docker pull private-registry.nginx.com/nap/waf-compiler:5.6.0
+```
+
+---
+
+## Step 3: Compile WAF Policy from JSON to Bundle
+
+Download the [provided WAF Policy JSON](https://raw.githubusercontent.com/nginx/kubernetes-ingress/main/tests/data/ap-waf-v5/wafv5.json):
+
+```bash
+curl -LO https://raw.githubusercontent.com/nginx/kubernetes-ingress/main/tests/data/ap-waf-v5/wafv5.json
+```
+
+Use your pulled NAP Docker image (`private-registry.nginx.com/nap/waf-compiler:5.6.0`) to compile the policy bundle:
+
+```bash
+# Using your newly created image
+docker run --rm \
+    -v $(pwd):$(pwd) \
+    private-registry.nginx.com/nap/waf-compiler:5.6.0 \
+    -p $(pwd)/wafv5.json \
+    -o $(pwd)/compiled_policy.tgz
+```
+
+After this command, your workspace should contain:
+
+```
+├── nginx-repo.crt
+├── nginx-repo.key
+├── nginx-repo.jwt
+├── wafv5.json
+└── compiled_policy.tgz
+```
+
+---
+
+## Step 4: Create the persistent volume and claim to store the policy bundle
+
+Save the following configuration data as `pvc.yml` in the same directory.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: task-pv-volume
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: task-pv-claim
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+```
+
+This sets up a 1Gi disk and attaches a claim to it that you will reference in the NIC deployment chart.
+
+Create these with:
+```bash
+kubectl apply -f pvc.yaml
+```
+
+Verify that the persistent volume and claim are created:
+
+```bash
+# For the persistent volume
+kubectl get pv
+
+# For the persistent volume claim
+kubectl get pvc
+```
+
+## Step 5: Deploy NGINX Plus NIC Controller with NAP Enabled using Helm
+
+Add the official NGINX Helm repository:
+```bash
+helm repo add nginx-stable https://helm.nginx.com/stable
+helm repo update
+```
+
+Create Kubernetes Docker and licensing secrets:
+```bash
+kubectl create secret \
+    docker-registry regcred \
+    --docker-server=private-registry.nginx.com \
+    --docker-username=$(cat nginx-repo.jwt) \
+    --docker-password=none
+
+kubectl create secret \
+    generic license-token \
+    --from-file=license.jwt=./nginx-repo.jwt \
+    --type=nginx.com/license
+```
+
+Install the required CRDs for NGINX Ingress Controller:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/nginx/kubernetes-ingress/v5.0.0/deploy/crds.yaml
+```
+
+Using helm, install NGINX Ingress Controller
+
+```bash
+helm upgrade nic nginx-stable/nginx-ingress \
+    --set controller.image.repository="private-registry.nginx.com/nginx-ic-nap-v5/nginx-plus-ingress" \
+    --set controller.image.tag="5.0.0-alpine-fips" \
+    --set controller.nginxplus=true \
+    --set controller.appprotect.enable=true \
+    --set controller.appprotect.v5=true \
+    --set controller.appprotect.volumes[2].persistentVolumeClaim.claimName="task-pv-claim" \
+    --set controller.serviceAccount.imagePullSecretName="regcred" \
+    --set controller.volumeMounts[0].name="app-protect-bundles" \
+    --set controller.volumeMounts[0].mountPath="/etc/app_protect/bundles/" \
+    --install
+```
+
+Verify deployment success:
+```bash
+kubectl get pods
+```
+
+---
+
+## Step 6: Copy the policy bundle into the running instance
+
+Get the name of the pod from the `kubectl get pods` command above.
+
+Copy the file into the `nginx-ingress` container within the pod:
+
+```bash
+kubectl cp ./compiled_policy.tgz \
+    <pod name>:/etc/app_protect/bundles/compiled_policy.tgz \
+    -c nginx-ingress
+```
+
+Replace `<pod name>` with the actual name of the pod, for example:
+
+```bash
+kubectl cp ./compiled_policy.tgz \
+    nic-nginx-ingress-controller-9bd89589d-j925h:/etc/app_protect/bundles/compiled_policy.tgz \
+    -c nginx-ingress
+```
+
+Confirm that the policy file is in the pod. The following command should list `compiled_policy.tgz`.
+
+```bash
+kubectl exec --stdin --tty \
+    -c nginx-ingress \
+    <pod name> \
+    -- ls -la /etc/app_protect/bundles
+```
+
+## Step 7: Confirm that the WAF policies work
+
+Save the following kubernetes config file as `webapp.yaml`:
+
+```yaml
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: webapp
+spec:
+  host: webapp.example.com
+  policies:
+  - name: waf-policy
+  upstreams:
+  - name: webapp
+    service: webapp-svc
+    port: 80
+  routes:
+  - path: /
+    action:
+      pass: webapp
+---
+apiVersion: k8s.nginx.org/v1
+kind: Policy
+metadata:
+  name: waf-policy
+spec:
+  waf:
+    enable: true
+    apBundle: "compiled_policy.tgz"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webapp
+  template:
+    metadata:
+      labels:
+        app: webapp
+    spec:
+      containers:
+        - name: webapp
+          image: nginxdemos/nginx-hello:plain-text
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webapp-svc
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: webapp
+```
+
+### Save the public IP and PORT in environment variables
+
+Find out what they are with this:
+
+```bash
+kubectl get svc
+```
+Take note of the external IP of the `nic-nginx-ingress-controller` service and the port. Save them in the following 
+environment variables:
+
+```bash
+IC_IP=XXX.YYY.ZZZ.III
+IC_HTTP_PORT=<port number>
+```
+
+### Validate that the WAF works
+
+Send a valid request to the deployed application:
+
+```bash
+curl --resolve webapp.example.com:$IC_HTTP_PORT:$IC_IP http://webapp.example.com:$IC_HTTP_PORT/
+```
+
+```text
+Server address: 10.92.2.13:8080
+Server name: webapp-7b7dfbff54-dtxzt
+Date: 18/Apr/2025:19:39:18 +0000
+URI: /
+Request ID: 4f378a01fb8a36ae27e2c3059d264527
+```
+
+And send one that should be rejected
+
+```bash
+curl --resolve webapp.example.com:$IC_HTTP_PORT:$IC_IP "http://webapp.example.com:$IC_HTTP_PORT/<script>"
+```
+
+```text
+<html><head><title>Request Rejected</title></head><body>The requested URL was rejected. Please consult with your 
+administrator.<br><br>Your support ID is: 11241918873745059631<br><br>
+<a href='javascript:history.back();'>[Go Back]</a></body></html>
+```
+
+This is mostly the same as the [examples/custom_resources/app-protect-waf-v5](https://github.com/nginx/kubernetes-ingress/tree/main/examples/custom-resources/app-protect-waf-v5)
+deployment in a single file with the policy bundle already set.
+
+You now have a fully operational NIC with NAP deployed in your Kubernetes environment. For further details, troubleshooting, or support, refer to the [official NGINX documentation](https://docs.nginx.com) or reach out directly to your F5/NGINX account team.

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -19,7 +19,7 @@ This is accomplished with the following steps:
 
 ---
 
-## Step 1: Prepare Secrets and Credentials (From MyF5 Portal)
+## Prepare Secrets and credentials
 
 Download the following files from your [MyF5 Portal](https://my.f5.com):
 

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -35,12 +35,13 @@ Store these files locally:
 └── nginx-repo.jwt
 ```
 
+
 ## Step 2: Pull the NGINX App Protect WAF Compiler image
 
 Log into the nginx private registry using your jwt file and the password `none` which you will have to type in when 
 asked:
 
-```bash
+```shell
 $ docker login private-registry.nginx.com --username=$(cat nginx-repo.jwt)
 
 i Info → A Personal Access Token (PAT) can be used instead.
@@ -53,7 +54,7 @@ Login Succeeded
 
 Once that's done, pull the `waf-compiler` image with:
 
-```bash
+```shell
 $ docker pull private-registry.nginx.com/nap/waf-compiler:5.6.0
 ```
 
@@ -63,13 +64,13 @@ $ docker pull private-registry.nginx.com/nap/waf-compiler:5.6.0
 
 Download the [provided WAF Policy JSON](https://raw.githubusercontent.com/nginx/kubernetes-ingress/main/tests/data/ap-waf-v5/wafv5.json):
 
-```bash
+```shell
 curl -LO https://raw.githubusercontent.com/nginx/kubernetes-ingress/main/tests/data/ap-waf-v5/wafv5.json
 ```
 
 Use your pulled NAP Docker image (`private-registry.nginx.com/nap/waf-compiler:5.6.0`) to compile the policy bundle:
 
-```bash
+```shell
 # Using your newly created image
 docker run --rm \
     -v $(pwd):$(pwd) \
@@ -127,13 +128,13 @@ spec:
 This sets up a 1Gi disk and attaches a claim to it that you will reference in the NIC deployment chart.
 
 Create these with:
-```bash
+```shell
 kubectl apply -f pvc.yaml
 ```
 
 Verify that the persistent volume and claim are created:
 
-```bash
+```shell
 # For the persistent volume
 kubectl get pv
 
@@ -144,13 +145,13 @@ kubectl get pvc
 ## Step 5: Deploy NGINX Plus NIC Controller with NAP Enabled using Helm
 
 Add the official NGINX Helm repository:
-```bash
+```shell
 helm repo add nginx-stable https://helm.nginx.com/stable
 helm repo update
 ```
 
 Create Kubernetes Docker and licensing secrets:
-```bash
+```shell
 kubectl create secret \
     docker-registry regcred \
     --docker-server=private-registry.nginx.com \
@@ -165,13 +166,13 @@ kubectl create secret \
 
 Install the required CRDs for NGINX Ingress Controller:
 
-```bash
+```shell
 kubectl apply -f https://raw.githubusercontent.com/nginx/kubernetes-ingress/v5.0.0/deploy/crds.yaml
 ```
 
 Using helm, install NGINX Ingress Controller
 
-```bash
+```shell
 helm upgrade nic nginx-stable/nginx-ingress \
     --set controller.image.repository="private-registry.nginx.com/nginx-ic-nap-v5/nginx-plus-ingress" \
     --set controller.image.tag="5.0.0-alpine-fips" \
@@ -186,7 +187,7 @@ helm upgrade nic nginx-stable/nginx-ingress \
 ```
 
 Verify deployment success:
-```bash
+```shell
 kubectl get pods
 ```
 
@@ -198,7 +199,7 @@ Get the name of the pod from the `kubectl get pods` command above.
 
 Copy the file into the `nginx-ingress` container within the pod:
 
-```bash
+```shell
 kubectl cp ./compiled_policy.tgz \
     <pod name>:/etc/app_protect/bundles/compiled_policy.tgz \
     -c nginx-ingress
@@ -206,7 +207,7 @@ kubectl cp ./compiled_policy.tgz \
 
 Replace `<pod name>` with the actual name of the pod, for example:
 
-```bash
+```shell
 kubectl cp ./compiled_policy.tgz \
     nic-nginx-ingress-controller-9bd89589d-j925h:/etc/app_protect/bundles/compiled_policy.tgz \
     -c nginx-ingress
@@ -214,7 +215,7 @@ kubectl cp ./compiled_policy.tgz \
 
 Confirm that the policy file is in the pod. The following command should list `compiled_policy.tgz`.
 
-```bash
+```shell
 kubectl exec --stdin --tty \
     -c nginx-ingress \
     <pod name> \
@@ -290,13 +291,13 @@ spec:
 
 Find out what they are with this:
 
-```bash
+```shell
 kubectl get svc
 ```
 Take note of the external IP of the `nic-nginx-ingress-controller` service and the port. Save them in the following 
 environment variables:
 
-```bash
+```shell
 IC_IP=XXX.YYY.ZZZ.III
 IC_HTTP_PORT=<port number>
 ```
@@ -305,7 +306,7 @@ IC_HTTP_PORT=<port number>
 
 Send a valid request to the deployed application:
 
-```bash
+```shell
 curl --resolve webapp.example.com:$IC_HTTP_PORT:$IC_IP http://webapp.example.com:$IC_HTTP_PORT/
 ```
 
@@ -319,7 +320,7 @@ Request ID: 4f378a01fb8a36ae27e2c3059d264527
 
 And send one that should be rejected
 
-```bash
+```shell
 curl --resolve webapp.example.com:$IC_HTTP_PORT:$IC_IP "http://webapp.example.com:$IC_HTTP_PORT/<script>"
 ```
 

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -34,20 +34,13 @@ This is accomplished with the following steps:
 
 ---
 
+## Compile WAF Policy from JSON to Bundle
 
-Password:
-Login Succeeded
-```
-
-Once that's done, pull the `waf-compiler` image with:
+Pull the `waf-compiler` image with:
 
 ```shell
 $ docker pull private-registry.nginx.com/nap/waf-compiler:5.6.0
 ```
-
----
-
-## Step 3: Compile WAF Policy from JSON to Bundle
 
 Download the [provided WAF Policy JSON](https://raw.githubusercontent.com/nginx/kubernetes-ingress/main/tests/data/ap-waf-v5/wafv5.json):
 
@@ -78,7 +71,7 @@ After this command, your workspace should contain:
 
 ---
 
-## Step 4: Create the persistent volume and claim to store the policy bundle
+## Create the persistent volume and claim to store the policy bundle
 
 Save the following configuration data as `pvc.yml` in the same directory.
 
@@ -129,7 +122,7 @@ kubectl get pv
 kubectl get pvc
 ```
 
-## Step 5: Deploy NGINX Plus NIC Controller with NAP Enabled using Helm
+## Deploy NGINX Plus NIC Controller with NAP Enabled using Helm
 
 Add the official NGINX Helm repository:
 ```shell
@@ -180,7 +173,7 @@ kubectl get pods
 
 ---
 
-## Step 6: Copy the policy bundle into the running instance
+## Copy the policy bundle into the running instance
 
 Get the name of the pod from the `kubectl get pods` command above.
 
@@ -209,7 +202,7 @@ kubectl exec --stdin --tty \
     -- ls -la /etc/app_protect/bundles
 ```
 
-## Step 7: Confirm that the WAF policies work
+## Confirm that the WAF policies work
 
 Save the following kubernetes config file as `webapp.yaml`:
 

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -4,7 +4,6 @@ toc: true
 weight: 500
 type: how-to
 product: NIC
-docs: DOCS-609
 ---
 
 This document describes how to build a local F5 NGINX App Protect WAF v5 Docker image with NGINX Plus Ingress 

--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -7,7 +7,8 @@ product: NIC
 docs: DOCS-609
 ---
 
-This document describes how to build a local F5 NGINX App Protect WAF Docker image with NGINX Plus Ingress Controller, which can be used to compile WAF policies.
+This document describes how to build a local F5 NGINX App Protect WAF v5 Docker image with NGINX Plus Ingress 
+Controller, which can be used to compile WAF policies.
 
 This is accomplished with the following steps:
 


### PR DESCRIPTION
Closes #7416

* Adds installation guide for NIC and waf
* users don't need to leave the document
* uses the wafv5 json from the examples directory
* users are guided to download their key, certificate, and jwt files, and set up license secrets and image pull secrets
* users are guided on copying their compiled policy bundle onto the deployment
* users are shown how to compile a json into a policy bundle
* example applications are deployed and waf is used in those
* there are examples of successful and expectedly failed requests

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
