### PR TITLE
Add control labels to Agent for N1C

### DIFF
--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -634,10 +634,12 @@ func (lm *LocalManager) AgentStart(agentDone chan error, instanceGroup string) {
 			fmt.Sprintf("product-type=%s", metadataInfo.ProductType),
 			fmt.Sprintf("product-version=%s", metadataInfo.ProductVersion),
 			fmt.Sprintf("cluster-id=%s", metadataInfo.ClusterID),
-			fmt.Sprintf("installation-name=%s", metadataInfo.InstallationName),
 			fmt.Sprintf("installation-id=%s", metadataInfo.InstallationID),
-			fmt.Sprintf("control-id=%s", metadataInfo.InstallationID), // control-id is required but is the same as installation-id
+			fmt.Sprintf("installation-name=%s", metadataInfo.InstallationName),
 			fmt.Sprintf("installation-namespace=%s", metadataInfo.InstallationNamespace),
+			fmt.Sprintf("control-id=%s", metadataInfo.InstallationID),               // control-id is required but is the same as installation-id
+			fmt.Sprintf("control-name=%s", metadataInfo.InstallationName),           // control-name is required but is the same as installation-name
+			fmt.Sprintf("control-namespace=%s", metadataInfo.InstallationNamespace), // control-namespace is required but is the same as installation-namespace
 		}
 		metadataLabels := "--labels=" + strings.Join(labels, ",")
 		args = append(args, metadataLabels)


### PR DESCRIPTION
### Proposed changes

- Add `control-name` and `control-namespace` to Agent Labels to connect to NGINX One Console

To test, I checked the cmdline file of nginx-agent to verify the correct labels are being sent;.
```
kubectl exec -it pod/my-release-nginx-ingress-controller-5cdf4c697-tmh9j -- sh
~ $ pidof nginx-agent
64
~ $ cat proc/64/cmdline 
/usr/bin/nginx-agent--labels=
product-type=nic,
product-version=5.2.0-SNAPSHOT,
cluster-id=3ee06fe6-60a1-452f-8e88-0f3bc8d4e245,
installation-id=279d40db-5bbf-4ef6-a817-8a6416075726,installation-name=my-release-nginx-ingress-controller,
installation-namespace=default,
control-id=279d40db-5bbf-4ef6-a817-8a6416075726,
control-name=my-release-nginx-ingress-controller,
control-namespace=default
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
