### PR TITLE
docs: NIC+NAP wafv5 install guide perm fix

### DIFF
--- a/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/site/content/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -45,7 +45,7 @@ docker pull private-registry.nginx.com/nap/waf-compiler:5.6.0
 Download the [provided WAF Policy JSON](https://raw.githubusercontent.com/nginx/kubernetes-ingress/main/tests/data/ap-waf-v5/wafv5.json):
 
 ```shell
-curl -LO https://raw.githubusercontent.com/nginx/kubernetes-ingress/main/tests/data/ap-waf-v5/wafv5.json
+curl -L https://raw.githubusercontent.com/nginx/kubernetes-ingress/main/tests/data/ap-waf-v5/wafv5.json -o /tmp/waf5.json
 ```
 
 Use your pulled NAP Docker image (`private-registry.nginx.com/nap/waf-compiler:5.6.0`) to compile the policy bundle:
@@ -53,10 +53,17 @@ Use your pulled NAP Docker image (`private-registry.nginx.com/nap/waf-compiler:5
 ```shell
 # Using your newly created image
 docker run --rm \
-    -v $(pwd):$(pwd) \
+    -v /tmp:/tmp \
     private-registry.nginx.com/nap/waf-compiler:5.6.0 \
-    -p $(pwd)/wafv5.json \
-    -o $(pwd)/compiled_policy.tgz
+    -p /tmp/wafv5.json \
+    -o /tmp/compiled_policy.tgz
+```
+
+Move the downloaded JSON and compiled policy to your workspace:
+
+```shell
+mv /tmp/wafv5.json ./wafv5.json
+mv /tmp/compiled_policy.tgz ./compiled_policy.tgz
 ```
 
 After this command, your workspace should contain:


### PR DESCRIPTION
Closes #7757

* Use `/tmp` folder on both the host and the docker image when compiling the waf policy bundle due to file permission handling differences between docker engine and docker desktop
* Update the installation guide to reflect the new location of the waf policy bundle and downloaded source JSON

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
