### PR TITLE
Fix gofumpt empty string errors

### DIFF
--- a/cmd/nginx-ingress/utils.go
+++ b/cmd/nginx-ingress/utils.go
@@ -11,7 +11,7 @@ func getBuildInfo() (commitHash string, commitTime string, dirtyBuild string) {
 
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		return
+		return commitHash, commitTime, dirtyBuild
 	}
 	for _, kv := range info.Settings {
 		switch kv.Key {

--- a/internal/certmanager/test_files/context_builder.go
+++ b/internal/certmanager/test_files/context_builder.go
@@ -158,10 +158,10 @@ func (b *Builder) EnsureReactorCalled(testName string, fn coretesting.ReactionFu
 	return func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
 		handled, ret, err = fn(action)
 		if !handled {
-			return
+			return handled, ret, err
 		}
 		b.requiredReactors[testName] = true
-		return
+		return handled, ret, err
 	}
 }
 

--- a/internal/certmanager/test_files/reactors.go
+++ b/internal/certmanager/test_files/reactors.go
@@ -44,7 +44,7 @@ func ObjectCreatedReactor(t *testing.T, b *Builder, expectedObj runtime.Object) 
 	return func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
 		createAction, ok := action.(coretesting.CreateAction)
 		if !ok {
-			return
+			return handled, ret, err
 		}
 		obj := createAction.GetObject()
 		if !reflect.DeepEqual(obj, expectedObj) {
@@ -60,7 +60,7 @@ func ObjectDeletedReactor(t *testing.T, b *Builder, obj runtime.Object) coretest
 	return func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
 		delAction, ok := action.(coretesting.DeleteAction)
 		if !ok {
-			return
+			return handled, ret, err
 		}
 
 		namespace, name := delAction.GetNamespace(), delAction.GetName()

--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -47,7 +47,7 @@ func (s *storeToIngressLister) GetByKeySafe(key string) (ing *networking.Ingress
 		return nil, exists, err
 	}
 	ing = item.(*networking.Ingress).DeepCopy()
-	return
+	return ing, exists, err
 }
 
 // List lists all Ingress' in the store.


### PR DESCRIPTION
### Proposed changes

Fix gofumpt complaining about empty/naked returns

Since [v0.9.0](https://github.com/mvdan/gofumpt/releases/tag/v0.9.0), it seems gofumpt is failing our linter due to empty returns. 

Using the make command, we seem to grab the latest version [here](https://github.com/search?q=repo%3Anginx%2Fkubernetes-ingress%20gofumpt&type=code)

This is to give each empty return the named values 
[eg](https://go.dev/tour/basics/7)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
