### PR TITLE
add flag based fix to avoid default endpoint

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -323,6 +323,7 @@ func main() {
 		NICVersion:                   version,
 		DynamicWeightChangesReload:   *enableDynamicWeightChangesReload,
 		InstallationFlags:            parsedFlags,
+		ShuttingDown:                 false,
 	}
 
 	lbc := k8s.NewLoadBalancerController(lbcInput)
@@ -816,6 +817,7 @@ func handleTermination(lbc *k8s.LoadBalancerController, nginxManager nginx.Manag
 		nl.Fatalf(lbc.Logger, "AppProtectDosAgent command exited unexpectedly with status: %v", err)
 	case <-signalChan:
 		nl.Info(lbc.Logger, "Received SIGTERM, shutting down")
+		lbc.ShuttingDown = true
 		lbc.Stop()
 		nginxManager.Quit()
 		<-cpcfg.nginxDone

--- a/internal/k8s/configmap.go
+++ b/internal/k8s/configmap.go
@@ -82,6 +82,11 @@ func (lbc *LoadBalancerController) syncConfigMap(task task) {
 	key := task.Key
 	nl.Debugf(lbc.Logger, "Syncing configmap %v", key)
 
+	if key == lbc.mgmtConfigMapName && lbc.isPodMarkedForDeletion() {
+		nl.Debugf(lbc.Logger, "Pod is shutting down, skipping management ConfigMap sync")
+		return
+	}
+
 	switch key {
 	case lbc.nginxConfigMapName:
 		obj, configExists, err := lbc.configMapLister.GetByKey(key)

--- a/internal/k8s/configmap.go
+++ b/internal/k8s/configmap.go
@@ -125,6 +125,9 @@ func (lbc *LoadBalancerController) syncConfigMap(task task) {
 		nl.Debugf(lbc.Logger, "Skipping ConfigMap update because batch sync is on")
 		return
 	}
-
+	if err := lbc.ctx.Err(); err != nil {
+		nl.Debugf(lbc.Logger, "Context canceled, skipping ConfigMap sync for %v: %v", task.Key, err)
+		return
+	}
 	lbc.updateAllConfigs()
 }

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -185,6 +185,7 @@ type LoadBalancerController struct {
 	weightChangesDynamicReload    bool
 	nginxConfigMapName            string
 	mgmtConfigMapName             string
+	ShuttingDown                  bool
 }
 
 var keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
@@ -241,6 +242,7 @@ type NewLoadBalancerControllerInput struct {
 	NICVersion                   string
 	DynamicWeightChangesReload   bool
 	InstallationFlags            []string
+	ShuttingDown                 bool
 }
 
 // NewLoadBalancerController creates a controller
@@ -286,6 +288,7 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 		weightChangesDynamicReload:   input.DynamicWeightChangesReload,
 		nginxConfigMapName:           input.ConfigMaps,
 		mgmtConfigMapName:            input.MGMTConfigMap,
+		ShuttingDown:                 input.ShuttingDown,
 	}
 
 	lbc.syncQueue = newTaskQueue(lbc.Logger, lbc.sync)
@@ -3644,4 +3647,23 @@ func (lbc *LoadBalancerController) createCombinedDeploymentHeadlessServiceName()
 	}
 	combinedDeployment := fmt.Sprintf("%s-%s", name, strings.ToLower(owner.Kind))
 	return combinedDeployment
+}
+
+func (lbc *LoadBalancerController) isPodMarkedForDeletion() bool {
+	// Check if the controller is shutting down
+	if lbc.ShuttingDown {
+		nl.Debugf(lbc.Logger, "SIGTERM already recieved, controller is shutting down")
+		return true
+	}
+	podName := os.Getenv("POD_NAME")
+	podNamespace := os.Getenv("POD_NAMESPACE")
+
+	if podName != "" && podNamespace != "" {
+		pod, err := lbc.client.CoreV1().Pods(podNamespace).Get(context.Background(), podName, meta_v1.GetOptions{})
+		if err == nil && pod.DeletionTimestamp != nil {
+			nl.Debugf(lbc.Logger, "Pod %s/%s is marked for deletion", podNamespace, podName)
+			return true
+		}
+	}
+	return false
 }

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -3659,8 +3659,8 @@ func (lbc *LoadBalancerController) isPodMarkedForDeletion() bool {
 		nl.Debugf(lbc.Logger, "SIGTERM already received, controller is shutting down")
 		return true
 	}
-	podName := os.Getenv("POD_NAME")
-	podNamespace := os.Getenv("POD_NAMESPACE")
+	podName := lbc.metadata.pod.Name
+	podNamespace := lbc.metadata.pod.Namespace
 	pod, err := lbc.client.CoreV1().Pods(podNamespace).Get(context.Background(), podName, meta_v1.GetOptions{})
 	if err == nil && pod.DeletionTimestamp != nil {
 		nl.Debugf(lbc.Logger, "Pod %s/%s is marked for deletion", podNamespace, podName)

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -3652,18 +3652,16 @@ func (lbc *LoadBalancerController) createCombinedDeploymentHeadlessServiceName()
 func (lbc *LoadBalancerController) isPodMarkedForDeletion() bool {
 	// Check if the controller is shutting down
 	if lbc.ShuttingDown {
-		nl.Debugf(lbc.Logger, "SIGTERM already recieved, controller is shutting down")
+		nl.Debugf(lbc.Logger, "SIGTERM already received, controller is shutting down")
 		return true
 	}
 	podName := os.Getenv("POD_NAME")
 	podNamespace := os.Getenv("POD_NAMESPACE")
-
-	if podName != "" && podNamespace != "" {
-		pod, err := lbc.client.CoreV1().Pods(podNamespace).Get(context.Background(), podName, meta_v1.GetOptions{})
-		if err == nil && pod.DeletionTimestamp != nil {
-			nl.Debugf(lbc.Logger, "Pod %s/%s is marked for deletion", podNamespace, podName)
-			return true
-		}
+	pod, err := lbc.client.CoreV1().Pods(podNamespace).Get(context.Background(), podName, meta_v1.GetOptions{})
+	if err == nil && pod.DeletionTimestamp != nil {
+		nl.Debugf(lbc.Logger, "Pod %s/%s is marked for deletion", podNamespace, podName)
+		return true
 	}
+
 	return false
 }

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -3639,3 +3639,79 @@ func TestCreateIngressExWithZoneSync(t *testing.T) {
 		}
 	}
 }
