### PR TITLE
remove s390x, arm/7 and ppc64le

### DIFF
--- a/.github/data/matrix-images-oss.json
+++ b/.github/data/matrix-images-oss.json
@@ -4,12 +4,12 @@
     "alpine"
   ],
   "platforms": [
-    "linux/arm, linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"
+    "linux/arm64, linux/amd64"
   ],
   "include": [
     {
       "image": "ubi",
-      "platforms": "linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"
+      "platforms": "linux/arm64, linux/amd64"
     }
   ]
 }

--- a/.github/data/matrix-regression.json
+++ b/.github/data/matrix-regression.json
@@ -6,7 +6,7 @@
       "image": "debian",
       "type": "oss",
       "marker": "'not upgrade'",
-      "platforms": "linux/arm, linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"
+      "platforms": "linux/arm64, linux/amd64"
     },
     {
       "label": "regression",

--- a/.github/data/patch-images.json
+++ b/.github/data/patch-images.json
@@ -3,19 +3,19 @@
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/nginx-ingress",
     "source_os": "debian",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic/nginx-ingress",
-    "platforms": "linux/arm, linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"
+    "platforms": "linux/arm64, linux/amd64"
   },
   {
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/nginx-ingress",
     "source_os": "alpine",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic/nginx-ingress",
-    "platforms": "linux/arm, linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"
+    "platforms": "linux/arm64, linux/amd64"
   },
   {
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/nginx-ingress",
     "source_os": "ubi",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic/nginx-ingress",
-    "platforms": "linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"
+    "platforms": "linux/arm64, linux/amd64"
   },
   {
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/nginx-plus-ingress",

--- a/.github/data/patch-images.json
+++ b/.github/data/patch-images.json
@@ -3,19 +3,19 @@
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/nginx-ingress",
     "source_os": "debian",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic/nginx-ingress",
-    "platforms": "linux/arm64, linux/amd64"
+    "platforms": "linux/arm, linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"
   },
   {
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/nginx-ingress",
     "source_os": "alpine",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic/nginx-ingress",
-    "platforms": "linux/arm64, linux/amd64"
+    "platforms": "linux/arm, linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"
   },
   {
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/nginx-ingress",
     "source_os": "ubi",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic/nginx-ingress",
-    "platforms": "linux/arm64, linux/amd64"
+    "platforms": "linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"
   },
   {
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/nginx-plus-ingress",

--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: arm,arm64,ppc64le,s390x
+          platforms: arm64
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -128,7 +128,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: arm64,s390x
+          platforms: arm64
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.github/workflows/build-oss.yml
+++ b/.github/workflows/build-oss.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: arm,arm64,ppc64le,s390x
+          platforms: arm64
         if: ${{ steps.images_exist.outputs.base_exists != 'true' || steps.images_exist.outputs.target_exists != 'true' }}
 
       - name: Docker Buildx

--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: arm,arm64,ppc64le,s390x
+          platforms: arm64
         if: ${{ steps.images_exist.outputs.base_exists != 'true' || steps.images_exist.outputs.target_exists != 'true' }}
 
       - name: Docker Buildx

--- a/.github/workflows/build-ubi-dependency.yml
+++ b/.github/workflows/build-ubi-dependency.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: arm64,ppc64le,s390x
+          platforms: arm64
 
       - name: Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -126,7 +126,7 @@ jobs:
           push: true
           # build multi-arch so that it can be mounted from any image
           # even though only ppc64le will contain binaries
-          platforms: "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
+          platforms: "linux/amd64,linux/arm64"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/patch-image.yml
+++ b/.github/workflows/patch-image.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: arm,arm64,ppc64le,s390x
+          platforms: arm64
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,8 +10,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    goarm:
-      - 7
     flags:
       - -trimpath
     gcflags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,10 +9,7 @@ builds:
       - linux
     goarch:
       - amd64
-      - arm
       - arm64
-      - ppc64le
-      - s390x
     goarm:
       - 7
     flags:

--- a/site/content/installation/build-nginx-ingress-controller.md
+++ b/site/content/installation/build-nginx-ingress-controller.md
@@ -182,7 +182,7 @@ The _Makefile_ includes several key variables. You have the option to either mod
 {{<bootstrap-table "table table-striped table-bordered">}}
 | <div style="width:200px">Variable</div> | Description   |
 |-----------------------------------------|---------------|
-| _ARCH_                                | Defines the architecture for the image and binary. The default is `amd64`, but you can also choose from `arm64`, `arm`, `ppc64le`, and `s390x`.   |
+| _ARCH_                                | Defines the architecture for the image and binary. The default is `amd64`, but you can also use `arm64`. |
 | _PREFIX_                              | Gives the image its name. The default is `nginx/nginx-ingress`.  |
 | _TAG_                                 | Adds a tag to the image. This is often the version of NGINX Ingress Controller.   |
 | _DOCKER\_BUILD\_OPTIONS_                | Allows for additional [options](https://docs.docker.com/engine/reference/commandline/build/#options) during the `docker build` process, like `--pull`.  |

--- a/site/content/technical-specifications.md
+++ b/site/content/technical-specifications.md
@@ -42,10 +42,10 @@ _All images include NGINX 1.27.4._
 
 {{< bootstrap-table "table table-bordered table-responsive" >}}
 |<div style="width:200px">Name</div> | <div style="width:100px">Base image</div> | DockerHub image | Architectures |
-| ---| --- | --- | --- | --- |
-|Alpine-based image | ``nginx:1.27.4-alpine``,<br>based on on ``alpine:3.21`` | ``nginx/nginx-ingress:{{< nic-version >}}-alpine`` | arm/v7<br>arm64<br>amd64<br>ppc64le<br>s390x |
-|Debian-based image | ``nginx:1.27.4``,<br>based on on ``debian:12-slim`` | ``nginx/nginx-ingress:{{< nic-version >}}`` | arm/v7<br>arm64<br>amd64<br>ppc64le<br>s390x |
-|Ubi-based image | ``redhat/ubi9-minimal`` | ``nginx/nginx-ingress:{{< nic-version >}}-ubi`` | arm64<br>amd64<br>ppc64le<br>s390x |
+| ---| --- | --- | --- |
+|Alpine-based image | ``nginx:1.27.4-alpine``,<br>based on on ``alpine:3.21`` | ``nginx/nginx-ingress:{{< nic-version >}}-alpine`` | arm64<br>amd64 |
+|Debian-based image | ``nginx:1.27.4``,<br>based on on ``debian:12-slim`` | ``nginx/nginx-ingress:{{< nic-version >}}`` | arm64<br>amd64 |
+|Ubi-based image | ``redhat/ubi9-minimal`` | ``nginx/nginx-ingress:{{< nic-version >}}-ubi`` | arm64<br>amd64 |
 {{% /bootstrap-table %}}
 
 ---


### PR DESCRIPTION
### Proposed changes

- remove building and publishing of the s390x, arm/7 and ppc64le architechure binaries. 

Note
Users can still build and run NIC using these images. 

eg.
`NGINX Ingress Controller Version=5.0.0 Commit=179ad349fc4ffe316b881f9c376114ce57c9c82d Date=2025-05-13T13:11:50Z DirtyState=true Arch=linux/s390x Go=go1.24.`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
