### PR TITLE
Fix populate client max body size on VirtualServer Route match

### DIFF
--- a/internal/configs/version2/__snapshots__/templates_test.snap
+++ b/internal/configs/version2/__snapshots__/templates_test.snap
@@ -323,9 +323,11 @@ server {
     app_protect_dos_monitor uri=test.example.com protocol=http timeout=30;
     # server snippet
     location /split {
+        
         rewrite ^ @split_0 last;
     }
     location /coffee {
+        
         rewrite ^ @match last;
     }
     location @hc-coffee {
@@ -750,9 +752,11 @@ server {
     app_protect_dos_monitor uri=test.example.com protocol=http timeout=30;
     # server snippet
     location /split {
+        
         rewrite ^ @split_0 last;
     }
     location /coffee {
+        
         rewrite ^ @match last;
     }
     location @hc-coffee {
@@ -2883,9 +2887,11 @@ server {
     limit_req zone=pol_rl_test_test_test burst=5 delay=10;
     # server snippet
     location /split {
+        
         rewrite ^ @split_0 last;
     }
     location /coffee {
+        
         rewrite ^ @match last;
     }
     location @vs_cafe_cafe_vsr_tea_tea_tea__tea_error_page_0 {
@@ -3267,9 +3273,11 @@ server {
     
     # server snippet
     location /split {
+        
         rewrite ^ @split_0 last;
     }
     location /coffee {
+        
         rewrite ^ @match last;
     }
     location @hc-coffee {

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -337,8 +337,9 @@ type Distribution struct {
 
 // InternalRedirectLocation defines a location for internally redirecting requests to named locations.
 type InternalRedirectLocation struct {
-	Path        string
-	Destination string
+	Path              string
+	Destination       string
+	ClientMaxBodySize string
 }
 
 // Map defines a map.

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -399,6 +399,9 @@ server {
 
     {{- range $l := $s.InternalRedirectLocations }}
     location {{ $l.Path }} {
+        {{ if $l.ClientMaxBodySize }}
+        client_max_body_size {{ $l.ClientMaxBodySize }};
+        {{ end }}
         rewrite ^ {{ $l.Destination }} last;
     }
     {{- end }}

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -211,6 +211,9 @@ server {
 
     {{- range $l := $s.InternalRedirectLocations }}
     location {{ $l.Path }} {
+        {{ if $l.ClientMaxBodySize }}
+        client_max_body_size {{ $l.ClientMaxBodySize }};
+        {{ end }}
         rewrite ^ {{ $l.Destination }} last;
     }
     {{- end }}

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -3067,10 +3067,21 @@ func generateMatchesConfig(route conf_v1.Route, upstreamNamer *upstreamNamer, cr
 		}
 	}
 
+	// Find any locations with a clientMaxBodySize defined to populate the parent rewrite/redirect location
+	// See issue #7332 for why this needs to exist on the InternalRedirectLocation struct
+	var clientMaxBodySize string
+	for _, l := range locations {
+		if l.ClientMaxBodySize != "" {
+			clientMaxBodySize = l.ClientMaxBodySize
+			break
+		}
+	}
+
 	// Generate an InternalRedirectLocation to the location defined by the main map variable
 	irl := version2.InternalRedirectLocation{
-		Path:        route.Path,
-		Destination: variable,
+		Path:              route.Path,
+		Destination:       variable,
+		ClientMaxBodySize: clientMaxBodySize,
 	}
 
 	return routingCfg{


### PR DESCRIPTION
### Proposed changes

This fixes #7332 which when using virtual server/routes with a match condition then the max body size of the upstream is ultimately lost as nginx doesn't inherit from the sub locations, this PR adds it to the internal redirect location (the parent).

I couldn't see another way for this to work other than creating an issue against nginx, but there's no guarantees that would be accepted as I would imagine instant parameter inheritance in a version might break existing systems that are expected to work in the current way.

Some edge cases to this implementation;
- any upstream with a client max body size then applies to all matched routes on that path
- if a path with matched routes has multiple upstreams all with different max client body sizes, only the first would be used (perhaps we log a warning if this happens?)

I've added the initial unit tests, I haven't added the template test (I guess this is still worthwhile to prevent this breaking/removal in the future) - I wanted to gauge if it's also worth while adding to the suite tests? (which the helm template looks to be broke in the main branch currently)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ x ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have checked that all unit tests pass after adding my changes
- [ x ] I have updated necessary documentation
- [ x ] I have rebased my branch onto main
- [ x ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
