### PR TITLE
Remove aws marketplace images from patching workflow

### DIFF
--- a/.github/data/patch-images.json
+++ b/.github/data/patch-images.json
@@ -25,12 +25,6 @@
   },
   {
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/nginx-plus-ingress",
-    "source_os": "mktpl",
-    "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic/nginx-plus-ingress",
-    "platforms": "linux/arm64, linux/amd64"
-  },
-  {
-    "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/nginx-plus-ingress",
     "source_os": "alpine",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic/nginx-plus-ingress",
     "platforms": "linux/arm64, linux/amd64"
@@ -55,18 +49,6 @@
   },
   {
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic-nap/nginx-plus-ingress",
-    "source_os": "mktpl",
-    "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic-nap/nginx-plus-ingress",
-    "platforms": "linux/amd64"
-  },
-  {
-    "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic-nap/nginx-plus-ingress",
-    "source_os": "ubi",
-    "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic-nap/nginx-plus-ingress",
-    "platforms": "linux/amd64"
-  },
-  {
-    "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic-nap/nginx-plus-ingress",
     "source_os": "ubi8",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic-nap/nginx-plus-ingress",
     "platforms": "linux/amd64"
@@ -109,12 +91,6 @@
   },
   {
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic-dos/nginx-plus-ingress",
-    "source_os": "mktpl",
-    "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic-dos/nginx-plus-ingress",
-    "platforms": "linux/amd64"
-  },
-  {
-    "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic-dos/nginx-plus-ingress",
     "source_os": "ubi",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic-dos/nginx-plus-ingress",
     "platforms": "linux/amd64"
@@ -122,12 +98,6 @@
   {
     "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic-dos-nap/nginx-plus-ingress",
     "source_os": "debian",
-    "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic-dos-nap/nginx-plus-ingress",
-    "platforms": "linux/amd64"
-  },
-  {
-    "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic-dos-nap/nginx-plus-ingress",
-    "source_os": "mktpl",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic-dos-nap/nginx-plus-ingress",
     "platforms": "linux/amd64"
   },


### PR DESCRIPTION
### Proposed changes

We are not currently publishing AWS Marketplace images.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
