### PR TITLE
Replace archive.builds with .ids in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,7 +95,7 @@ changelog:
 
 archives:
   - id: archives
-    builds: [kubernetes-ingress]
+    ids: [kubernetes-ingress]
 
 sboms:
   - id: sboms


### PR DESCRIPTION
Closes #7799

### Proposed changes

Replaces `archives.builds` with `archives.ids` per deprecation notice in goreleaser: https://goreleaser.com/deprecations/#archivesbuilds

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
