### PR TITLE
Add upstream and downstream support for the PROXY protocol on TransportServer

### DIFF
--- a/config/crd/bases/k8s.nginx.org_transportservers.yaml
+++ b/config/crd/bases/k8s.nginx.org_transportservers.yaml
@@ -129,6 +129,9 @@ spec:
                     description: The number of tries for passing a connection to the
                       next server. The default is 0.
                     type: integer
+                  proxyProtocol:
+                    description: Enables or disables the use of the PROXY protocol. The default is false.
+                    type: boolean
                   udpRequests:
                     description: The number of datagrams, after receiving which, the
                       next datagram from the same client starts a new session. The

--- a/config/crd/bases/k8s.nginx.org_transportservers.yaml
+++ b/config/crd/bases/k8s.nginx.org_transportservers.yaml
@@ -130,7 +130,8 @@ spec:
                       next server. The default is 0.
                     type: integer
                   proxyProtocol:
-                    description: Enables or disables the use of the PROXY protocol. The default is false.
+                    description: Enables or disables the use of the PROXY protocol
+                      for upstream connections. The default is false.
                     type: boolean
                   udpRequests:
                     description: The number of datagrams, after receiving which, the

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -1041,7 +1041,8 @@ spec:
                       next server. The default is 0.
                     type: integer
                   proxyProtocol:
-                    description: Enables or disables the use of the PROXY protocol. The default is false.
+                    description: Enables or disables the use of the PROXY protocol
+                      for upstream connections. The default is false.
                     type: boolean
                   udpRequests:
                     description: The number of datagrams, after receiving which, the

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -1040,6 +1040,9 @@ spec:
                     description: The number of tries for passing a connection to the
                       next server. The default is 0.
                     type: integer
+                  proxyProtocol:
+                    description: Enables or disables the use of the PROXY protocol. The default is false.
+                    type: boolean
                   udpRequests:
                     description: The number of datagrams, after receiving which, the
                       next datagram from the same client starts a new session. The

--- a/docs/crd/k8s.nginx.org_transportservers.md
+++ b/docs/crd/k8s.nginx.org_transportservers.md
@@ -33,6 +33,7 @@ The `.spec` object supports the following fields:
 | `upstreamParameters.nextUpstream` | `boolean` | If a connection to the proxied server cannot be established, determines whether a client connection will be passed to the next server. The default is true. |
 | `upstreamParameters.nextUpstreamTimeout` | `string` | The time allowed to pass a connection to the next server. The default is 0. |
 | `upstreamParameters.nextUpstreamTries` | `integer` | The number of tries for passing a connection to the next server. The default is 0. |
+| `upstreamParameters.proxyProtocol` | `boolean` | Enables or disables the use of the PROXY protocol. The default is false. |
 | `upstreamParameters.udpRequests` | `integer` | The number of datagrams, after receiving which, the next datagram from the same client starts a new session. The default is 0. |
 | `upstreamParameters.udpResponses` | `integer` | The number of datagrams expected from the proxied server in response to a client datagram. By default, the number of datagrams is not limited. |
 | `upstreams` | `array` | A list of upstreams. |

--- a/docs/crd/k8s.nginx.org_transportservers.md
+++ b/docs/crd/k8s.nginx.org_transportservers.md
@@ -33,7 +33,7 @@ The `.spec` object supports the following fields:
 | `upstreamParameters.nextUpstream` | `boolean` | If a connection to the proxied server cannot be established, determines whether a client connection will be passed to the next server. The default is true. |
 | `upstreamParameters.nextUpstreamTimeout` | `string` | The time allowed to pass a connection to the next server. The default is 0. |
 | `upstreamParameters.nextUpstreamTries` | `integer` | The number of tries for passing a connection to the next server. The default is 0. |
-| `upstreamParameters.proxyProtocol` | `boolean` | Enables or disables the use of the PROXY protocol. The default is false. |
+| `upstreamParameters.proxyProtocol` | `boolean` | Enables or disables the use of the PROXY protocol for upstream connections. The default is false. |
 | `upstreamParameters.udpRequests` | `integer` | The number of datagrams, after receiving which, the next datagram from the same client starts a new session. The default is 0. |
 | `upstreamParameters.udpResponses` | `integer` | The number of datagrams expected from the proxied server in response to a client datagram. By default, the number of datagrams is not limited. |
 | `upstreams` | `array` | A list of upstreams. |

