### PR TITLE
Pin mvdan/gofumpt in github workflow ci and fix bash variable quoting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
 
       - name: Install gofumpt
-        run: go install mvdan.cc/gofumpt@latest
+        run: go install mvdan.cc/gofumpt@v0.8.0
         if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
 
       - name: Check if telemetry schema changed

--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -4,12 +4,12 @@ git_tag=$1
 docker_tag=edge
 
 git_commit=$(git rev-parse HEAD)
-commit_tag=$(git describe --exact-match ${git_commit} 2>/dev/null)
+commit_tag=$(git describe --exact-match "${git_commit}" 2>/dev/null)
 
-if [[ ${commit_tag} == ${git_tag} ]]; then
+if [[ ${commit_tag} == "${git_tag}" ]]; then
     # we're on the exact commit of the tag, use the docker image for the tag
     docker_tag=${git_tag//v/}
-    echo ${docker_tag}
+    echo "${docker_tag}"
     exit 0
 
 else
@@ -17,7 +17,7 @@ else
     # if it's the latest commit from 'main' the SHA will match the 'revision' of the 'edge' docker image
     docker pull nginx/nginx-ingress:${docker_tag} >/dev/null 2>&1
     DOCKER_SHA=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' nginx/nginx-ingress:${docker_tag})
-    if [[ ${DOCKER_SHA} == ${git_commit} ]]; then
+    if [[ ${DOCKER_SHA} == "${git_commit}" ]]; then
         # we're on the same commit as the latest edge
         echo ${docker_tag}
         exit 0


### PR DESCRIPTION
### Proposed changes

* pin gofumpt to current latest (v0.8.0) rather than "latest"
* quote variables in a bash script to prevent globbing and word splitting, see https://github.com/koalaman/shellcheck/wiki/SC2053

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
