### PR TITLE
fix: prevent duplicate Host header in proxy configurations

### DIFF
--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -348,7 +348,6 @@ server {
 		{{- end}}
 		{{- $proxySetHeaders := generateProxySetHeaders $location $.Ingress.Annotations }}
 		{{$proxySetHeaders}}
-		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_set_header X-Forwarded-Host $host;

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -263,7 +263,6 @@ server {
 		{{- end}}
 		{{- $proxySetHeaders := generateProxySetHeaders $location $.Ingress.Annotations -}}
 		{{$proxySetHeaders}}
-		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_set_header X-Forwarded-Host $host;

--- a/internal/configs/version1/template_helper_test.go
+++ b/internal/configs/version1/template_helper_test.go
@@ -529,6 +529,7 @@ func TestGenerateProxySetHeadersForValidHeadersInMaster(t *testing.T) {
 			},
 			wantProxyHeaders: []string{
 				"proxy_set_header X-Forwarded-ABC1 $http_x_forwarded_abc1;",
+				"proxy_set_header Host $host;",
 			},
 		},
 		{
@@ -538,6 +539,7 @@ func TestGenerateProxySetHeadersForValidHeadersInMaster(t *testing.T) {
 			},
 			wantProxyHeaders: []string{
 				"proxy_set_header X-Forwarded-ABC $http_x_forwarded_abc;",
+				"proxy_set_header Host $host;",
 			},
 		},
 		{
@@ -548,6 +550,7 @@ func TestGenerateProxySetHeadersForValidHeadersInMaster(t *testing.T) {
 			wantProxyHeaders: []string{
 				"proxy_set_header X-Forwarded-ABC $http_x_forwarded_abc;",
 				"proxy_set_header BVC $http_bvc;",
+				"proxy_set_header Host $host;",
 			},
 		},
 		{
@@ -558,6 +561,7 @@ func TestGenerateProxySetHeadersForValidHeadersInMaster(t *testing.T) {
 			wantProxyHeaders: []string{
 				"proxy_set_header X-Forwarded-ABC $http_x_forwarded_abc;",
 				`proxy_set_header BVC "test";`,
+				"proxy_set_header Host $host;",
 			},
 		},
 		{
@@ -569,6 +573,7 @@ func TestGenerateProxySetHeadersForValidHeadersInMaster(t *testing.T) {
 				"proxy_set_header X-Forwarded-ABC $http_x_forwarded_abc;",
 				"proxy_set_header BVC $http_bvc;",
 				"proxy_set_header X-Forwarded-Test $http_x_forwarded_test;",
+				"proxy_set_header Host $host;",
 			},
 		},
 		{
@@ -580,6 +585,7 @@ func TestGenerateProxySetHeadersForValidHeadersInMaster(t *testing.T) {
 				`proxy_set_header X-Forwarded-ABC "abc";`,
 				`proxy_set_header BVC "bat";`,
 				"proxy_set_header X-Forwarded-Test $http_x_forwarded_test;",
+				"proxy_set_header Host $host;",
 			},
 		},
 		{
@@ -589,6 +595,7 @@ func TestGenerateProxySetHeadersForValidHeadersInMaster(t *testing.T) {
 			},
 			wantProxyHeaders: []string{
 				`proxy_set_header X-Forwarded-ABC "test test2";`,
+				"proxy_set_header Host $host;",
 			},
 		},
 	}
@@ -674,10 +681,12 @@ func TestGenerateProxySetHeadersForValidHeadersInMasterAndTwoMinions(t *testing.
 			wantCoffeeHeaders: []string{
 				"proxy_set_header X-Forwarded-ABC $http_x_forwarded_abc;",
 				"proxy_set_header X-Forwarded-Coffee $http_x_forwarded_coffee;",
+				"proxy_set_header Host $host;",
 			},
 			wantTeaHeaders: []string{
 				"proxy_set_header X-Forwarded-ABC $http_x_forwarded_abc;",
 				"proxy_set_header X-Forwarded-Tea $http_x_forwarded_tea;",
+				"proxy_set_header Host $host;",
 			},
 		},
 	}
@@ -736,9 +745,11 @@ func TestGenerateProxySetHeadersForValidHeadersInMinionOverrideMaster(t *testing
 			},
 			wantCoffeeHeaders: []string{
 				`proxy_set_header X-Forwarded-ABC "coffee"`,
+				"proxy_set_header Host $host;",
 			},
 			wantTeaHeaders: []string{
 				"proxy_set_header X-Forwarded-ABC $http_x_forwarded_abc;",
+				"proxy_set_header Host $host;",
 			},
 		},
 	}
