### PR TITLE
support NIC running in proxy mode

### DIFF
--- a/cmd/nginx-ingress/flags.go
+++ b/cmd/nginx-ingress/flags.go
@@ -114,6 +114,10 @@ var (
 		`Path to the TransportServer NGINX configuration template for a TransportServer resource.
 	(default for NGINX "nginx.transportserver.tmpl"; default for NGINX Plus "nginx-plus.transportserver.tmpl")`)
 
+	oidcTemplatePath = flag.String("oidc-template-path", "",
+		`Path to the OIDC NGINX configuration template.
+	(default for NGINX Plus "oidc.tmpl")`)
+
 	externalService = flag.String("external-service", "",
 		`Specifies the name of the service with the type LoadBalancer through which the Ingress Controller pods are exposed externally.
 	The external address of the service is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources. For Ingress resources only: Requires -report-ingress-status.`)
@@ -432,7 +436,7 @@ func mustValidateFlags(ctx context.Context) {
 		nl.Fatal(l, "ingresslink and external-service cannot both be set")
 	}
 
-	if *nginxPlus && *mgmtConfigMap == "" {
+	if *nginxPlus && *mgmtConfigMap == "" && *proxyURL == "" {
 		nl.Fatal(l, "NGINX Plus requires a mgmt ConfigMap to be set")
 	}
 }

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -88,11 +88,6 @@ func main() {
 	ctx := initLogger(*logFormat, logLevels[*logLevel], os.Stdout)
 	l := nl.LoggerFromContext(ctx)
 
-	// TODO: Use fake manager
-	if *proxyURL == "" {
-		cleanupSocketFiles(l)
-	}
-
 	initValidate(ctx)
 	parsedFlags := os.Args[1:]
 
@@ -167,6 +162,8 @@ func main() {
 	}
 
 	nginxManager, useFakeNginxManager := createNginxManager(ctx, managerCollector, licenseReporter, deploymentMetadata)
+
+	nginxManager.CleanupSocketFiles()
 
 	nginxVersion := getNginxVersionInfo(ctx, nginxManager)
 
@@ -630,7 +627,7 @@ func createNginxManager(ctx context.Context, managerCollector collectors.Manager
 	var nginxManager nginx.Manager
 	switch {
 	case useFakeNginxManager:
-		nginxManager = nginx.NewFakeManager(ctx, "/etc/nginx")
+		nginxManager = nginx.NewFakeManager(ctx, "/etc/nginx", *nginxPlus)
 	case *enableConfigSafety:
 		nginxManager = nginx.NewConfigRollbackManager(ctx, "/etc/nginx/", *nginxDebug, managerCollector, licenseReporter, deploymentMetadata, timeout, *nginxPlus)
 	default:
@@ -885,24 +882,6 @@ func handleTermination(lbc *k8s.LoadBalancerController, nginxManager nginx.Manag
 	}
 	nl.Info(lbc.Logger, "Exiting successfully")
 	os.Exit(0)
-}
-
-// Clean up any leftover socket files from previous runs
-func cleanupSocketFiles(l *slog.Logger) {
-	files, readErr := os.ReadDir(socketPath)
-	if readErr != nil {
-		nl.Errorf(l, "error trying to read directory %s: %v", socketPath, readErr)
-	} else {
-		for _, f := range files {
-			if !f.IsDir() && strings.HasSuffix(f.Name(), ".sock") {
-				fullPath := filepath.Join(socketPath, f.Name())
-				nl.Infof(l, "Removing socket file %s", fullPath)
-				if removeErr := os.Remove(fullPath); removeErr != nil {
-					nl.Errorf(l, "error trying to remove file %s: %v", fullPath, removeErr)
-				}
-			}
-		}
-	}
 }
 
 func ready(lbc *k8s.LoadBalancerController) http.HandlerFunc {

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -88,7 +88,10 @@ func main() {
 	ctx := initLogger(*logFormat, logLevels[*logLevel], os.Stdout)
 	l := nl.LoggerFromContext(ctx)
 
-	cleanupSocketFiles(l)
+	// TODO: Use fake manager
+	if *proxyURL == "" {
+		cleanupSocketFiles(l)
+	}
 
 	initValidate(ctx)
 	parsedFlags := os.Args[1:]
@@ -101,10 +104,36 @@ func main() {
 	if err := validateKubernetesVersionInfo(ctx, kubeClient); err != nil {
 		nl.Fatal(l, err)
 	}
-	pod, err := kubeClient.CoreV1().Pods(controllerNamespace).Get(context.TODO(), podName, meta_v1.GetOptions{})
-	if err != nil {
-		nl.Fatalf(l, "Failed to get pod: %v", err)
+
+	var pod *api_v1.Pod
+
+	if *proxyURL != "" {
+		if controllerNamespace == "" {
+			controllerNamespace = "nginx-ingress"
+		}
+		if podName == "" {
+			podName = "nginx-ingress-controller-proxy-mode"
+		}
+		pod = &api_v1.Pod{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      podName,
+				Namespace: controllerNamespace,
+				OwnerReferences: []meta_v1.OwnerReference{
+					{
+						Kind: "Deployment",
+						Name: "nginx-ingress-controller-proxy-mode",
+					},
+				},
+			},
+		}
+	} else {
+		var err error
+		pod, err = kubeClient.CoreV1().Pods(controllerNamespace).Get(context.TODO(), podName, meta_v1.GetOptions{})
+		if err != nil {
+			nl.Fatalf(l, "Failed to get pod: %v", err)
+		}
 	}
+
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(func(format string, args ...interface{}) {
 		nl.Infof(l, format, args...)
@@ -127,13 +156,13 @@ func main() {
 
 	var licenseReporter *license_reporting.LicenseReporter
 
-	if *nginxPlus {
+	if *nginxPlus && *proxyURL == "" {
 		licenseReporter = license_reporting.NewLicenseReporter(kubeClient, eventRecorder, pod)
 	}
 
 	var deploymentMetadata *metadata.Metadata
 
-	if *agent {
+	if *agent && *proxyURL == "" {
 		deploymentMetadata = metadata.NewMetadataReporter(kubeClient, pod, version)
 	}
 
@@ -154,15 +183,28 @@ func main() {
 	}
 
 	var agentVersion string
-	if *agent {
+	if *agent && *proxyURL == "" {
 		agentVersion = getAgentVersionInfo(nginxManager)
 	}
 
-	go updateSelfWithVersionInfo(ctx, eventRecorder, kubeClient, version, appProtectVersion, agentVersion, nginxVersion, 10, time.Second*5)
+	// Skip pod label updates in proxy mode since the pod may not exist or be accessible
+	if *proxyURL == "" {
+		go updateSelfWithVersionInfo(ctx, eventRecorder, kubeClient, version, appProtectVersion, agentVersion, nginxVersion, 10, time.Second*5)
+	}
 
 	var mgmtCfgParams *configs.MGMTConfigParams
 	if *nginxPlus {
-		mgmtCfgParams = processMGMTConfigMap(kubeClient, configs.NewDefaultMGMTConfigParams(ctx), eventRecorder, pod)
+		if *proxyURL == "" {
+			mgmtCfgParams = processMGMTConfigMap(kubeClient, configs.NewDefaultMGMTConfigParams(ctx), eventRecorder, pod)
+		} else {
+			// In proxy mode, also process the mgmt configmap if specified
+			if *mgmtConfigMap != "" {
+				mgmtCfgParams = processMGMTConfigMap(kubeClient, configs.NewDefaultMGMTConfigParams(ctx), eventRecorder, pod)
+			} else {
+				mgmtCfgParams = configs.NewDefaultMGMTConfigParams(ctx)
+			}
+		}
+
 		if err := processLicenseSecret(kubeClient, nginxManager, mgmtCfgParams, controllerNamespace); err != nil {
 			logEventAndExit(ctx, eventRecorder, pod, secretErrorReason, err)
 		}
@@ -174,7 +216,6 @@ func main() {
 		if err := processClientAuthSecret(kubeClient, nginxManager, mgmtCfgParams, controllerNamespace); err != nil {
 			logEventAndExit(ctx, eventRecorder, pod, secretErrorReason, err)
 		}
-
 	}
 
 	templateExecutor, templateExecutorV2 := createTemplateExecutors(ctx)
@@ -234,12 +275,10 @@ func main() {
 		DefaultCABundle:                caBundlePath,
 	}
 
-	if *nginxPlus {
-		if cfgParams.ZoneSync.Enable && cfgParams.ZoneSync.Port != 0 {
-			err := createAndValidateHeadlessService(ctx, kubeClient, cfgParams, controllerNamespace, pod)
-			if err != nil {
-				logEventAndExit(ctx, eventRecorder, pod, nl.EventReasonServiceFailedToCreate, err)
-			}
+	if *nginxPlus && cfgParams.ZoneSync.Enable && cfgParams.ZoneSync.Port != 0 {
+		err := createAndValidateHeadlessService(ctx, kubeClient, cfgParams, controllerNamespace, pod)
+		if err != nil {
+			logEventAndExit(ctx, eventRecorder, pod, nl.EventReasonServiceFailedToCreate, err)
 		}
 	}
 
@@ -253,7 +292,7 @@ func main() {
 	process := startChildProcesses(nginxManager, appProtectV5)
 
 	plusClient := createPlusClient(ctx, *nginxPlus, useFakeNginxManager, nginxManager)
-	if *nginxPlus {
+	if *nginxPlus && *proxyURL == "" {
 		licenseReporter.Config.PlusClient = plusClient
 	}
 
@@ -568,6 +607,9 @@ func createTemplateExecutors(ctx context.Context) (*version1.TemplateExecutor, *
 	if *transportServerTemplatePath != "" {
 		nginxTransportServerTemplatePath = *transportServerTemplatePath
 	}
+	if *oidcTemplatePath != "" {
+		nginxOIDCConfTemplatePath = *oidcTemplatePath
+	}
 
 	templateExecutor, err := version1.NewTemplateExecutor(nginxConfTemplatePath, nginxIngressTemplatePath)
 	if err != nil {
@@ -588,7 +630,7 @@ func createNginxManager(ctx context.Context, managerCollector collectors.Manager
 	var nginxManager nginx.Manager
 	switch {
 	case useFakeNginxManager:
-		nginxManager = nginx.NewFakeManager("/etc/nginx")
+		nginxManager = nginx.NewFakeManager(ctx, "/etc/nginx")
 	case *enableConfigSafety:
 		nginxManager = nginx.NewConfigRollbackManager(ctx, "/etc/nginx/", *nginxDebug, managerCollector, licenseReporter, deploymentMetadata, timeout, *nginxPlus)
 	default:

--- a/internal/configs/configurator_bench_test.go
+++ b/internal/configs/configurator_bench_test.go
@@ -23,7 +23,7 @@ func createTestConfiguratorBench() (*Configurator, error) {
 		return nil, err
 	}
 
-	manager := nginx.NewFakeManager("/etc/nginx")
+	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx")
 	cnf := NewConfigurator(ConfiguratorParams{
 		NginxManager:            manager,
 		StaticCfgParams:         createTestStaticConfigParams(),

--- a/internal/configs/configurator_bench_test.go
+++ b/internal/configs/configurator_bench_test.go
@@ -23,7 +23,7 @@ func createTestConfiguratorBench() (*Configurator, error) {
 		return nil, err
 	}
 
-	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx")
+	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx", false)
 	cnf := NewConfigurator(ConfiguratorParams{
 		NginxManager:            manager,
 		StaticCfgParams:         createTestStaticConfigParams(),

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -47,7 +47,7 @@ func createTestConfigurator(t *testing.T) *Configurator {
 		t.Fatal(err)
 	}
 
-	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx")
+	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx", false)
 	cnf := NewConfigurator(ConfiguratorParams{
 		NginxManager:            manager,
 		StaticCfgParams:         createTestStaticConfigParams(),
@@ -78,7 +78,7 @@ func createTestConfiguratorInvalidIngressTemplate(t *testing.T) *Configurator {
 		t.Fatal(err)
 	}
 
-	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx")
+	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx", false)
 	cnf := NewConfigurator(ConfiguratorParams{
 		NginxManager:            manager,
 		StaticCfgParams:         createTestStaticConfigParams(),

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -47,7 +47,7 @@ func createTestConfigurator(t *testing.T) *Configurator {
 		t.Fatal(err)
 	}
 
-	manager := nginx.NewFakeManager("/etc/nginx")
+	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx")
 	cnf := NewConfigurator(ConfiguratorParams{
 		NginxManager:            manager,
 		StaticCfgParams:         createTestStaticConfigParams(),
@@ -78,7 +78,7 @@ func createTestConfiguratorInvalidIngressTemplate(t *testing.T) *Configurator {
 		t.Fatal(err)
 	}
 
-	manager := nginx.NewFakeManager("/etc/nginx")
+	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx")
 	cnf := NewConfigurator(ConfiguratorParams{
 		NginxManager:            manager,
 		StaticCfgParams:         createTestStaticConfigParams(),

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -2,6 +2,7 @@ package version1
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"regexp"
 	"strconv"
@@ -14,7 +15,7 @@ import (
 	"github.com/nginx/kubernetes-ingress/internal/nginx"
 )
 
-var fakeManager = nginx.NewFakeManager("/etc/nginx")
+var fakeManager = nginx.NewFakeManager(context.Background(), "/etc/nginx")
 
 func TestMain(m *testing.M) {
 	v := m.Run()

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/nginx/kubernetes-ingress/internal/nginx"
 )
 
-var fakeManager = nginx.NewFakeManager(context.Background(), "/etc/nginx")
+var fakeManager = nginx.NewFakeManager(context.Background(), "/etc/nginx", false)
 
 func TestMain(m *testing.M) {
 	v := m.Run()

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -41,7 +41,7 @@ type trackingNginxManager struct {
 
 func newTrackingNginxManager() *trackingNginxManager {
 	return &trackingNginxManager{
-		FakeManager: nginx.NewFakeManager("/etc/nginx"),
+		FakeManager: nginx.NewFakeManager(context.Background(), "/etc/nginx", false),
 	}
 }
 

--- a/internal/nginx/fake_manager.go
+++ b/internal/nginx/fake_manager.go
@@ -1,14 +1,13 @@
 package nginx
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"os"
 	"path"
 
 	nl "github.com/nginx/kubernetes-ingress/internal/logger"
-	nic_glog "github.com/nginx/kubernetes-ingress/internal/logger/glog"
-	"github.com/nginx/kubernetes-ingress/internal/logger/levels"
 	"github.com/nginx/nginx-plus-go-client/v3/client"
 )
 
@@ -21,12 +20,13 @@ type FakeManager struct {
 }
 
 // NewFakeManager creates a FakeManager.
-func NewFakeManager(confPath string) *FakeManager {
+func NewFakeManager(ctx context.Context, confPath string) *FakeManager {
+	l := nl.LoggerFromContext(ctx)
 	return &FakeManager{
 		confdPath:       path.Join(confPath, "conf.d"),
 		secretsPath:     path.Join(confPath, "secrets"),
 		dhparamFilename: path.Join(confPath, "secrets", "dhparam.pem"),
-		logger:          slog.New(nic_glog.New(os.Stdout, &nic_glog.Options{Level: levels.LevelInfo})),
+		logger:          l,
 	}
 }
 

--- a/internal/nginx/fake_manager.go
+++ b/internal/nginx/fake_manager.go
@@ -17,16 +17,19 @@ type FakeManager struct {
 	secretsPath     string
 	dhparamFilename string
 	logger          *slog.Logger
+	nginxPlus       bool
+	done            chan error
 }
 
 // NewFakeManager creates a FakeManager.
-func NewFakeManager(ctx context.Context, confPath string) *FakeManager {
+func NewFakeManager(ctx context.Context, confPath string, nginxPlus bool) *FakeManager {
 	l := nl.LoggerFromContext(ctx)
 	return &FakeManager{
 		confdPath:       path.Join(confPath, "conf.d"),
 		secretsPath:     path.Join(confPath, "secrets"),
 		dhparamFilename: path.Join(confPath, "secrets", "dhparam.pem"),
 		logger:          l,
+		nginxPlus:       nginxPlus,
 	}
 }
 
@@ -118,14 +121,20 @@ func (fm *FakeManager) CreateDHParam(_ string) (string, error) {
 }
 
 // Version provides a fake implementation of Version.
+// It returns an OSS or Plus version string based on the nginxPlus flag passed at construction.
 func (fm *FakeManager) Version() Version {
 	nl.Debug(fm.logger, "Printing nginx version")
-	return NewVersion("nginx version: nginx/1.25.3 (nginx-plus-r31)")
+	if fm.nginxPlus {
+		return NewVersion("nginx version: nginx/1.0.0 (nginx-plus-r00)")
+	}
+	return NewVersion("nginx version: nginx/1.0.0")
 }
 
 // Start provides a fake implementation of Start.
-func (fm *FakeManager) Start(_ chan error) {
+// It stores the done channel so Quit can signal it for clean shutdown.
+func (fm *FakeManager) Start(done chan error) {
 	nl.Debug(fm.logger, "Starting nginx")
+	fm.done = done
 }
 
 // Reload provides a fake implementation of Reload.
@@ -135,8 +144,16 @@ func (fm *FakeManager) Reload(_ bool) error {
 }
 
 // Quit provides a fake implementation of Quit.
+// It signals the done channel so handleTermination can complete cleanly after SIGTERM.
 func (fm *FakeManager) Quit() {
 	nl.Debug(fm.logger, "Quitting nginx")
+	if fm.done != nil {
+		fm.done <- nil
+	}
+}
+
+// CleanupSocketFiles provides a no-op fake implementation of CleanupSocketFiles.
+func (fm *FakeManager) CleanupSocketFiles() {
 }
 
 // UpdateConfigVersionFile provides a fake implementation of UpdateConfigVersionFile.

--- a/internal/nginx/fake_manager_test.go
+++ b/internal/nginx/fake_manager_test.go
@@ -1,0 +1,24 @@
+package nginx
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFakeManagerVersionOSS(t *testing.T) {
+	t.Parallel()
+	fm := NewFakeManager(context.Background(), "/etc/nginx", false)
+	v := fm.Version()
+	if v.IsPlus {
+		t.Error("expected OSS version when nginxPlus is false")
+	}
+}
+
+func TestFakeManagerVersionPlus(t *testing.T) {
+	t.Parallel()
+	fm := NewFakeManager(context.Background(), "/etc/nginx", true)
+	v := fm.Version()
+	if !v.IsPlus {
+		t.Error("expected Plus version when nginxPlus is true")
+	}
+}

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -52,6 +52,9 @@ const (
 	appProtectDosAgentStartDebugCmd = "/usr/bin/admd -d --standalone --log debug"
 
 	defaultCAPath = "/etc/ssl/certs/ca-certificates.crt"
+
+	// socketPath is the directory where NGINX writes Unix domain socket files.
+	socketPath = "/var/lib/nginx"
 )
 
 var (
@@ -105,6 +108,7 @@ type Manager interface {
 	GetOSCABundlePath() (string, error)
 	UpsertSplitClientsKeyVal(zoneName string, key string, value string)
 	DeleteKeyValStateFiles(virtualServerName string)
+	CleanupSocketFiles()
 }
 
 // LocalManager updates NGINX configuration, starts, reloads and quits NGINX, updates License Reporting and the Deployment Metadata file
@@ -804,4 +808,22 @@ func getOSCABundlePath(s string) string {
 	}
 
 	return caFilePath
+}
+
+// CleanupSocketFiles removes any leftover NGINX Unix domain socket files from previous runs.
+func (lm *LocalManager) CleanupSocketFiles() {
+	files, readErr := os.ReadDir(socketPath)
+	if readErr != nil {
+		nl.Errorf(lm.logger, "error trying to read directory %s: %v", socketPath, readErr)
+		return
+	}
+	for _, f := range files {
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".sock") {
+			fullPath := filepath.Join(socketPath, f.Name())
+			nl.Infof(lm.logger, "Removing socket file %s", fullPath)
+			if removeErr := os.Remove(fullPath); removeErr != nil {
+				nl.Errorf(lm.logger, "error trying to remove file %s: %v", fullPath, removeErr)
+			}
+		}
+	}
 }

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -2690,7 +2690,7 @@ func newConfigurator(t *testing.T) *configs.Configurator {
 		t.Fatal(err)
 	}
 
-	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx")
+	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx", false)
 	cnf := configs.NewConfigurator(configs.ConfiguratorParams{
 		NginxManager: manager,
 		StaticCfgParams: &configs.StaticConfigParams{

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -2690,7 +2690,7 @@ func newConfigurator(t *testing.T) *configs.Configurator {
 		t.Fatal(err)
 	}
 
-	manager := nginx.NewFakeManager("/etc/nginx")
+	manager := nginx.NewFakeManager(context.Background(), "/etc/nginx")
 	cnf := configs.NewConfigurator(configs.ConfiguratorParams{
 		NginxManager: manager,
 		StaticCfgParams: &configs.StaticConfigParams{


### PR DESCRIPTION
### Proposed changes


Improves the `-proxy` flag so the NIC can run outside the cluster without crashing.

- Create a synthetic pod object instead of fetching from the API
- Skip license reporting, deployment metadata, pod label updates and agent version operations that require a real pod
- Use default mgmt config params when `-mgmt-configmap` is not specified
- Allow `-nginx-plus` without `-mgmt-configmap` in proxy mode
- Move socket file cleanup into the Manager interface so it is a no-op in proxy mode instead of guarding with a flag check
- Return the correct OSS or Plus version in proxy mode so the binary/flag consistency check passes without a real NGINX binary
- Fix SIGTERM shutdown so the controller exits cleanly in proxy mode
- Add `-oidc-template-path` flag for overriding the OIDC template path

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
