### PR TITLE
Remove existence check from templates before range

### DIFF
--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -213,10 +213,8 @@ server {
 		error_page 504 @grpcerror504;
 		{{- end}}
 
-		{{- if $location.LocationSnippets}}
 		{{- range $value := $location.LocationSnippets}}
 		{{$value}}{{end}}
-		{{- end}}
 
 		{{- with $jwt := $location.JWTAuth}}
 		auth_jwt_key_file {{$jwt.Key}};
@@ -264,10 +262,8 @@ server {
 		{{- if $.Keepalive}}
 		proxy_set_header Connection "";{{end}}
 		{{- end}}
-		{{- if $location.LocationSnippets}}
-		{{range $value := $location.LocationSnippets}}
-		{{$value}}{{end}}
-		{{- end}}
+		{{- range $value := $location.LocationSnippets}}
+		{{$value}}{{- end}}
 
 		{{- with $jwt := $location.JWTAuth }}
 		auth_jwt_key_file {{$jwt.Key}};

--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -22,10 +22,8 @@ load_module modules/ngx_http_app_protect_module.so;
 load_module modules/ngx_http_app_protect_dos_module.so;
 {{- end}}
 load_module modules/ngx_fips_check_module.so;
-{{- if .MainSnippets}}
-{{range $value := .MainSnippets}}
-{{$value}}{{end}}
-{{- end}}
+{{- range $value := .MainSnippets}}
+{{$value}}{{- end}}
 
 load_module modules/ngx_http_js_module.so;
 
@@ -42,10 +40,8 @@ http {
     js_import /etc/nginx/njs/apikey_auth.js;
     js_set $apikey_auth_hash apikey_auth.hash;
 
-    {{- if .HTTPSnippets}}
-    {{range $value := .HTTPSnippets}}
-    {{$value}}{{end}}
-    {{- end}}
+    {{- range $value := .HTTPSnippets}}
+    {{$value}}{{- end}}
 
     {{if .LogFormat -}}
     log_format  main {{if .LogFormatEscaping}}escape={{ .LogFormatEscaping }} {{end}}

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -107,10 +107,8 @@ server {
 	auth_basic_user_file {{ .Secret }};
 	{{- end }}
 
-	{{- if $server.ServerSnippets}}
 	{{- range $value := $server.ServerSnippets}}
-	{{$value}}{{end}}
-	{{- end}}
+	{{$value}}{{- end}}
 
 	{{- range $location := $server.Locations}}
 	location {{  makeLocationPath $location $.Ingress.Annotations | printf }} {
@@ -137,10 +135,8 @@ server {
 		error_page 504 @grpcerror504;
 		{{- end}}
 
-		{{- if $location.LocationSnippets}}
 		{{- range $value := $location.LocationSnippets}}
-		{{$value}}{{end}}
-		{{- end}}
+		{{$value}}{{- end}}
 
 		{{- with $location.BasicAuth }}
 		auth_basic {{ printf "%q" .Realm }};
@@ -183,10 +179,8 @@ server {
 		{{- if $.Keepalive}}
 		proxy_set_header Connection "";{{end}}
 		{{- end}}
-		{{- if $location.LocationSnippets}}
-		{{range $value := $location.LocationSnippets}}
-		{{$value}}{{end}}
-		{{- end}}
+		{{- range $value := $location.LocationSnippets}}
+		{{$value}}{{- end}}
 		{{- with $location.BasicAuth }}
 		auth_basic {{ printf "%q" .Realm }};
 		auth_basic_user_file {{ .Secret }};

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -15,10 +15,8 @@ pid        /var/lib/nginx/nginx.pid;
 load_module modules/ngx_otel_module.so;
 {{- end}}
 
-{{- if .MainSnippets}}
-{{range $value := .MainSnippets}}
-{{$value}}{{end}}
-{{- end}}
+{{- range $value := .MainSnippets}}
+{{$value}}{{- end}}
 
 load_module modules/ngx_http_js_module.so;
 
@@ -36,10 +34,8 @@ http {
     js_import /etc/nginx/njs/apikey_auth.js;
     js_set $apikey_auth_hash apikey_auth.hash;
 
-    {{- if .HTTPSnippets}}
-    {{range $value := .HTTPSnippets}}
-    {{$value}}{{end}}
-    {{- end}}
+    {{- range $value := .HTTPSnippets}}
+    {{$value}}{{- end}}
 
     {{if .LogFormat -}}
     log_format  main {{if .LogFormatEscaping}}escape={{ .LogFormatEscaping }} {{end}}


### PR DESCRIPTION
Closes #8095

Per testing and documentation the if guard to check if a slice is not empty or not nil is not necessary.

## Documentation:

> {{range pipeline}} T1 {{end}}
>	The value of the pipeline must be an array, slice, map, iter.Seq,
>	iter.Seq2, integer or channel.
>	If the value of the pipeline has length zero, nothing is output;
>	otherwise, dot is set to the successive elements of the array,
>	slice, or map and T1 is executed. If the value is a map and the
>	keys are of basic type with a defined order, the elements will be
>	visited in sorted key order.

[https://pkg.go.dev/text/template#hdr-Actions](https://pkg.go.dev/text/template#hdr-Actions)

## Code testing:

```
<p>begin</p>
{{ range $value := .Elements }}
    <p>{{ $value }}</p>
{{ end }}
<p>end</p>
```

struct that gets populated with data:
```
type Example struct {
    Elements []string
}
```

executed with the following data:
```
// slice is not empty
e := Example{
    Elements: []string{"one", "two", "three"}
}

// slice is empty, but initialised
eEmpty := Example {
    Elements: []string{}
}

// slice is nil
eNil := Example {
    Elements: nil
}
```

The output for these three in order:
```
<p>begin</p>

    <p>Element 1</p>

    <p>Element 2</p>

    <p>Element 3</p>

<p>end</p>
<p>begin</p>

<p>end</p>
<p>begin</p>

<p>end</p>
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
