### PR TITLE
Change resource type to ContainerResource in HPA

### DIFF
--- a/charts/nginx-ingress/templates/controller-hpa.yaml
+++ b/charts/nginx-ingress/templates/controller-hpa.yaml
@@ -23,17 +23,19 @@ spec:
 {{- end }}
   metrics:
     {{- if .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
+    - type: ContainerResource
+      containerResource:
         name: memory
+        container: {{ include "nginx-ingress.name" . }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
     {{- if .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
+    - type: ContainerResource
+      containerResource:
         name: cpu
+        container: {{ include "nginx-ingress.name" . }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.controller.autoscaling.targetCPUUtilizationPercentage }}


### PR DESCRIPTION
Updated Horizontal Pod Autoscaler (HPA) configuration to use container-level resource metrics instead of overall pod resource metrics for more granular scaling control

### Proposed changes

Updated the HPA metric configuration from resource-level 
(pod-wide CPU/memory usage) to container-level resource metrics.

This ensures scaling decisions are made based on individual 
container utilization, improving precision in multi-container 
pod environments and preventing inaccurate scaling behavior.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