--- a/internal/configs/transportserver.go
+++ b/internal/configs/transportserver.go
@@ -70,7 +70,7 @@ func generateTransportServerConfig(p transportServerConfigParams) (*version2.Tra
 
 	var proxyRequests, proxyResponses *int
 	var connectTimeout, nextUpstreamTimeout string
-	var nextUpstream bool
+	var nextUpstream, proxyProtocolUpstream bool
 	var nextUpstreamTries int
 	if p.transportServerEx.TransportServer.Spec.UpstreamParameters != nil {
 		proxyRequests = p.transportServerEx.TransportServer.Spec.UpstreamParameters.UDPRequests
@@ -83,6 +83,7 @@ func generateTransportServerConfig(p transportServerConfigParams) (*version2.Tra
 		}
 
 		connectTimeout = p.transportServerEx.TransportServer.Spec.UpstreamParameters.ConnectTimeout
+		proxyProtocolUpstream = p.transportServerEx.TransportServer.Spec.UpstreamParameters.ProxyProtocol
 	}
 
 	var proxyTimeout string
@@ -102,6 +103,7 @@ func generateTransportServerConfig(p transportServerConfigParams) (*version2.Tra
 	isTLSPassthrough := p.transportServerEx.TransportServer.Spec.Listener.Name == conf_v1.TLSPassthroughListenerName
 	serverName := generateServerName(host, isTLSPassthrough)
 	isUDP := p.transportServerEx.TransportServer.Spec.Listener.Protocol == "UDP"
+	isProxyProtocol := p.transportServerEx.TransportServer.Spec.Listener.Protocol == "PROXY"
 
 	tsConfig := &version2.TransportServerConfig{
 		Server: version2.StreamServer{
@@ -111,6 +113,7 @@ func generateTransportServerConfig(p transportServerConfigParams) (*version2.Tra
 			Port:                     p.listenerPort,
 			UDP:                      isUDP,
 			StatusZone:               statusZone,
+			ProxyProtocolListener:    isProxyProtocol,
 			ProxyRequests:            proxyRequests,
 			ProxyResponses:           proxyResponses,
 			ProxyPass:                upstreamNamer.GetNameForUpstream(p.transportServerEx.TransportServer.Spec.Action.Pass),
@@ -121,6 +124,7 @@ func generateTransportServerConfig(p transportServerConfigParams) (*version2.Tra
 			ProxyNextUpstream:        nextUpstream,
 			ProxyNextUpstreamTimeout: generateTimeWithDefault(nextUpstreamTimeout, "0s"),
 			ProxyNextUpstreamTries:   nextUpstreamTries,
+			ProxyProtocolUpstream:    proxyProtocolUpstream,
 			HealthCheck:              healthCheck,
 			ServerSnippets:           serverSnippets,
 			DisableIPV6:              p.transportServerEx.DisableIPV6,

--- a/internal/configs/version2/nginx-plus.transportserver.tmpl
+++ b/internal/configs/version2/nginx-plus.transportserver.tmpl
@@ -78,4 +78,8 @@ server {
     proxy_next_upstream_timeout {{ $s.ProxyNextUpstreamTimeout }};
     proxy_next_upstream_tries {{ $s.ProxyNextUpstreamTries }};
     {{- end }}
+
+    {{- if $s.ProxyProtocolUpstream }}
+    proxy_protocol on;
+    {{- end }}
 }

--- a/internal/configs/version2/nginx.transportserver.tmpl
+++ b/internal/configs/version2/nginx.transportserver.tmpl
@@ -54,4 +54,8 @@ server {
     proxy_next_upstream_timeout {{ $s.ProxyNextUpstreamTimeout }};
     proxy_next_upstream_tries {{ $s.ProxyNextUpstreamTries }};
     {{- end }}
+
+    {{- if $s.ProxyProtocolUpstream }}
+    proxy_protocol on;
+    {{- end }}
 }

--- a/internal/configs/version2/stream.go
+++ b/internal/configs/version2/stream.go
@@ -53,6 +53,8 @@ type StreamServer struct {
 	ProxyNextUpstream        bool
 	ProxyNextUpstreamTimeout string
 	ProxyNextUpstreamTries   int
+	ProxyProtocolUpstream    bool
+	ProxyProtocolListener    bool
 	HealthCheck              *StreamHealthCheck
 	ServerSnippets           []string
 	DisableIPV6              bool

--- a/internal/configs/version2/template_helper.go
+++ b/internal/configs/version2/template_helper.go
@@ -187,7 +187,7 @@ func makeTransportListener(s StreamServer) string {
 		ipAddress:     s.IPv4,
 		port:          port,
 		tls:           s.SSL.Enabled,
-		proxyProtocol: false,
+		proxyProtocol: s.ProxyProtocolListener,
 		udp:           s.UDP,
 		ipType:        ipv4,
 	})
@@ -198,7 +198,7 @@ func makeTransportListener(s StreamServer) string {
 			ipAddress:     s.IPv6,
 			port:          port,
 			tls:           s.SSL.Enabled,
-			proxyProtocol: false,
+			proxyProtocol: s.ProxyProtocolListener,
 			udp:           s.UDP,
 			ipType:        ipv6,
 		})

--- a/internal/configs/version2/template_helper_test.go
+++ b/internal/configs/version2/template_helper_test.go
@@ -489,6 +489,15 @@ func TestMakeTransportListener(t *testing.T) {
 			Port:        5353,
 		}, expected: "listen 5353;\n"},
 		{server: StreamServer{
+			ProxyProtocolListener: true,
+			SSL: &StreamSSL{
+				Enabled: false,
+			},
+			UDP:         false,
+			DisableIPV6: true,
+			Port:        5353,
+		}, expected: "listen 5353 proxy_protocol;\n"},
+		{server: StreamServer{
 			UDP: true,
 			SSL: &StreamSSL{
 				Enabled: false,

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -714,6 +714,8 @@ type UpstreamParameters struct {
 	NextUpstreamTimeout string `json:"nextUpstreamTimeout"`
 	// The number of tries for passing a connection to the next server. The default is 0.
 	NextUpstreamTries int `json:"nextUpstreamTries"`
+	// Enables or disables the use of the PROXY protocol. The default is false.
+	ProxyProtocol bool `json:"proxyProtocol"`
 }
 
 // SessionParameters defines session parameters.

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -714,7 +714,7 @@ type UpstreamParameters struct {
 	NextUpstreamTimeout string `json:"nextUpstreamTimeout"`
 	// The number of tries for passing a connection to the next server. The default is 0.
 	NextUpstreamTries int `json:"nextUpstreamTries"`
-	// Enables or disables the use of the PROXY protocol. The default is false.
+	// Enables or disables the use of the PROXY protocol for upstream connections. The default is false.
 	ProxyProtocol bool `json:"proxyProtocol"`
 }
 

--- a/pkg/apis/configuration/validation/globalconfiguration.go
+++ b/pkg/apis/configuration/validation/globalconfiguration.go
@@ -20,9 +20,10 @@ const (
 )
 
 var allowedProtocols = map[string]bool{
-	"TCP":  true,
-	"UDP":  true,
-	"HTTP": true,
+	"TCP":   true,
+	"UDP":   true,
+	"HTTP":  true,
+	"PROXY": true,
 }
 
 // GlobalConfigurationValidator validates a GlobalConfiguration resource.
@@ -104,8 +105,8 @@ func (gcv *GlobalConfigurationValidator) checkIPPortProtocolConflicts(combinatio
 	}
 	for _, existingProtocol := range existingProtocols {
 		switch listener.Protocol {
-		case "HTTP", "TCP":
-			if existingProtocol == "HTTP" || existingProtocol == "TCP" {
+		case "HTTP", "TCP", "PROXY":
+			if existingProtocol == "HTTP" || existingProtocol == "TCP" || existingProtocol == "PROXY" {
 				return field.Invalid(fieldPath.Child("protocol"), listener.Protocol, fmt.Sprintf("Listener %s: Duplicated ip:port protocol combination %s:%d %s", listener.Name, ip, listener.Port, listener.Protocol))
 			}
 		case "UDP":

--- a/pkg/client/applyconfiguration/configuration/v1/upstreamparameters.go
+++ b/pkg/client/applyconfiguration/configuration/v1/upstreamparameters.go
@@ -19,6 +19,8 @@ type UpstreamParametersApplyConfiguration struct {
 	NextUpstreamTimeout *string `json:"nextUpstreamTimeout,omitempty"`
 	// The number of tries for passing a connection to the next server. The default is 0.
 	NextUpstreamTries *int `json:"nextUpstreamTries,omitempty"`
+	// Enables or disables the use of the PROXY protocol. The default is false.
+	ProxyProtocol *bool `json:"proxyProtocol,omitempty"`
 }
 
 // UpstreamParametersApplyConfiguration constructs a declarative configuration of the UpstreamParameters type for use with

--- a/pkg/client/applyconfiguration/configuration/v1/upstreamparameters.go
+++ b/pkg/client/applyconfiguration/configuration/v1/upstreamparameters.go
@@ -76,3 +76,11 @@ func (b *UpstreamParametersApplyConfiguration) WithNextUpstreamTries(value int) 
 	b.NextUpstreamTries = &value
 	return b
 }
+
+// WithProxyProtocol sets the ProxyProtocol field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ProxyProtocol field is set to the value of the last call.
+func (b *UpstreamParametersApplyConfiguration) WithProxyProtocol(value bool) *UpstreamParametersApplyConfiguration {
+	b.ProxyProtocol = &value
+	return b
+}


### PR DESCRIPTION
### Proposed changes

This PR adds upstream and downstream support for the PROXY protocol to `TransportServer`

Current behavior and limitations:
  - TransportServers with custom listeners will never use the PROXY protocol downstream https://github.com/nginx/kubernetes-ingress/blob/e070acad51e94d6ca6a278ce52c026546b851105/internal/configs/version2/template_helper.go#L190
  - TransportServers cannot use the PROXY protocol upstream (without custom snippets)

These limitations are unblocked by:
  - `proxyProtocol` is added to `upstreamParameters` in the TransportServer CRD.
    - Resolves https://github.com/nginx/kubernetes-ingress/issues/8122
  - `PROXY` protocol is added as an available protocol to listener configuration in the TransportServer and GlobalConfiguration CRDs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
