### PR TITLE
Rename Agent Deployment metadata to match the requirements

### DIFF
--- a/internal/common_cluster_info/common_cluster_info.go
+++ b/internal/common_cluster_info/common_cluster_info.go
@@ -61,8 +61,8 @@ func GetInstallationID(ctx context.Context, client kubernetes.Interface, podNSNa
 	}
 }
 
-// GetDeploymentName returns the name of the Deployment
-func GetDeploymentName(ctx context.Context, client kubernetes.Interface, podNSName types.NamespacedName) (string, error) {
+// GetInstallationName returns the name of the Deployment
+func GetInstallationName(ctx context.Context, client kubernetes.Interface, podNSName types.NamespacedName) (string, error) {
 	pod, err := client.CoreV1().Pods(podNSName.Namespace).Get(ctx, podNSName.Name, metav1.GetOptions{})
 	if err != nil {
 		return "", err

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -13,22 +13,22 @@ import (
 
 // Labels contains the metadata information needed for reporting to Agent
 type Labels struct {
-	ProductName         string `json:"product_name"`
-	ProductVersion      string `json:"product_version"`
-	ClusterID           string `json:"cluster_id"`
-	DeploymentName      string `json:"deployment_name"`
-	DeploymentID        string `json:"deployment_id"`
-	DeploymentNamespace string `json:"deployment_namespace"`
+	ProductType           string `json:"product-type"`
+	ProductVersion        string `json:"product-version"`
+	ClusterID             string `json:"cluster-id"`
+	InstallationName      string `json:"installation-name"`
+	InstallationID        string `json:"installation-id"`
+	InstallationNamespace string `json:"installation-namespace"`
 }
 
-func newMetadataInfo(deploymentNamespace, clusterID, deploymentID, productVersion, deploymentName string) *Labels {
+func newMetadataInfo(installationNamespace, clusterID, installationID, productVersion, installationName string) *Labels {
 	return &Labels{
-		ProductName:         "nic",
-		ProductVersion:      productVersion,
-		ClusterID:           clusterID,
-		DeploymentID:        deploymentID,
-		DeploymentName:      deploymentName,
-		DeploymentNamespace: deploymentNamespace,
+		ProductType:           "nic",
+		ProductVersion:        productVersion,
+		ClusterID:             clusterID,
+		InstallationID:        installationID,
+		InstallationName:      installationName,
+		InstallationNamespace: installationNamespace,
 	}
 }
 
@@ -52,19 +52,19 @@ func NewMetadataReporter(client kubernetes.Interface, pod *api_v1.Pod, version s
 
 // CollectAndWrite collects the metadata information and returns a Labels struct
 func (md *Metadata) CollectAndWrite(ctx context.Context) (*Labels, error) {
-	deploymentNamespace := md.PodNSName.Namespace
+	installationNamespace := md.PodNSName.Namespace
 	clusterID, err := clusterInfo.GetClusterID(ctx, md.K8sClientReader)
 	if err != nil {
 		return nil, fmt.Errorf("error collecting ClusterID: %w", err)
 	}
-	deploymentID, err := clusterInfo.GetInstallationID(ctx, md.K8sClientReader, md.PodNSName)
+	installationID, err := clusterInfo.GetInstallationID(ctx, md.K8sClientReader, md.PodNSName)
 	if err != nil {
 		return nil, fmt.Errorf("error collecting InstallationID: %w", err)
 	}
-	deploymentName, err := clusterInfo.GetDeploymentName(ctx, md.K8sClientReader, md.PodNSName)
+	installationName, err := clusterInfo.GetInstallationName(ctx, md.K8sClientReader, md.PodNSName)
 	if err != nil {
-		return nil, fmt.Errorf("error collecting DeploymentName: %w", err)
+		return nil, fmt.Errorf("error collecting InstallationName: %w", err)
 	}
-	info := newMetadataInfo(deploymentNamespace, clusterID, deploymentID, md.NICVersion, deploymentName)
+	info := newMetadataInfo(installationNamespace, clusterID, installationID, md.NICVersion, installationName)
 	return info, nil
 }

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -13,23 +13,23 @@ import (
 
 func TestNewMetadataInfo(t *testing.T) {
 	info := newMetadataInfo("nginx-ingress", "e3a5e702-65a7-a55f-753d78cd7ff7", "555-1222-4414test-11223355", "5.0.0", "my-release")
-	if info.ProductName != "nic" {
-		t.Errorf("ProductName = %q, want %q", info.ProductName, "nic")
+	if info.ProductType != "nic" {
+		t.Errorf("ProductName = %q, want %q", info.ProductType, "nic")
 	}
-	if info.DeploymentNamespace != "nginx-ingress" {
-		t.Errorf("DeploymentNamespace = %q, want %q", info.DeploymentNamespace, "nginx-ingress")
+	if info.InstallationNamespace != "nginx-ingress" {
+		t.Errorf("DeploymentNamespace = %q, want %q", info.InstallationNamespace, "nginx-ingress")
 	}
 	if info.ClusterID != "e3a5e702-65a7-a55f-753d78cd7ff7" {
 		t.Errorf("ClusterID = %q, want %q", info.ClusterID, "e3a5e702-65a7-a55f-753d78cd7ff7")
 	}
-	if info.DeploymentID != "555-1222-4414test-11223355" {
-		t.Errorf("DeploymentID = %q, want %q", info.DeploymentID, "555-1222-4414test-11223355")
+	if info.InstallationID != "555-1222-4414test-11223355" {
+		t.Errorf("DeploymentID = %q, want %q", info.InstallationID, "555-1222-4414test-11223355")
 	}
 	if info.ProductVersion != "5.0.0" {
 		t.Errorf("ProductVersion = %q, want %q", info.ProductVersion, "5.0.0")
 	}
-	if info.DeploymentName != "my-release" {
-		t.Errorf("DeploymentName = %q, want %q", info.DeploymentName, "my-release")
+	if info.InstallationName != "my-release" {
+		t.Errorf("DeploymentName = %q, want %q", info.InstallationName, "my-release")
 	}
 }
 
@@ -75,8 +75,8 @@ func TestCollectAndWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CollectAndWrite() error = %v", err)
 	}
-	if got, want := info.ProductName, "nic"; got != want {
-		t.Errorf("ProductName = %q, want %q", got, want)
+	if got, want := info.ProductType, "nic"; got != want {
+		t.Errorf("ProductType = %q, want %q", got, want)
 	}
 }
 

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -631,12 +631,12 @@ func (lm *LocalManager) AgentStart(agentDone chan error, instanceGroup string) {
 			nl.Fatalf(lm.logger, "Failed to start NGINX Agent: %v", err)
 		}
 		labels := []string{
-			fmt.Sprintf("product_name=%s", metadataInfo.ProductName),
-			fmt.Sprintf("product_version=%s", metadataInfo.ProductVersion),
-			fmt.Sprintf("cluster_id=%s", metadataInfo.ClusterID),
-			fmt.Sprintf("deployment_name=%s", metadataInfo.DeploymentName),
-			fmt.Sprintf("deployment_id=%s", metadataInfo.DeploymentID),
-			fmt.Sprintf("deployment_namespace=%s", metadataInfo.DeploymentNamespace),
+			fmt.Sprintf("product-type=%s", metadataInfo.ProductType),
+			fmt.Sprintf("product-version=%s", metadataInfo.ProductVersion),
+			fmt.Sprintf("cluster-id=%s", metadataInfo.ClusterID),
+			fmt.Sprintf("installation-name=%s", metadataInfo.InstallationName),
+			fmt.Sprintf("installation-id=%s", metadataInfo.InstallationID),
+			fmt.Sprintf("installation-namespace=%s", metadataInfo.InstallationNamespace),
 		}
 		metadataLabels := "--labels=" + strings.Join(labels, ",")
 		args = append(args, metadataLabels)


### PR DESCRIPTION
### Proposed changes

Update to https://github.com/nginx/kubernetes-ingress/pull/7737

Renames Agent Deployment metadata to match the requirements for N1C
- DeploymentID/DeploymentName/DeploymentNamespace -> InstallationID/InstallationName/InstallationNamespace
- ProductName -> ProductType
- Change `_` to `-`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
