### PR TITLE
Always run tests when inputs.run_tests is true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -717,6 +717,7 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
+      force: ${{ inputs.force }}
 
   smoke-tests-plus:
     if: ${{ inputs.force || (inputs.run_tests && inputs.run_tests || true) || needs.checks.outputs.docs_only != 'true' }}
@@ -744,6 +745,7 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
+      force: ${{ inputs.force }}
 
   smoke-tests-nap:
     if: ${{ inputs.force || (inputs.run_tests && inputs.run_tests || true) || needs.checks.outputs.docs_only != 'true' }}
@@ -771,6 +773,7 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
+      force: ${{ inputs.run_tests }}
 
   tag-stable:
     name: Tag tested image as stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -717,7 +717,7 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
-      force: ${{ inputs.force }}
+      force: ${{ inputs.run_tests }}
 
   smoke-tests-plus:
     if: ${{ inputs.force || (inputs.run_tests && inputs.run_tests || true) || needs.checks.outputs.docs_only != 'true' }}
@@ -745,7 +745,7 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
-      force: ${{ inputs.force }}
+      force: ${{ inputs.run_tests }}
 
   smoke-tests-nap:
     if: ${{ inputs.force || (inputs.run_tests && inputs.run_tests || true) || needs.checks.outputs.docs_only != 'true' }}

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -33,6 +33,9 @@ on:
       k8s-version:
         required: true
         type: string
+      force:
+        required: true
+        type: boolean
 
 defaults:
   run:
@@ -81,6 +84,9 @@ jobs:
           if docker pull ${{ steps.image_details.outputs.name }}:${{ steps.image_details.outputs.stable_tag }}; then
             echo "exists=true" >> $GITHUB_OUTPUT
           fi
+          if [ "${{ inputs.force }}" = "true" ]; then
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
         if: ${{ inputs.authenticated }}
 
       - name: NAP modules
@@ -103,7 +109,7 @@ jobs:
           fail-on-cache-miss: true
         if: ${{ !inputs.authenticated }}
 
-      - name: Check if test image exists
+      - name: Check if pytest image exists
         id: check-image
         run: |
           docker manifest inspect "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/test-runner:${{ hashFiles('./tests/requirements.txt', './tests/Dockerfile') || 'latest' }}"
@@ -111,7 +117,7 @@ jobs:
         continue-on-error: true
         if: ${{ inputs.authenticated  }}
 
-      - name: Build Test-Runner Container
+      - name: Build Pytest-Runner Container
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           file: tests/Dockerfile


### PR DESCRIPTION
### Proposed changes

In a workflow_dispatch, always run tests when `inputs.run_tests` is `true`.  This is done by overriding the check for the stable image when setting up the smoke tests.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