@@ -794,6 +805,75 @@ func TestGenerateProxySetHeadersForValidHeadersInOnlyOneMinion(t *testing.T) {
 			},
 			wantCoffeeHeaders: []string{
 				`proxy_set_header X-Forwarded-ABC "coffee"`,
+				"proxy_set_header Host $host;",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			generatedMasterConfig, err := generateProxySetHeaders(&Location{Path: ""}, tc.masterAnnotations)
+			if err != nil {
+				t.Fatal(err)
+			}
+			generatedCoffeeConfig, err := generateProxySetHeaders(&Location{Path: "coffee"}, tc.coffeeAnnotations)
+			if err != nil {
+				t.Fatal(err)
+			}
+			generatedTeaConfig, err := generateProxySetHeaders(&Location{Path: "tea"}, tc.teaAnnotations)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			generatedCoffeeConfig = generatedMasterConfig + "\n" + generatedCoffeeConfig
+			generatedTeaConfig = generatedMasterConfig + "\n" + generatedTeaConfig
+
+			for _, wantHeader := range tc.wantCoffeeHeaders {
+				if !strings.Contains(generatedCoffeeConfig, wantHeader) {
+					t.Errorf("expected header %q not found in generated coffee config", wantHeader)
+				}
+			}
+
+			for _, wantHeader := range tc.wantTeaHeaders {
+				if !strings.Contains(generatedTeaConfig, wantHeader) {
+					t.Errorf("expected header %q not found in generated tea config", wantHeader)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateProxySetHeadersForValidHeadersInMasterAndTwoMinionsOverrideHost(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		masterAnnotations map[string]string
+		coffeeAnnotations map[string]string
+		teaAnnotations    map[string]string
+		wantCoffeeHeaders []string
+		wantTeaHeaders    []string
+	}{
+		{
+			name: "One Master Header and a unique header in Coffee and Tea",
+			masterAnnotations: map[string]string{
+				"nginx.org/proxy-set-headers": "X-Forwarded-ABC",
+			},
+			coffeeAnnotations: map[string]string{
+				"nginx.org/proxy-set-headers": "X-Forwarded-Coffee,Host:coffee",
+			},
+			teaAnnotations: map[string]string{
+				"nginx.org/proxy-set-headers": "X-Forwarded-Tea",
+			},
+			wantCoffeeHeaders: []string{
+				"proxy_set_header X-Forwarded-ABC $http_x_forwarded_abc;",
+				"proxy_set_header X-Forwarded-Coffee $http_x_forwarded_coffee;",
+				`proxy_set_header Host "coffee";`,
+			},
+			wantTeaHeaders: []string{
+				"proxy_set_header X-Forwarded-ABC $http_x_forwarded_abc;",
+				"proxy_set_header X-Forwarded-Tea $http_x_forwarded_tea;",
+				"proxy_set_header Host $host;",
 			},
 		},
 	}


### PR DESCRIPTION
In Ingress, when users define Host header in nginx.org/proxy-set-headers annotations, it was being duplicated because the code always added a default Host header automatically. The value set via the annotation had no effect.

### Proposed changes
Remove the default "Host" header setting from nginx.ingress.tmpl and nginx-plus.ingress.tmpl template files.
Adds the "Host" header dynamically. If it is not defined in "master" or "minions", the default value "proxy_set_header Host $host;" is added.
This PR refers to Issue https://github.com/nginx/kubernetes-ingress/issues/8992

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ * ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ * ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ * ] I have rebased my branch onto main
- [ * ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