+func TestIsPodMarkedForDeletion(t *testing.T) {
+	t.Parallel()
+
+	logger := nl.LoggerFromContext(context.Background())
+
+	tests := []struct {
+		name            string
+		shutdownFlag    bool
+		envPodName      string
+		envPodNamespace string
+		podExists       bool
+		podHasTimestamp bool
+		expectedResult  bool
+	}{
+		{
+			name:           "controller is shutting down",
+			shutdownFlag:   true,
+			expectedResult: true,
+		},
+		{
+			name:            "pod exists with deletion timestamp",
+			envPodName:      "test-pod",
+			envPodNamespace: "test-namespace",
+			podExists:       true,
+			podHasTimestamp: true,
+			expectedResult:  true,
+		},
+		{
+			name:            "pod exists without deletion timestamp",
+			envPodName:      "test-pod",
+			envPodNamespace: "test-namespace",
+			podExists:       true,
+			podHasTimestamp: false,
+			expectedResult:  false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+
+			client := fake.NewSimpleClientset()
+
+			if test.podExists {
+				pod := &api_v1.Pod{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:      test.envPodName,
+						Namespace: test.envPodNamespace,
+					},
+				}
+
+				if test.podHasTimestamp {
+					now := meta_v1.Now()
+					pod.DeletionTimestamp = &now
+				}
+
+				_, err := client.CoreV1().Pods(test.envPodNamespace).Create(context.Background(), pod, meta_v1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Error creating pod: %v", err)
+				}
+			}
+
+			lbc := &LoadBalancerController{
+				client:       client,
+				ShuttingDown: test.shutdownFlag,
+				Logger:       logger,
+			}
+
+			// Call the function and verify result
+			result := lbc.isPodMarkedForDeletion()
+			if result != test.expectedResult {
+				t.Errorf("Returned %v but expected %v", result, test.expectedResult)
+			}
+		})
+	}
+}

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -3639,6 +3639,7 @@ func TestCreateIngressExWithZoneSync(t *testing.T) {
 		}
 	}
 }
+
 func TestIsPodMarkedForDeletion(t *testing.T) {
 	t.Parallel()
 
@@ -3679,7 +3680,6 @@ func TestIsPodMarkedForDeletion(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-
 			client := fake.NewSimpleClientset()
 
 			if test.podExists {

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -3682,8 +3682,15 @@ func TestIsPodMarkedForDeletion(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
-			os.Setenv("POD_NAME", test.envPodName)
-			os.Setenv("POD_NAMESPACE", test.envPodNamespace)
+
+			err := os.Setenv("POD_NAME", test.envPodName)
+			if err != nil {
+				t.Fatalf("Failed to set POD_NAME environment variable: %v", err)
+			}
+			err = os.Setenv("POD_NAMESPACE", test.envPodNamespace)
+			if err != nil {
+				t.Fatalf("Failed to set POD_NAMESPACE environment variable: %v", err)
+			}
 			if test.podExists {
 				pod := &api_v1.Pod{
 					ObjectMeta: meta_v1.ObjectMeta{

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -3682,15 +3681,6 @@ func TestIsPodMarkedForDeletion(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
-
-			err := os.Setenv("POD_NAME", test.envPodName)
-			if err != nil {
-				t.Fatalf("Failed to set POD_NAME environment variable: %v", err)
-			}
-			err = os.Setenv("POD_NAMESPACE", test.envPodNamespace)
-			if err != nil {
-				t.Fatalf("Failed to set POD_NAMESPACE environment variable: %v", err)
-			}
 			if test.podExists {
 				pod := &api_v1.Pod{
 					ObjectMeta: meta_v1.ObjectMeta{
@@ -3711,7 +3701,15 @@ func TestIsPodMarkedForDeletion(t *testing.T) {
 			}
 
 			lbc := &LoadBalancerController{
-				client:       client,
+				client: client,
+				metadata: controllerMetadata{
+					pod: &api_v1.Pod{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:      test.envPodName,
+							Namespace: test.envPodNamespace,
+						},
+					},
+				},
 				ShuttingDown: test.shutdownFlag,
 				Logger:       logger,
 			}

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -3681,7 +3682,8 @@ func TestIsPodMarkedForDeletion(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
-
+			os.Setenv("POD_NAME", test.envPodName)
+			os.Setenv("POD_NAMESPACE", test.envPodNamespace)
 			if test.podExists {
 				pod := &api_v1.Pod{
 					ObjectMeta: meta_v1.ObjectMeta{


### PR DESCRIPTION
### Proposed changes

- This PR adds extra gates which stops mgmt cm from getting synced if controller is in shut down mode or pod is marked for deletion

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
