### PR TITLE
Add Context to logging for JSON and TEXT formats

### DIFF
--- a/cmd/nginx-ingress/main_test.go
+++ b/cmd/nginx-ingress/main_test.go
@@ -30,12 +30,12 @@ func TestLogFormats(t *testing.T) {
 		{
 			name:   "json format message",
 			format: "json",
-			wantre: `^{"time":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+.*","level":"INFO","msg":".*}`,
+			wantre: `^{"time":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+.*","level":"INFO","source":\{"file":"[^"]+\.go","line":\d+\},"msg":".*}`,
 		},
 		{
 			name:   "text format message",
 			format: "text",
-			wantre: `^time=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+.*level=\w+\smsg=\w+`,
+			wantre: `^time=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+.*level=\w+\ssource=[^:]+\.go:\d+\smsg=\w+`,
 		},
 	}
 	t.Parallel()


### PR DESCRIPTION
### Proposed changes

- Add source to JSON and Text log output to give context similar to glog

JSON
before
```
{"time":"2025-04-25T15:50:33.813809341Z","level":"DEBUG","msg":"The queue has 6 element(s)"}
```
after

```
{"time":"2025-04-28T09:38:53.881957803Z","level":"DEBUG","source":{"file":"task_queue.go","line":77},"msg":"The queue has 6 element(s)"}
```
TEXT
before
```
time=2025-04-28T09:39:36.565Z level=DEBUG msg="The queue has 6 element(s)"
```
after
```
time=2025-04-25T15:57:36.855Z level=DEBUG source=task_queue.go:77 msg="The queue has 6 element(s)"
```

Solves: https://github.com/nginx/kubernetes-ingress/issues/7574



### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
