### PR TITLE
Add External Auth Policy to VS/VSR

### DIFF
--- a/.github/data/matrix-smoke-oss.json
+++ b/.github/data/matrix-smoke-oss.json
@@ -36,45 +36,59 @@
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 1/6",
+      "label": "policies 1/8",
       "image": "alpine",
       "type": "oss",
       "marker": "'policies and not policies_rl and not policies_ac and not policies_jwt and not policies_mtls and not policies_cache and not policies_cors and not policies_external_auth'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 2/6",
+      "label": "policies 2/8",
       "image": "alpine",
       "type": "oss",
       "marker": "'policies_ac or policies_jwt'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 3/6",
+      "label": "policies 3/8",
       "image": "alpine",
       "type": "oss",
       "marker": "'policies_rl or policies_cors'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 4/6",
+      "label": "policies 4/8",
       "image": "alpine",
       "type": "oss",
       "marker": "'policies_mtls or policies_cache or otel'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 5/6",
+      "label": "policies 5/8",
       "image": "alpine",
       "type": "oss",
-      "marker": "'policies_external_auth and not policies_external_auth_tls'",
+      "marker": "'policies_external_auth and not policies_external_auth_tls and not policies_external_auth_vs'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 6/6",
+      "label": "policies 6/8",
       "image": "alpine",
       "type": "oss",
-      "marker": "'policies_external_auth_tls'",
+      "marker": "'policies_external_auth_vs and not policies_external_auth_tls'",
+      "platforms": "linux/arm64, linux/amd64"
+    },
+    {
+      "label": "policies 7/8",
+      "image": "alpine",
+      "type": "oss",
+      "marker": "'policies_external_auth_tls and not policies_external_auth_vs'",
+      "platforms": "linux/arm64, linux/amd64"
+    },
+    {
+      "label": "policies 8/8",
+      "image": "alpine",
+      "type": "oss",
+      "marker": "'policies_external_auth_tls and policies_external_auth_vs'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {

--- a/.github/data/matrix-smoke-plus.json
+++ b/.github/data/matrix-smoke-plus.json
@@ -92,52 +92,66 @@
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 1/7",
+      "label": "policies 1/9",
       "image": "ubi-9-plus",
       "type": "plus",
       "marker": "'policies and not policies_ac and not policies_jwt and not policies_mtls and not policies_rl and not policies_cache and not policies_cors and not policies_external_auth'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 2/7",
+      "label": "policies 2/9",
       "image": "ubi-9-plus",
       "type": "plus",
       "marker": "'policies_ac or policies_mtls or policies_cache'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 3/7",
+      "label": "policies 3/9",
       "image": "ubi-9-plus",
       "type": "plus",
       "marker": "'policies_jwt or otel'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 4/7",
+      "label": "policies 4/9",
       "image": "ubi-9-plus",
       "type": "plus",
       "marker": "'policies_rl'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 5/7",
+      "label": "policies 5/9",
       "image": "ubi-9-plus",
       "type": "plus",
       "marker": "'policies_cors'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 6/7",
+      "label": "policies 6/9",
       "image": "ubi-9-plus",
       "type": "plus",
-      "marker": "'policies_external_auth and not policies_external_auth_tls'",
+      "marker": "'policies_external_auth and not policies_external_auth_tls and not policies_external_auth_vs'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {
-      "label": "policies 7/7",
+      "label": "policies 7/9",
       "image": "ubi-9-plus",
       "type": "plus",
-      "marker": "'policies_external_auth_tls'",
+      "marker": "'policies_external_auth_vs and not policies_external_auth_tls'",
+      "platforms": "linux/arm64, linux/amd64"
+    },
+    {
+      "label": "policies 8/9",
+      "image": "ubi-9-plus",
+      "type": "plus",
+      "marker": "'policies_external_auth_tls and not policies_external_auth_vs'",
+      "platforms": "linux/arm64, linux/amd64"
+    },
+    {
+      "label": "policies 9/9",
+      "image": "ubi-9-plus",
+      "type": "plus",
+      "marker": "'policies_external_auth_tls and policies_external_auth_vs'",
       "platforms": "linux/arm64, linux/amd64"
     },
     {

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,8 @@ examples/ingress-resources/session-persistence/cafe-secret.yaml
 examples/custom-resources/basic-configuration-vsr/cafe-secret.yaml
 examples/ingress-resources/external-auth/tls-secret.yaml
 examples/ingress-resources/external-auth-mergeable/tls-secret.yaml
+examples/custom-resources/external-auth/tls-secret.yaml
+examples/custom-resources/external-auth-oauth2/tls-secret.yaml
 examples/custom-resources/vsr-route-selector-policies/cafe-secret.yaml
 tests/data/dos/tls-secret.yaml
 tests/data/hsts/mergeable-tls/tls-secret.yaml
@@ -201,10 +203,14 @@ common-secrets/external-auth-server-tls-secret.yaml
 common-secrets/external-auth-ca-secret-crl.yaml
 examples/ingress-resources/external-auth-mergeable/external-auth-ca-secret.yaml
 examples/ingress-resources/external-auth-mergeable/external-auth-ca-secret-crl.yaml
+examples/custom-resources/external-auth-oauth2/external-auth-ca-secret.yaml
+examples/custom-resources/external-auth-oauth2/external-auth-ca-secret-crl.yaml
 tests/data/external-auth/backend/external-auth-ca-secret.yaml
 tests/data/external-auth/backend/external-auth-ca-secret-crl.yaml
 examples/ingress-resources/external-auth/external-auth-server-tls-secret.yaml
 examples/ingress-resources/external-auth-mergeable/external-auth-server-tls-secret.yaml
+examples/custom-resources/external-auth/external-auth-server-tls-secret.yaml
+examples/custom-resources/external-auth-oauth2/external-auth-server-tls-secret.yaml
 tests/data/external-auth/backend/external-auth-server-tls-secret.yaml
 
 # TLS Certificate secrets
@@ -234,6 +240,8 @@ tests/data/auth-basic-secrets/auth-basic-secret-invalid.yaml
 common-secrets/htpasswd-secret-external-auth.yaml
 examples/ingress-resources/external-auth/htpasswd-secret.yaml
 examples/ingress-resources/external-auth-mergeable/htpasswd-secret.yaml
+examples/custom-resources/external-auth/htpasswd-secret.yaml
+examples/custom-resources/external-auth-oauth2/htpasswd-secret.yaml
 tests/data/external-auth/backend/htpasswd-secret.yaml
 
 # Jwks secrets

--- a/examples/custom-resources/external-auth-oauth2/README.md
+++ b/examples/custom-resources/external-auth-oauth2/README.md
@@ -1,0 +1,135 @@
+# External Authentication with OAuth2
+
+In this example we deploy the cafe application, configure load balancing with a VirtualServer, and apply different
+external authentication methods per route:
+
+- `/tea` is protected by **HTTP Basic Auth** using an NGINX service that validates credentials from an htpasswd file.
+- `/coffee` is protected by **OAuth2 Proxy** using [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/)
+  configured with [GitHub OAuth](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app).
+
+Each route references its own ExternalAuth Policy in the VirtualServer route configuration.
+
+For a simpler example that uses only basic-auth with a spec-level policy, see [external-auth](../external-auth/).
+
+## Prerequisites
+
+1. Run `make secrets` command to generate the necessary secrets for the example.
+1. Follow the [installation](https://docs.nginx.com/nginx-ingress-controller/install/manifests)
+   instructions to deploy the Ingress Controller with custom resources enabled.
+1. Save the public IP address of the Ingress Controller into a shell variable:
+
+    ```console
+    IC_IP=XXX.YYY.ZZZ.III
+    ```
+
+1. Save the HTTPS port of the Ingress Controller into a shell variable:
+
+    ```console
+    IC_HTTPS_PORT=<port number>
+    ```
+
+## Step 1 - Deploy the Cafe Application
+
+Create the coffee and tea deployments and services:
+
+```console
+kubectl apply -f cafe.yaml
+```
+
+## Step 2 - Deploy Secrets
+
+Create the TLS secrets:
+
+```console
+kubectl apply -f tls-secret.yaml
+kubectl apply -f external-auth-server-tls-secret.yaml
+kubectl apply -f external-auth-ca-secret.yaml
+```
+
+## Step 3 - Deploy the Basic Auth Backend
+
+Create the htpasswd secret and deploy the basic-auth service:
+
+```console
+kubectl apply -f htpasswd-secret.yaml
+kubectl apply -f basic-auth.yaml
+```
+
+## Step 4 - Create a GitHub OAuth App
+
+1. Go to **GitHub -> Settings -> Developer settings ->
+   [OAuth Apps](https://github.com/settings/developers)** and click **New OAuth App**.
+1. Fill in the form:
+
+   | Field | Value |
+   | ----- | ----- |
+   | **Application name** | `nginx-ingress-demo` (or any name) |
+   | **Homepage URL** | `https://cafe.example.com` |
+   | **Authorization callback URL** | `https://cafe.example.com/oauth2/callback` |
+
+1. Click **Register application**.
+1. Note the **Client ID** and generate a **client secret**.
+
+## Step 5 - Deploy OAuth2 Proxy
+
+1. Base64-encode your GitHub client secret and update `oauth2-proxy-client-secret.yaml` with the value, then update the
+   `OAUTH2_PROXY_CLIENT_ID` environment variable in `oauth2-proxy.yaml` with your client ID:
+
+    ```console
+    echo -n '<your-github-client-secret>' | base64
+    ```
+
+1. Apply the secret and deploy oauth2-proxy:
+
+    ```console
+    kubectl apply -f oauth2-proxy-client-secret.yaml
+    kubectl apply -f oauth2-proxy.yaml
+    ```
+
+## Step 6 - Deploy the ExternalAuth Policies
+
+Create the ExternalAuth policies that the VirtualServer routes will reference:
+
+```console
+kubectl apply -f basic-auth-policy.yaml
+kubectl apply -f oauth2-policy.yaml
+```
+
+## Step 7 - Configure Load Balancing
+
+Create the VirtualServer resource. Each route references its own ExternalAuth policy -- `/tea` is protected by
+basic-auth and `/coffee` is protected by OAuth2 Proxy:
+
+```console
+kubectl apply -f cafe-virtual-server.yaml
+```
+
+## Step 8 - Test the Configuration
+
+### Basic Auth (`/tea`)
+
+1. Send a request without credentials. NGINX will reject it with a `401`:
+
+    ```console
+    curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/tea --insecure
+    ```
+
+1. Send a request with valid credentials (default: `foo` / `bar`):
+
+    ```console
+    curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/tea --insecure -u foo:bar
+    ```
+
+    ```text
+    Server address: 10.244.0.6:8080
+    Server name: tea-7b9b4bbd99-bdbxm
+    ...
+    ```
+
+### OAuth2 (`/coffee`)
+
+Open `https://cafe.example.com/coffee` in a browser. You will be redirected to GitHub to authorize the OAuth App. After
+granting access, GitHub redirects you back and the page loads normally.
+
+> **Note:** The OAuth2 flow requires browser interaction. Use a browser for the initial login. Once authenticated, the
+> `_oauth2_proxy` cookie allows subsequent requests, including `curl`, to pass through.

--- a/examples/custom-resources/external-auth-oauth2/basic-auth-policy.yaml
+++ b/examples/custom-resources/external-auth-oauth2/basic-auth-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: k8s.nginx.org/v1
+kind: Policy
+metadata:
+  name: external-auth-basic-policy
+spec:
+  externalAuth:
+    authURI: "/auth"
+    authServiceName: "default/basic-auth-svc"
+    sslEnabled: true
+    sslVerify: true
+    sslVerifyDepth: 2
+    sniName: "external-auth-tls"
+    trustedCertSecret: "external-auth-ca-secret"

--- a/examples/custom-resources/external-auth-oauth2/basic-auth.yaml
+++ b/examples/custom-resources/external-auth-oauth2/basic-auth.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: secure-config
+data:
+  http.conf: |-
+    server {
+        listen 8080;
+        listen [::]:8080;
+
+        root /usr/share/nginx/html;
+        try_files /index.html =404;
+
+        auth_basic "Protected Area";
+        auth_basic_user_file /etc/nginx/auth/htpasswd;
+
+        expires -1;
+
+        sub_filter_once off;
+        sub_filter 'server_hostname' '$hostname';
+        sub_filter 'server_address' '$server_addr:$server_port';
+        sub_filter 'server_url' '$request_uri';
+        sub_filter 'server_date' '$time_local';
+        sub_filter 'request_id' '$request_id';
+    }
+  https.conf: |-
+    server {
+        listen 8443 ssl;
+        listen [::]:8443 ssl;
+
+        root /usr/share/nginx/html;
+        try_files /index.html =404;
+
+        ssl_certificate /etc/nginx/ssl/tls.crt;
+        ssl_certificate_key /etc/nginx/ssl/tls.key;
+
+        auth_basic "Protected Area";
+        auth_basic_user_file /etc/nginx/auth/htpasswd;
+
+        expires -1;
+
+        sub_filter_once off;
+        sub_filter 'server_hostname' '$hostname';
+        sub_filter 'server_address' '$server_addr:$server_port';
+        sub_filter 'server_url' '$request_uri';
+        sub_filter 'server_date' '$time_local';
+        sub_filter 'request_id' '$request_id';
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: basic-auth
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: basic-auth
+  template:
+    metadata:
+      labels:
+        app: basic-auth
+    spec:
+      containers:
+        - name: basic-auth
+          image: nginxdemos/nginx-hello:plain-text
+          ports:
+            - containerPort: 8080
+            - containerPort: 8443
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/nginx/conf.d
+            - name: htpasswd-volume
+              mountPath: /etc/nginx/auth/htpasswd
+              subPath: htpasswd
+              readOnly: true
+            - name: tls-volume
+              mountPath: /etc/nginx/ssl
+              readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: secure-config
+        - name: htpasswd-volume
+          secret:
+            secretName: htpasswd-secret
+        - name: tls-volume
+          secret:
+            secretName: external-auth-server-tls-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: basic-auth-svc
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  - port: 443
+    targetPort: 8443
+    protocol: TCP
+    name: https
+  selector:
+    app: basic-auth

--- a/examples/custom-resources/external-auth-oauth2/cafe-virtual-server.yaml
+++ b/examples/custom-resources/external-auth-oauth2/cafe-virtual-server.yaml
@@ -1,0 +1,28 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: cafe
+spec:
+  host: cafe.example.com
+  tls:
+    secret: tls-secret
+    redirect:
+      enable: true
+  upstreams:
+  - name: tea
+    service: tea-svc
+    port: 80
+  - name: coffee
+    service: coffee-svc
+    port: 80
+  routes:
+  - path: /tea
+    action:
+      pass: tea
+    policies:
+      - name: external-auth-basic-policy
+  - path: /coffee
+    action:
+      pass: coffee
+    policies:
+      - name: external-auth-oauth2-policy

--- a/examples/custom-resources/external-auth-oauth2/cafe.yaml
+++ b/examples/custom-resources/external-auth-oauth2/cafe.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coffee
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: coffee
+  template:
+    metadata:
+      labels:
+        app: coffee
+    spec:
+      containers:
+      - name: coffee
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coffee-svc
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: coffee
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tea
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tea
+  template:
+    metadata:
+      labels:
+        app: tea
+    spec:
+      containers:
+      - name: tea
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tea-svc
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: tea

--- a/examples/custom-resources/external-auth-oauth2/oauth2-policy.yaml
+++ b/examples/custom-resources/external-auth-oauth2/oauth2-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: k8s.nginx.org/v1
+kind: Policy
+metadata:
+  name: external-auth-oauth2-policy
+spec:
+  externalAuth:
+    authURI: "/oauth2/auth"
+    authSigninURI: "/oauth2/signin"
+    authServiceName: "default/oauth2-proxy-svc"
+    sslEnabled: true
+    sslVerify: true
+    sslVerifyDepth: 2
+    sniName: "external-auth-tls"
+    trustedCertSecret: "external-auth-ca-secret"

--- a/examples/custom-resources/external-auth-oauth2/oauth2-proxy-client-secret.yaml
+++ b/examples/custom-resources/external-auth-oauth2/oauth2-proxy-client-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oauth2-proxy-client-secret
+type: Opaque
+data:
+  # Replace this with the base64-encoded client secret from your GitHub OAuth App.
+  # echo -n '<your-github-client-secret>' | base64
+  client-secret: abcbase64==

--- a/examples/custom-resources/external-auth-oauth2/oauth2-proxy.yaml
+++ b/examples/custom-resources/external-auth-oauth2/oauth2-proxy.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oauth2-proxy-config
+data:
+  oauth2-proxy.cfg: |
+    provider = "github"
+    provider_display_name = "GitHub"
+    email_domains = ["*"]
+    upstreams = ["file:///dev/null"]
+    https_address = "0.0.0.0:4180"
+    redirect_url = "https://cafe.example.com/oauth2/callback"
+    cookie_secure = true
+    whitelist_domains = ["cafe.example.com"]
+    tls_cert_file = "/etc/tls/tls.crt"
+    tls_key_file = "/etc/tls/tls.key"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oauth2-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app: oauth2-proxy
+    spec:
+      containers:
+        - name: oauth2-proxy
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
+          args:
+            - --config=/etc/oauth2-proxy/oauth2-proxy.cfg
+          env:
+            - name: OAUTH2_PROXY_CLIENT_ID
+              value: "your-github-client-id"
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: oauth2-proxy-client-secret
+                  key: client-secret
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              value: "rmXYk59eajf5Mm2y19gjwA=="
+          ports:
+            - containerPort: 4180
+              name: https
+          volumeMounts:
+            - name: config
+              mountPath: /etc/oauth2-proxy
+              readOnly: true
+            - name: tls
+              mountPath: /etc/tls
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /ping
+              port: 4180
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: oauth2-proxy-config
+        - name: tls
+          secret:
+            secretName: external-auth-server-tls-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oauth2-proxy-svc
+spec:
+  ports:
+    - port: 443
+      targetPort: 4180
+      protocol: TCP
+      name: https
+  selector:
+    app: oauth2-proxy

--- a/examples/custom-resources/external-auth/README.md
+++ b/examples/custom-resources/external-auth/README.md
@@ -1,0 +1,106 @@
+# External Authentication
+
+In this example we deploy the cafe application, configure load balancing with a VirtualServer, and protect all routes
+with external authentication using HTTP Basic Auth via the ExternalAuth Policy.
+
+The basic-auth backend is an NGINX service that validates credentials from an htpasswd file. The ExternalAuth Policy is
+applied at the VirtualServer `spec.policies` level, so all routes inherit the policy automatically.
+
+## Prerequisites
+
+1. Run `make secrets` command to generate the necessary secrets for the example.
+1. Follow the [installation](https://docs.nginx.com/nginx-ingress-controller/install/manifests)
+   instructions to deploy the Ingress Controller with custom resources enabled.
+1. Save the public IP address of the Ingress Controller into a shell variable:
+
+    ```console
+    IC_IP=XXX.YYY.ZZZ.III
+    ```
+
+1. Save the HTTPS port of the Ingress Controller into a shell variable:
+
+    ```console
+    IC_HTTPS_PORT=<port number>
+    ```
+
+## Step 1 - Deploy the Cafe Application
+
+Create the coffee and tea deployments and services:
+
+```console
+kubectl apply -f cafe.yaml
+```
+
+## Step 2 - Deploy Secrets
+
+Create the TLS secret for the VirtualServer and the TLS secret used by the basic-auth backend:
+
+```console
+kubectl apply -f tls-secret.yaml
+kubectl apply -f external-auth-server-tls-secret.yaml
+```
+
+## Step 3 - Deploy the Basic Auth Backend
+
+Create the htpasswd secret and deploy the basic-auth service:
+
+```console
+kubectl apply -f htpasswd-secret.yaml
+kubectl apply -f basic-auth.yaml
+```
+
+## Step 4 - Deploy the ExternalAuth Policy
+
+Create the ExternalAuth policy that the VirtualServer will reference:
+
+```console
+kubectl apply -f basic-auth-policy.yaml
+```
+
+## Step 5 - Configure Load Balancing
+
+Create the VirtualServer resource. The basic-auth policy is applied at the `spec.policies` level, so all routes are
+protected:
+
+```console
+kubectl apply -f cafe-virtual-server.yaml
+```
+
+## Step 6 - Test the Configuration
+
+1. Send a request without credentials. NGINX will reject it with a `401`:
+
+    ```console
+    curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/tea --insecure
+    ```
+
+    ```text
+    <html>
+    <head><title>401 Authorization Required</title></head>
+    <body>
+    <center><h1>401 Authorization Required</h1></center>
+    </body>
+    </html>
+    ```
+
+1. Send a request with valid credentials (default: `foo` / `bar`):
+
+    ```console
+    curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/tea --insecure -u foo:bar
+    ```
+
+    ```text
+    Server address: 10.244.0.6:8080
+    Server name: tea-7b9b4bbd99-bdbxm
+    ...
+    ```
+
+    ```console
+    curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/coffee --insecure -u foo:bar
+    ```
+
+    ```text
+    Server address: 10.244.0.7:8080
+    Server name: coffee-7b9b4bbd99-xn7wp
+    ...
+    ```

--- a/examples/custom-resources/external-auth/basic-auth-policy.yaml
+++ b/examples/custom-resources/external-auth/basic-auth-policy.yaml
@@ -1,0 +1,9 @@
+apiVersion: k8s.nginx.org/v1
+kind: Policy
+metadata:
+  name: external-auth-basic-policy
+spec:
+  externalAuth:
+    authURI: "/auth"
+    authServiceName: "default/basic-auth-svc"
+    sslEnabled: true

--- a/examples/custom-resources/external-auth/basic-auth.yaml
+++ b/examples/custom-resources/external-auth/basic-auth.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: secure-config
+data:
+  http.conf: |-
+    server {
+        listen 8080;
+        listen [::]:8080;
+
+        root /usr/share/nginx/html;
+        try_files /index.html =404;
+
+        auth_basic "Protected Area";
+        auth_basic_user_file /etc/nginx/auth/htpasswd;
+
+        expires -1;
+
+        sub_filter_once off;
+        sub_filter 'server_hostname' '$hostname';
+        sub_filter 'server_address' '$server_addr:$server_port';
+        sub_filter 'server_url' '$request_uri';
+        sub_filter 'server_date' '$time_local';
+        sub_filter 'request_id' '$request_id';
+    }
+  https.conf: |-
+    server {
+        listen 8443 ssl;
+        listen [::]:8443 ssl;
+
+        root /usr/share/nginx/html;
+        try_files /index.html =404;
+
+        ssl_certificate /etc/nginx/ssl/tls.crt;
+        ssl_certificate_key /etc/nginx/ssl/tls.key;
+
+        auth_basic "Protected Area";
+        auth_basic_user_file /etc/nginx/auth/htpasswd;
+
+        expires -1;
+
+        sub_filter_once off;
+        sub_filter 'server_hostname' '$hostname';
+        sub_filter 'server_address' '$server_addr:$server_port';
+        sub_filter 'server_url' '$request_uri';
+        sub_filter 'server_date' '$time_local';
+        sub_filter 'request_id' '$request_id';
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: basic-auth
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: basic-auth
+  template:
+    metadata:
+      labels:
+        app: basic-auth
+    spec:
+      containers:
+        - name: basic-auth
+          image: nginxdemos/nginx-hello:plain-text
+          ports:
+            - containerPort: 8080
+            - containerPort: 8443
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/nginx/conf.d
+            - name: htpasswd-volume
+              mountPath: /etc/nginx/auth/htpasswd
+              subPath: htpasswd
+              readOnly: true
+            - name: tls-volume
+              mountPath: /etc/nginx/ssl
+              readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: secure-config
+        - name: htpasswd-volume
+          secret:
+            secretName: htpasswd-secret
+        - name: tls-volume
+          secret:
+            secretName: external-auth-server-tls-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: basic-auth-svc
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  - port: 443
+    targetPort: 8443
+    protocol: TCP
+    name: https
+  selector:
+    app: basic-auth

--- a/examples/custom-resources/external-auth/cafe-virtual-server.yaml
+++ b/examples/custom-resources/external-auth/cafe-virtual-server.yaml
@@ -1,0 +1,26 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: cafe
+spec:
+  policies:
+    - name: external-auth-basic-policy
+  host: cafe.example.com
+  tls:
+    secret: tls-secret
+    redirect:
+      enable: true
+  upstreams:
+  - name: tea
+    service: tea-svc
+    port: 80
+  - name: coffee
+    service: coffee-svc
+    port: 80
+  routes:
+  - path: /tea
+    action:
+      pass: tea
+  - path: /coffee
+    action:
+      pass: coffee

--- a/examples/custom-resources/external-auth/cafe.yaml
+++ b/examples/custom-resources/external-auth/cafe.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coffee
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: coffee
+  template:
+    metadata:
+      labels:
+        app: coffee
+    spec:
+      containers:
+      - name: coffee
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coffee-svc
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: coffee
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tea
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tea
+  template:
+    metadata:
+      labels:
+        app: tea
+    spec:
+      containers:
+      - name: tea
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tea-svc
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: tea

--- a/hack/secrets.json
+++ b/hack/secrets.json
@@ -62,6 +62,8 @@
         "/examples/custom-resources/basic-configuration-vsr/cafe-secret.yaml",
         "/examples/ingress-resources/external-auth/tls-secret.yaml",
         "/examples/ingress-resources/external-auth-mergeable/tls-secret.yaml",
+        "/examples/custom-resources/external-auth/tls-secret.yaml",
+        "/examples/custom-resources/external-auth-oauth2/tls-secret.yaml",
         "/examples/custom-resources/vsr-route-selector-policies/cafe-secret.yaml",
         "/tests/data/dos/tls-secret.yaml",
         "/tests/data/hsts/mergeable-tls/tls-secret.yaml",
@@ -1012,10 +1014,12 @@
         "secretType": "nginx.org/ca",
         "symlinks": [
           "/examples/ingress-resources/external-auth-mergeable/external-auth-ca-secret.yaml",
+          "/examples/custom-resources/external-auth-oauth2/external-auth-ca-secret.yaml",
           "/tests/data/external-auth/backend/external-auth-ca-secret.yaml"
         ],
         "usedIn": [
           "examples/ingress-resources/external-auth-mergeable",
+          "examples/custom-resources/external-auth-oauth2",
           "tests/data/external-auth/backend"
         ]
       },
@@ -1048,11 +1052,15 @@
         "symlinks": [
           "/examples/ingress-resources/external-auth/external-auth-server-tls-secret.yaml",
           "/examples/ingress-resources/external-auth-mergeable/external-auth-server-tls-secret.yaml",
+          "/examples/custom-resources/external-auth/external-auth-server-tls-secret.yaml",
+          "/examples/custom-resources/external-auth-oauth2/external-auth-server-tls-secret.yaml",
           "/tests/data/external-auth/backend/external-auth-server-tls-secret.yaml"
         ],
         "usedIn": [
           "examples/ingress-resources/external-auth",
           "examples/ingress-resources/external-auth-mergeable",
+          "examples/custom-resources/external-auth",
+          "examples/custom-resources/external-auth-oauth2",
           "tests/data/external-auth/backend"
         ]
       }
@@ -1265,12 +1273,17 @@
       "symlinks": [
         "/examples/ingress-resources/external-auth/htpasswd-secret.yaml",
         "/examples/ingress-resources/external-auth-mergeable/htpasswd-secret.yaml",
+        "/examples/custom-resources/external-auth/htpasswd-secret.yaml",
+        "/examples/custom-resources/external-auth-oauth2/htpasswd-secret.yaml",
         "/tests/data/external-auth/backend/htpasswd-secret.yaml"
       ],
       "usedIn": [
         "examples/ingress-resources/external-auth",
         "examples/ingress-resources/external-auth-mergeable",
-        "tests/suite/test_external_auth_policies.py"
+        "examples/custom-resources/external-auth",
+        "examples/custom-resources/external-auth-oauth2",
+        "tests/suite/test_external_auth_policies.py",
+        "tests/suite/test_external_auth_policies_vsr.py"
       ]
     }
   ],

--- a/internal/configs/configurator.go
+++ b/internal/configs/configurator.go
@@ -1204,16 +1204,17 @@ func (cnf *Configurator) UpdateEndpointsMergeableIngress(mergeableIngresses []*M
 }
 
 // UpdateEndpointsForVirtualServers updates endpoints in NGINX configuration for the VirtualServer resources.
-func (cnf *Configurator) UpdateEndpointsForVirtualServers(virtualServerExes []*VirtualServerEx) error {
+func (cnf *Configurator) UpdateEndpointsForVirtualServers(virtualServerExes []*VirtualServerEx) (Warnings, error) {
 	l := nl.LoggerFromContext(cnf.CfgParams.Context)
 	reloadPlus := false
+	allWarnings := newWarnings()
 
 	for _, vs := range virtualServerExes {
-		// It is safe to ignore warnings here as no new warnings should appear when updating Endpoints for VirtualServers
-		_, _, _, err := cnf.addOrUpdateVirtualServer(vs)
+		_, warnings, _, err := cnf.addOrUpdateVirtualServer(vs)
 		if err != nil {
-			return fmt.Errorf("error adding or updating VirtualServer %v/%v: %w", vs.VirtualServer.Namespace, vs.VirtualServer.Name, err)
+			return allWarnings, fmt.Errorf("error adding or updating VirtualServer %v/%v: %w", vs.VirtualServer.Namespace, vs.VirtualServer.Name, err)
 		}
+		allWarnings.Add(warnings)
 
 		if cnf.isPlus {
 			err := cnf.updatePlusEndpointsForVirtualServer(vs)
@@ -1226,14 +1227,14 @@ func (cnf *Configurator) UpdateEndpointsForVirtualServers(virtualServerExes []*V
 
 	if cnf.isPlus && !reloadPlus {
 		nl.Debug(l, "No need to reload nginx")
-		return nil
+		return allWarnings, nil
 	}
 
 	if err := cnf.Reload(nginx.ReloadForEndpointsUpdate); err != nil {
-		return fmt.Errorf("error reloading NGINX when updating endpoints: %w", err)
+		return allWarnings, fmt.Errorf("error reloading NGINX when updating endpoints: %w", err)
 	}
 
-	return nil
+	return allWarnings, nil
 }
 
 func (cnf *Configurator) updatePlusEndpointsForVirtualServer(virtualServerEx *VirtualServerEx) error {
@@ -1249,7 +1250,44 @@ func (cnf *Configurator) updatePlusEndpointsForVirtualServer(virtualServerEx *Vi
 		}
 	}
 
+	// Update external auth upstreams via the Plus API.
+	// These are generated from policies referenced by the VirtualServer
+	// and are not part of the VirtualServer spec upstreams, so they need separate handling.
+	for _, pol := range virtualServerEx.Policies {
+		if pol.Spec.ExternalAuth == nil || pol.Spec.ExternalAuth.AuthServiceName == "" {
+			continue
+		}
+		exAuth := pol.Spec.ExternalAuth
+		upstreamName := fmt.Sprintf("vs_exauth_%s_%s", pol.Namespace, pol.Name)
+		port := getExternalAuthPort(exAuth)
+		ns, svcName := ParseServiceReference(exAuth.AuthServiceName, pol.Namespace)
+		endpointKey := fmt.Sprintf("%s/%s:%d", ns, svcName, port)
+		if endps, exists := virtualServerEx.Endpoints[endpointKey]; exists {
+			cfg := nginx.ServerConfig{
+				MaxFails:    1,
+				MaxConns:    0,
+				FailTimeout: "10s",
+			}
+			err := cnf.updateServersInPlus(upstreamName, endps, cfg)
+			if err != nil {
+				return fmt.Errorf("couldn't update the endpoints for external auth upstream %v: %w", upstreamName, err)
+			}
+		}
+	}
+
 	return nil
+}
+
+// getExternalAuthPort returns the port for the external auth service.
+// It checks AuthServicePorts first, then falls back to 443 (SSL) or 80.
+func getExternalAuthPort(exAuth *conf_v1.ExternalAuth) int {
+	if len(exAuth.AuthServicePorts) > 0 && exAuth.AuthServicePorts[0] > 0 {
+		return exAuth.AuthServicePorts[0]
+	}
+	if exAuth.SSLEnabled {
+		return 443
+	}
+	return 80
 }
 
 // UpdateEndpointsForTransportServers updates endpoints in NGINX configuration for the TransportServer resources.
@@ -1371,18 +1409,6 @@ func (cnf *Configurator) updatePlusEndpoints(ingEx *IngressEx) error {
 	}
 
 	return nil
-}
-
-// getExternalAuthPort returns the port for the external auth service.
-// It checks AuthServicePorts first, then falls back to 443 (SSL) or 80.
-func getExternalAuthPort(exAuth *conf_v1.ExternalAuth) int {
-	if len(exAuth.AuthServicePorts) > 0 && exAuth.AuthServicePorts[0] > 0 {
-		return exAuth.AuthServicePorts[0]
-	}
-	if exAuth.SSLEnabled {
-		return 443
-	}
-	return 80
 }
 
 // EnableReloads enables NGINX reloads meaning that configuration changes will be followed by a reload.

--- a/internal/configs/version2/__snapshots__/templates_test.snap
+++ b/internal/configs/version2/__snapshots__/templates_test.snap
@@ -440,7 +440,7 @@ server {
         
         set $header_query_value "${http_x_header_name}${http_other_header}${arg_myQuery}${arg_myOtherQuery}";
         error_page 400 500 =200 "@error_page_1";
-        error_page 500  "@error_page_2";
+        error_page 500 "@error_page_2";
         proxy_intercept_errors on;
         set $default_connection_header close;
         proxy_connect_timeout 30s;
@@ -866,7 +866,7 @@ server {
 
         
         error_page 400 500 =200 "@error_page_1";
-        error_page 500  "@error_page_2";
+        error_page 500 "@error_page_2";
         proxy_intercept_errors on;
         set $default_connection_header close;
         proxy_connect_timeout 30s;
@@ -1164,7 +1164,8 @@ server {
 
 [TestExecuteVirtualServerTemplateWithCachePolicyOSS - 1]
 
-upstream test-upstream {zone test-upstream ;
+upstream test-upstream {
+    zone test-upstream ;
     server 10.0.0.20:8001 max_fails=0 fail_timeout= max_conns=0;
 }
 
@@ -3307,18 +3308,21 @@ server {
 
 [TestVirtualServerForNginx - 1]
 
-upstream test-upstream {zone test-upstream 256k;
+upstream test-upstream {
+    zone test-upstream 256k;
     random;
     server 10.0.0.20:8001 max_fails=4 fail_timeout=10s max_conns=31;
     keepalive 32;
     sticky cookie test expires=25s path=/tea;
 }
 
-upstream coffee-v1 {zone coffee-v1 256k;
+upstream coffee-v1 {
+    zone coffee-v1 256k;
     server 10.0.0.31:8001 max_fails=8 fail_timeout=15s max_conns=2;
 }
 
-upstream coffee-v2 {zone coffee-v2 256k;
+upstream coffee-v2 {
+    zone coffee-v2 256k;
     server 10.0.0.32:8001 max_fails=12 fail_timeout=20s max_conns=4;
 }
 
@@ -3467,7 +3471,7 @@ server {
 
         
         error_page 400 500 =200 "@error_page_1";
-        error_page 500  "@error_page_2";
+        error_page 500 "@error_page_2";
         proxy_intercept_errors on;
         set $default_connection_header close;
         proxy_connect_timeout 30s;
@@ -3872,7 +3876,7 @@ server {
 
         
         error_page 400 500 =200 "@error_page_1";
-        error_page 500  "@error_page_2";
+        error_page 500 "@error_page_2";
         proxy_intercept_errors on;
         set $default_connection_header close;
         proxy_connect_timeout 30s;
@@ -4282,7 +4286,7 @@ server {
 
         
         error_page 400 500 =200 "@error_page_1";
-        error_page 500  "@error_page_2";
+        error_page 500 "@error_page_2";
         proxy_intercept_errors on;
         set $default_connection_header close;
         proxy_connect_timeout 30s;
@@ -4588,18 +4592,21 @@ server {
 
 [TestVirtualServerForNginxWithServiceBeforeRedirect - 1]
 
-upstream test-upstream {zone test-upstream 256k;
+upstream test-upstream {
+    zone test-upstream 256k;
     random;
     server 10.0.0.20:8001 max_fails=4 fail_timeout=10s max_conns=31;
     keepalive 32;
     sticky cookie test expires=25s path=/tea;
 }
 
-upstream coffee-v1 {zone coffee-v1 256k;
+upstream coffee-v1 {
+    zone coffee-v1 256k;
     server 10.0.0.31:8001 max_fails=8 fail_timeout=15s max_conns=2;
 }
 
-upstream coffee-v2 {zone coffee-v2 256k;
+upstream coffee-v2 {
+    zone coffee-v2 256k;
     server 10.0.0.32:8001 max_fails=12 fail_timeout=20s max_conns=4;
 }
 
@@ -4748,7 +4755,7 @@ server {
 
         
         error_page 400 500 =200 "@error_page_1";
-        error_page 500  "@error_page_2";
+        error_page 500 "@error_page_2";
         proxy_intercept_errors on;
         set $default_connection_header close;
         proxy_connect_timeout 30s;

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -369,6 +369,14 @@ server {
     proxy_ssl_name {{ .SSLName }};
     {{- end }}
 
+    {{- if $s.ExternalAuth }}
+    auth_request {{ $s.ExternalAuth.URI.InternalPath }};
+    {{- end }}
+
+    {{- range $e := $s.ErrorPages }}
+    error_page {{ $e.Codes }} {{ if ne 0 $e.ResponseCode }}={{ end }}{{ if gt $e.ResponseCode 0 }}{{ $e.ResponseCode }} {{ end }}"{{ $e.Name }}";
+    {{- end }}
+
     {{- with $s.APIKey}}
     js_var $header_query_value {{ makeHeaderQueryValue $s.APIKey | printf }};
     js_var $apikey_auth_local_map "{{ .MapName}}";
@@ -505,6 +513,12 @@ server {
         {{- end }}
         {{- range $snippet := $l.Snippets }}
         {{ $snippet }}
+        {{- end }}
+
+        {{- if $l.AuthRequestOff }}
+        auth_request off;
+        {{- else if $l.ExternalAuth }}
+        auth_request {{ $l.ExternalAuth.URI.InternalPath }};
         {{- end }}
 
         {{- with $l.PoliciesErrorReturn }}
@@ -674,7 +688,7 @@ server {
         {{- end }}
 
         {{- range $e := $l.ErrorPages }}
-        error_page {{ $e.Codes }} {{ if ne 0 $e.ResponseCode }}={{ $e.ResponseCode }}{{ end }} "{{ $e.Name }}";
+        error_page {{ $e.Codes }} {{ if ne 0 $e.ResponseCode }}={{ end }}{{ if gt $e.ResponseCode 0 }}{{ $e.ResponseCode }} {{ end }}"{{ $e.Name }}";
         {{- end }}
 
         {{- if $l.ProxyInterceptErrors }}
@@ -722,6 +736,9 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $vs_connection_header;
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
+        {{- if $l.ProxyPassRequestBody }}
+        proxy_pass_request_body {{ $l.ProxyPassRequestBody }};
+        {{- end }}
             {{- end }}
 
         {{- $custom_headers := $l.ProxySetHeaders | headerListToCIMap }}
@@ -838,6 +855,15 @@ server {
             {{- else }}
         proxy_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
             {{- end }}
+        {{- if $l.ProxySSLVerify }}
+        proxy_ssl_verify on;
+        proxy_ssl_verify_depth {{ $l.ProxySSLVerifyDepth }};
+        proxy_ssl_server_name on;
+        proxy_ssl_name {{ $l.ProxySSLName }};
+        {{- end }}
+        {{- if $l.ProxySSLTrustedCertificate }}
+        proxy_ssl_trusted_certificate {{ $l.ProxySSLTrustedCertificate }};
+        {{- end }}
         {{ $proxyOrGRPC }}_next_upstream {{ $l.ProxyNextUpstream }};
         {{ $proxyOrGRPC }}_next_upstream_timeout {{ $l.ProxyNextUpstreamTimeout }};
         {{ $proxyOrGRPC }}_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -1,7 +1,7 @@
 {{- /*gotype: github.com/nginx/kubernetes-ingress/internal/configs/version2.VirtualServerConfig*/ -}}
 {{ range $u := .Upstreams }}
 upstream {{ $u.Name }} {
-    {{- if ne $u.UpstreamZoneSize "0" }}zone {{ $u.Name }} {{ $u.UpstreamZoneSize }};{{ end }}
+    {{ if ne $u.UpstreamZoneSize "0" }}zone {{ $u.Name }} {{ $u.UpstreamZoneSize }};{{ end }}
     {{- if $u.LBMethod }}
     {{ $u.LBMethod }};
     {{- end }}
@@ -239,6 +239,14 @@ server {
     proxy_ssl_name {{ .SSLName }};
     {{- end }}
 
+    {{- if $s.ExternalAuth }}
+    auth_request {{ $s.ExternalAuth.URI.InternalPath }};
+    {{- end }}
+
+    {{- range $e := $s.ErrorPages }}
+    error_page {{ $e.Codes }} {{ if ne 0 $e.ResponseCode }}={{ end }}{{ if gt $e.ResponseCode 0 }}{{ $e.ResponseCode }} {{ end }}"{{ $e.Name }}";
+    {{- end }}
+
     {{- range $snippet := $s.Snippets }}
     {{ $snippet }}
     {{- end }}
@@ -286,6 +294,12 @@ server {
         {{- end }}
         {{- range $snippet := $l.Snippets }}
         {{ $snippet }}
+        {{- end }}
+
+        {{- if $l.AuthRequestOff }}
+        auth_request off;
+        {{- else if $l.ExternalAuth }}
+        auth_request {{ $l.ExternalAuth.URI.InternalPath }};
         {{- end }}
 
         {{- with $l.PoliciesErrorReturn }}
@@ -383,7 +397,7 @@ server {
         {{- end }}
 
         {{- range $e := $l.ErrorPages }}
-        error_page {{ $e.Codes }} {{ if ne 0 $e.ResponseCode }}={{ $e.ResponseCode }}{{ end }} "{{ $e.Name }}";
+        error_page {{ $e.Codes }} {{ if ne 0 $e.ResponseCode }}={{ end }}{{ if gt $e.ResponseCode 0 }}{{ $e.ResponseCode }} {{ end }}"{{ $e.Name }}";
         {{- end }}
 
         {{- if $l.ProxyInterceptErrors }}
@@ -431,6 +445,9 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $vs_connection_header;
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
+        {{- if $l.ProxyPassRequestBody }}
+        proxy_pass_request_body {{ $l.ProxyPassRequestBody }};
+        {{- end }}
             {{- end }}
 
         {{- $custom_headers := $l.ProxySetHeaders | headerListToCIMap }}
@@ -543,6 +560,15 @@ server {
             {{- else }}
         proxy_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
             {{- end }}
+        {{- if $l.ProxySSLVerify }}
+        proxy_ssl_verify on;
+        proxy_ssl_verify_depth {{ $l.ProxySSLVerifyDepth }};
+        proxy_ssl_server_name on;
+        proxy_ssl_name {{ $l.ProxySSLName }};
+        {{- end }}
+        {{- if $l.ProxySSLTrustedCertificate }}
+        proxy_ssl_trusted_certificate {{ $l.ProxySSLTrustedCertificate }};
+        {{- end }}
         {{ $proxyOrGRPC }}_next_upstream {{ $l.ProxyNextUpstream }};
         {{ $proxyOrGRPC }}_next_upstream_timeout {{ $l.ProxyNextUpstreamTimeout }};
         {{ $proxyOrGRPC }}_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -2,6 +2,7 @@ package configs
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -363,6 +364,9 @@ func (vsc *virtualServerConfigurator) generateEndpointsForUpstream(
 	endpointsKey := GenerateEndpointsKey(serviceNamespace, serviceName, upstream.Subselector, upstream.Port)
 	externalNameSvcKey := GenerateExternalNameSvcKey(namespace, upstream.Service)
 	endpoints := virtualServerEx.Endpoints[endpointsKey]
+	if endpoints != nil && len(endpoints) == 0 {
+		vsc.addWarningf(owner, "No endpoints found for service %v", upstream.Service)
+	}
 	if !vsc.isPlus && len(endpoints) == 0 {
 		return []string{nginx502Server}
 	}
@@ -551,6 +555,50 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 
 	VariableNamer := NewVSVariableNamer(vsEx.VirtualServer)
 
+	// Track generated ExternalAuth proxy URLs to avoid duplicate upstream/location generation
+	generatedExternalAuthURLs := make(map[string]bool)
+	generatedOAuth2Location := false
+
+	// generate config for external auth if referenced in policiesCfg, adds an upstream for the
+	// external auth server and a location for the external auth requests
+	if policiesCfg.ExternalAuth != nil {
+		generatedExternalAuthURLs[policiesCfg.ExternalAuth.URI.InternalPath] = true
+		proxyURLUpstreamName := policiesCfg.ExternalAuth.URI.Upstream
+		proxyURLUpstream := conf_v1.Upstream{
+			Name:    proxyURLUpstreamName,
+			Service: policiesCfg.ExternalAuth.URI.Service,
+			Port:    vsc.getExAuthServicePort(policiesCfg, vsEx),
+		}
+
+		proxyPassUpstream := virtualServerUpstreamNamer.GetNameForUpstream(proxyURLUpstreamName)
+
+		locations = append(locations, vsc.generateExternalAuthLocation(policiesCfg, proxyPassUpstream))
+
+		upstreams, healthChecks, statusMatches = generateUpstreams(
+			sslConfig,
+			vsc,
+			proxyURLUpstream,
+			vsEx.VirtualServer,
+			vsEx.VirtualServer.Namespace,
+			virtualServerUpstreamNamer,
+			vsEx,
+			upstreams,
+			crUpstreams,
+			healthChecks,
+			statusMatches,
+		)
+
+		// generate config for external auth signin URL if configured
+		if policiesCfg.ExternalAuth.SigninURL != "" {
+			generatedExternalAuthURLs[policiesCfg.ExternalAuth.SigninURL] = true
+
+			if !generatedOAuth2Location {
+				locations = append(locations, vsc.generateExternalAuthOAuth2Location(policiesCfg, proxyPassUpstream))
+				generatedOAuth2Location = true
+			}
+		}
+	}
+
 	// specHasOIDC records whether the VirtualServer spec itself carries an OIDC policy.
 	// It is used below to inherit spec-level OIDC to routes that don't define their own,
 	// without allowing a route-level OIDC assignment to bleed into subsequent routes.
@@ -676,6 +724,50 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 			}
 			if _, exists := policiesCfg.APIKey.ClientMap[apiMapName]; !exists {
 				policiesCfg.APIKey.ClientMap[apiMapName] = routePoliciesCfg.APIKey.Clients
+			}
+		}
+
+		// generate config for route-level external auth if referenced in routePoliciesCfg,
+		// adds an upstream for the external auth server and a location for the external auth requests
+		if routePoliciesCfg.ExternalAuth != nil {
+			if !generatedExternalAuthURLs[routePoliciesCfg.ExternalAuth.URI.InternalPath] {
+				generatedExternalAuthURLs[routePoliciesCfg.ExternalAuth.URI.InternalPath] = true
+				proxyURLUpstreamName := routePoliciesCfg.ExternalAuth.URI.Upstream
+				proxyURLUpstream := conf_v1.Upstream{
+					Name:    proxyURLUpstreamName,
+					Service: routePoliciesCfg.ExternalAuth.URI.Service,
+					Port:    vsc.getExAuthServicePort(routePoliciesCfg, vsEx),
+				}
+
+				proxyPassUpstream := virtualServerUpstreamNamer.GetNameForUpstream(proxyURLUpstreamName)
+
+				locations = append(locations, vsc.generateExternalAuthLocation(routePoliciesCfg, proxyPassUpstream))
+
+				upstreams, healthChecks, statusMatches = generateUpstreams(
+					sslConfig,
+					vsc,
+					proxyURLUpstream,
+					vsEx.VirtualServer,
+					vsEx.VirtualServer.Namespace,
+					virtualServerUpstreamNamer,
+					vsEx,
+					upstreams,
+					crUpstreams,
+					healthChecks,
+					statusMatches,
+				)
+
+				// generate config for route-level external auth signin URL if configured
+				if routePoliciesCfg.ExternalAuth.SigninURL != "" {
+					generatedExternalAuthURLs[routePoliciesCfg.ExternalAuth.SigninURL] = true
+
+					if !generatedOAuth2Location {
+						locations = append(locations, vsc.generateExternalAuthOAuth2Location(routePoliciesCfg, proxyPassUpstream))
+						generatedOAuth2Location = true
+					}
+				}
+			} else {
+				vsc.addWarningf(vsEx.VirtualServer, "Duplicate external auth URI %s on this VirtualServer; external auth URI for route %s will be ignored.", routePoliciesCfg.ExternalAuth.URI.Path, r.Path)
 			}
 		}
 
@@ -857,6 +949,49 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 				}
 			}
 
+			// generate config for subroute-level external auth if referenced in routePoliciesCfg,
+			// adds an upstream for the external auth server and a location for the external auth requests
+			if routePoliciesCfg.ExternalAuth != nil {
+				if !generatedExternalAuthURLs[routePoliciesCfg.ExternalAuth.URI.InternalPath] {
+					generatedExternalAuthURLs[routePoliciesCfg.ExternalAuth.URI.InternalPath] = true
+					proxyURLUpstreamName := routePoliciesCfg.ExternalAuth.URI.Upstream
+					proxyURLUpstream := conf_v1.Upstream{
+						Name:    proxyURLUpstreamName,
+						Service: routePoliciesCfg.ExternalAuth.URI.Service,
+						Port:    vsc.getExAuthServicePort(routePoliciesCfg, vsEx),
+					}
+
+					proxyPassUpstream := upstreamNamer.GetNameForUpstream(proxyURLUpstreamName)
+
+					locations = append(locations, vsc.generateExternalAuthLocation(routePoliciesCfg, proxyPassUpstream))
+
+					upstreams, healthChecks, statusMatches = generateUpstreams(
+						sslConfig,
+						vsc,
+						proxyURLUpstream,
+						vsr,
+						vsr.Namespace,
+						upstreamNamer,
+						vsEx,
+						upstreams,
+						crUpstreams,
+						healthChecks,
+						statusMatches,
+					)
+					// generate config for subroute-level external auth signin URL if configured
+					if routePoliciesCfg.ExternalAuth.SigninURL != "" {
+						generatedExternalAuthURLs[routePoliciesCfg.ExternalAuth.SigninURL] = true
+
+						if !generatedOAuth2Location {
+							locations = append(locations, vsc.generateExternalAuthOAuth2Location(routePoliciesCfg, proxyPassUpstream))
+							generatedOAuth2Location = true
+						}
+					}
+				} else {
+					vsc.addWarningf(vsr, "Duplicate external auth URI %s on this VirtualServer; external auth URI for route %s will be ignored.", routePoliciesCfg.ExternalAuth.URI.Path, r.Path)
+				}
+			}
+
 			if len(routePoliciesCfg.RateLimit.GroupMaps) > 0 {
 				maps = append(maps, routePoliciesCfg.RateLimit.GroupMaps...)
 			}
@@ -996,6 +1131,8 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 			LimitReqOptions:           policiesCfg.RateLimit.Options,
 			LimitReqs:                 policiesCfg.RateLimit.Reqs,
 			JWTAuth:                   policiesCfg.JWTAuth.Auth,
+			ExternalAuth:              policiesCfg.ExternalAuth,
+			ErrorPages:                getServerErrorPages(policiesCfg),
 			BasicAuth:                 policiesCfg.BasicAuth,
 			JWTAuthList:               policiesCfg.JWTAuth.List,
 			JWKSAuthEnabled:           policiesCfg.JWTAuth.JWKSEnabled,
@@ -1023,6 +1160,105 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 	}
 
 	return vsCfg, vsc.warnings
+}
+
+func (vsc *virtualServerConfigurator) generateExternalAuthLocation(policiesCfg policiesCfg, proxyURLUpstreamName string) version2.Location {
+	var svcName string
+	_, svcName = ParseServiceReference(policiesCfg.ExternalAuth.URI.Service, "")
+	loc := version2.Location{
+		Path:                    policiesCfg.ExternalAuth.URI.InternalPath,
+		Internal:                true,
+		Snippets:                generateSnippets(true, policiesCfg.ExternalAuth.Snippets, nil),
+		ProxyPass:               fmt.Sprintf("%s://%s%s", generateProxyPassProtocol(policiesCfg.ExternalAuth.SSLEnabled), proxyURLUpstreamName, policiesCfg.ExternalAuth.URI.Path),
+		ProxyPassRequestHeaders: true,
+		ProxyPassRequestBody:    "off",
+		ProxySetHeaders: []version2.Header{
+			{Name: "Content-Length", Value: "0"},
+			{Name: "Host", Value: "$host"},
+			{Name: "X-Scheme", Value: "$scheme"},
+		},
+		ProxyConnectTimeout:      generateTimeWithDefault(vsc.cfgParams.ProxyConnectTimeout, vsc.cfgParams.ProxyConnectTimeout),
+		ProxyReadTimeout:         generateTimeWithDefault(vsc.cfgParams.ProxyReadTimeout, vsc.cfgParams.ProxyReadTimeout),
+		ProxySendTimeout:         generateTimeWithDefault(vsc.cfgParams.ProxySendTimeout, vsc.cfgParams.ProxySendTimeout),
+		ClientMaxBodySize:        "0",
+		ProxyNextUpstream:        "error timeout",
+		ProxyNextUpstreamTimeout: generateTimeWithDefault(vsc.cfgParams.ProxyNextUpstreamTimeout, "0s"),
+		ServiceName:              svcName,
+		IsVSR:                    false,
+	}
+	if policiesCfg.ExternalAuth.SSLVerify {
+		loc.ProxySSLVerify = true
+		loc.ProxySSLVerifyDepth = policiesCfg.ExternalAuth.SSLVerifyDepth
+		loc.ProxySSLTrustedCertificate = policiesCfg.ExternalAuth.SSLTrustedCert
+		loc.ProxySSLName = policiesCfg.ExternalAuth.SNIName
+	}
+	return loc
+}
+
+func (vsc *virtualServerConfigurator) getExAuthServicePort(cfg policiesCfg, vsEx *VirtualServerEx) uint16 {
+	if len(cfg.ExternalAuth.ServicePorts) > 0 {
+		port := cfg.ExternalAuth.ServicePorts[0]
+		if port > 0 && port <= math.MaxUint16 {
+			return uint16(port)
+		}
+	}
+
+	var proxyPort uint16
+	if cfg.ExternalAuth.URI.Port != "" {
+		value, err := strconv.ParseUint(cfg.ExternalAuth.URI.Port, 10, 16)
+		if err != nil {
+			vsc.addWarningf(vsEx.VirtualServer, "Invalid port in ExternalAuth URI: %v. ExternalAuth location will be generated without a port. Error: %v", cfg.ExternalAuth.URI.Port, err)
+		} else {
+			proxyPort = uint16(value)
+		}
+	} else if cfg.ExternalAuth.SSLEnabled {
+		proxyPort = 443
+	} else {
+		proxyPort = 80
+	}
+	return proxyPort
+}
+
+func (vsc *virtualServerConfigurator) generateExternalAuthOAuth2Location(policiesCfg policiesCfg, signinUpstreamName string) version2.Location {
+	loc := version2.Location{
+		Path:           policiesCfg.ExternalAuth.SigninRedirectBasePath,
+		AuthRequestOff: true,
+		ProxyPass:      fmt.Sprintf("%s://%s", generateProxyPassProtocol(policiesCfg.ExternalAuth.SSLEnabled), signinUpstreamName),
+		ProxySetHeaders: []version2.Header{
+			{Name: "X-Auth-Request-Redirect", Value: "$request_uri"},
+			{Name: "Host", Value: "$host"},
+			{Name: "X-Scheme", Value: "$scheme"},
+		},
+		ProxyConnectTimeout:      generateTimeWithDefault(vsc.cfgParams.ProxyConnectTimeout, vsc.cfgParams.ProxyConnectTimeout),
+		ProxyReadTimeout:         generateTimeWithDefault(vsc.cfgParams.ProxyReadTimeout, vsc.cfgParams.ProxyReadTimeout),
+		ProxySendTimeout:         generateTimeWithDefault(vsc.cfgParams.ProxySendTimeout, vsc.cfgParams.ProxySendTimeout),
+		ClientMaxBodySize:        "0",
+		ProxyNextUpstream:        "error timeout",
+		ProxyNextUpstreamTimeout: generateTimeWithDefault(vsc.cfgParams.ProxyNextUpstreamTimeout, "0s"),
+		ServiceName:              policiesCfg.ExternalAuth.URI.Upstream,
+		IsVSR:                    false,
+		ProxyPassRequestHeaders:  true,
+	}
+	if policiesCfg.ExternalAuth.SSLVerify {
+		loc.ProxySSLVerify = true
+		loc.ProxySSLVerifyDepth = policiesCfg.ExternalAuth.SSLVerifyDepth
+		loc.ProxySSLTrustedCertificate = policiesCfg.ExternalAuth.SSLTrustedCert
+		loc.ProxySSLName = policiesCfg.ExternalAuth.SNIName
+	}
+	return loc
+}
+
+func getServerErrorPages(cfg policiesCfg) []version2.ErrorPage {
+	if cfg.ExternalAuth != nil && cfg.ExternalAuth.SigninURL != "" {
+		return []version2.ErrorPage{
+			{
+				Name:         cfg.ExternalAuth.SigninURL,
+				Codes:        "401",
+				ResponseCode: 0,
+			},
+		}
+	}
+	return nil
 }
 
 func (vsc *virtualServerConfigurator) mergeWarnings(routeWarnings Warnings) {
@@ -1192,6 +1428,7 @@ func addPoliciesCfgToLocation(cfg policiesCfg, location *version2.Location) {
 	location.LimitReqOptions = cfg.RateLimit.Options
 	location.LimitReqs = cfg.RateLimit.Reqs
 	location.JWTAuth = cfg.JWTAuth.Auth
+	location.ExternalAuth = cfg.ExternalAuth
 	location.BasicAuth = cfg.BasicAuth
 	location.EgressMTLS = cfg.EgressMTLS
 	if cfg.OIDC != nil {
@@ -1201,6 +1438,15 @@ func addPoliciesCfgToLocation(cfg policiesCfg, location *version2.Location) {
 	location.APIKey = cfg.APIKey.Key
 	location.Cache = cfg.Cache
 	location.PoliciesErrorReturn = cfg.ErrorReturn
+
+	if cfg.ExternalAuth != nil && cfg.ExternalAuth.SigninURL != "" {
+		location.ErrorPages = append(location.ErrorPages, version2.ErrorPage{
+			Name:         cfg.ExternalAuth.SigninURL,
+			Codes:        "401",
+			ResponseCode: 0,
+		})
+		location.ProxyInterceptErrors = true
+	}
 
 	// Add CORS headers if present
 	if len(cfg.CORSHeaders) > 0 {

--- a/internal/configs/virtualserver_helpers_test.go
+++ b/internal/configs/virtualserver_helpers_test.go
@@ -2315,12 +2315,37 @@ func TestGenerateEndpointsForUpstream(t *testing.T) {
 						Namespace: namespace,
 					},
 				},
-				Endpoints: map[string][]string{},
+				Endpoints: map[string][]string{
+					"test-namespace/test:8080": {},
+				},
 			},
 			isPlus:               false,
 			isResolverConfigured: false,
 			expected:             []string{nginx502Server},
-			msg:                  "Service with no endpoints",
+			warningsExpected:     true,
+			msg:                  "Service exists with no endpoints",
+		},
+		{
+			upstream: conf_v1.Upstream{
+				Service: name,
+				Port:    8080,
+			},
+			vsEx: &VirtualServerEx{
+				VirtualServer: &conf_v1.VirtualServer{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+				},
+				Endpoints: map[string][]string{
+					"test-namespace/test:8080": {},
+				},
+			},
+			isPlus:               true,
+			isResolverConfigured: false,
+			expected:             []string{},
+			warningsExpected:     true,
+			msg:                  "Service exists with no endpoints (Plus)",
 		},
 		{
 			upstream: conf_v1.Upstream{
@@ -2336,10 +2361,11 @@ func TestGenerateEndpointsForUpstream(t *testing.T) {
 				},
 				Endpoints: map[string][]string{},
 			},
-			isPlus:               true,
+			isPlus:               false,
 			isResolverConfigured: false,
-			expected:             nil,
-			msg:                  "Service with no endpoints",
+			expected:             []string{nginx502Server},
+			warningsExpected:     false,
+			msg:                  "Service unknown, no warning emitted",
 		},
 		{
 			upstream: conf_v1.Upstream{
@@ -2383,6 +2409,7 @@ func TestGenerateEndpointsForUpstream(t *testing.T) {
 			isPlus:               false,
 			isResolverConfigured: false,
 			expected:             []string{nginx502Server},
+			warningsExpected:     false,
 			msg:                  "Upstream with subselector, without a matching endpoint",
 		},
 	}
@@ -3622,5 +3649,80 @@ func TestGenerateTimeWithDefault(t *testing.T) {
 		if result != test.expected {
 			t.Errorf("generateTimeWithDefault(%q, %q) returned %q but expected %q", test.value, test.defaultValue, result, test.expected)
 		}
+	}
+}
+
+func TestGetExAuthServicePort(t *testing.T) {
+	t.Parallel()
+
+	vsEx := &VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{Name: "test-vs", Namespace: "default"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		cfg      policiesCfg
+		expected uint16
+	}{
+		{
+			name: "Ports from policy spec takes precedence over URI port",
+			cfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI:          &version2.AuthURI{Port: "80"},
+					ServicePorts: []int{9000},
+				},
+			},
+			expected: 9000,
+		},
+		{
+			name: "first port from Ports is used",
+			cfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					ServicePorts: []int{8080, 9000},
+				},
+			},
+			expected: 8080,
+		},
+		{
+			name: "falls back to URI port when Ports is empty",
+			cfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI:          &version2.AuthURI{Port: "8443"},
+					ServicePorts: []int{},
+				},
+			},
+			expected: 8443,
+		},
+		{
+			name: "falls back to URI port when Ports is nil",
+			cfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI: &version2.AuthURI{Port: "3000"},
+				},
+			},
+			expected: 3000,
+		},
+		{
+			name: "defaults to 80 when no Ports and no URI port",
+			cfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI: &version2.AuthURI{},
+				},
+			},
+			expected: 80,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			vsc := newVirtualServerConfigurator(&ConfigParams{}, false, false, &StaticConfigParams{}, false, &fakeBV)
+			got := vsc.getExAuthServicePort(tc.cfg, vsEx)
+			if got != tc.expected {
+				t.Errorf("getExAuthServicePort() = %d, want %d", got, tc.expected)
+			}
+		})
 	}
 }

--- a/internal/configs/virtualserver_policy_test.go
+++ b/internal/configs/virtualserver_policy_test.go
@@ -3,6 +3,7 @@ package configs
 import (
 	"context"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -278,6 +279,720 @@ func TestGenerateVirtualServerConfigJWKSPolicy(t *testing.T) {
 		false,
 		&StaticConfigParams{TLSPassthrough: true},
 		false,
+		&fakeBV,
+	)
+
+	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
+
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("GenerateVirtualServerConfig() mismatch (-want +got):\n%s", diff)
+	}
+
+	if len(warnings) != 0 {
+		t.Errorf("GenerateVirtualServerConfig returned warnings: %v", vsc.warnings)
+	}
+}
+
+// TestGenerateVirtualServerConfigExternalAuthPolicyPlusRoute tests ExternalAuth policy applied at the route level
+// with NGINX Plus. ExternalAuth functionality is interchangeable between OSS and Plus — the isPlus flag does not
+// affect ExternalAuth configuration generation.
+func TestGenerateVirtualServerConfigExternalAuthPolicyPlusRoute(t *testing.T) {
+	t.Parallel()
+
+	virtualServerEx := VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "cafe",
+				Namespace: "default",
+			},
+			Spec: conf_v1.VirtualServerSpec{
+				Host: "cafe.example.com",
+				Upstreams: []conf_v1.Upstream{
+					{
+						Name:    "tea",
+						Service: "tea-svc",
+						Port:    80,
+					},
+					{
+						Name:    "coffee",
+						Service: "coffee-svc",
+						Port:    80,
+					},
+				},
+				Routes: []conf_v1.Route{
+					{
+						Path: "/tea",
+						Action: &conf_v1.Action{
+							Pass: "tea",
+						},
+						Policies: []conf_v1.PolicyReference{
+							{
+								Name:      "external-auth-policy-route",
+								Namespace: "default",
+							},
+						},
+					},
+					{
+						Path: "/coffee",
+						Action: &conf_v1.Action{
+							Pass: "coffee",
+						},
+					},
+				},
+			},
+		},
+		Policies: map[string]*conf_v1.Policy{
+			"default/external-auth-policy-route": {
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "external-auth-policy-route",
+					Namespace: "default",
+				},
+				Spec: conf_v1.PolicySpec{
+					ExternalAuth: &conf_v1.ExternalAuth{
+						AuthURI:         "/oauth2/auth",
+						AuthServiceName: "auth-server",
+						AuthSigninURI:   "/oauth2/signin",
+						AuthSnippets:    "proxy_set_header X-Custom-Header \"custom-value\";",
+					},
+				},
+			},
+		},
+		Endpoints: map[string][]string{
+			"default/tea-svc:80": {
+				"10.0.0.20:80",
+			},
+			"default/coffee-svc:80": {
+				"10.0.0.30:80",
+			},
+			"default/auth-server:80": {
+				"10.0.0.40:80",
+			},
+		},
+	}
+
+	expected := version2.VirtualServerConfig{
+		Upstreams: []version2.Upstream{
+			{
+				UpstreamLabels: version2.UpstreamLabels{
+					Service:           "coffee-svc",
+					ResourceType:      "virtualserver",
+					ResourceName:      "cafe",
+					ResourceNamespace: "default",
+				},
+				Name: "vs_default_cafe_coffee",
+				Servers: []version2.UpstreamServer{
+					{
+						Address: "10.0.0.30:80",
+					},
+				},
+				Keepalive: 16,
+			},
+			{
+				UpstreamLabels: version2.UpstreamLabels{
+					Service:           "tea-svc",
+					ResourceType:      "virtualserver",
+					ResourceName:      "cafe",
+					ResourceNamespace: "default",
+				},
+				Name: "vs_default_cafe_tea",
+				Servers: []version2.UpstreamServer{
+					{
+						Address: "10.0.0.20:80",
+					},
+				},
+				Keepalive: 16,
+			},
+			{
+				UpstreamLabels: version2.UpstreamLabels{
+					Service:           "auth-server",
+					ResourceType:      "virtualserver",
+					ResourceName:      "cafe",
+					ResourceNamespace: "default",
+				},
+				Name: "vs_default_cafe_vs_exauth_default_external-auth-policy-route",
+				Servers: []version2.UpstreamServer{
+					{
+						Address: "10.0.0.40:80",
+					},
+				},
+				Keepalive: 16,
+			},
+		},
+		HTTPSnippets:  []string{},
+		LimitReqZones: []version2.LimitReqZone{},
+		Server: version2.Server{
+			ServerName:      "cafe.example.com",
+			StatusZone:      "cafe.example.com",
+			ProxyProtocol:   true,
+			ServerTokens:    "off",
+			RealIPHeader:    "X-Real-IP",
+			SetRealIPFrom:   []string{"0.0.0.0/0"},
+			RealIPRecursive: true,
+			Snippets:        []string{"# server snippet"},
+			TLSPassthrough:  true,
+			VSNamespace:     "default",
+			VSName:          "cafe",
+			Locations: []version2.Location{
+				{
+					Path:                    "/_external_auth/oauth2/auth",
+					Internal:                true,
+					Snippets:                []string{`proxy_set_header X-Custom-Header "custom-value";`},
+					ProxyPass:               "http://vs_default_cafe_vs_exauth_default_external-auth-policy-route/oauth2/auth",
+					ProxyPassRequestHeaders: true,
+					ProxyPassRequestBody:    "off",
+					ProxySetHeaders: []version2.Header{
+						{Name: "Content-Length", Value: "0"},
+						{Name: "Host", Value: "$host"},
+						{Name: "X-Scheme", Value: "$scheme"},
+					},
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ServiceName:              "auth-server",
+					ClientMaxBodySize:        "0",
+				},
+				{
+					Path:                     "/oauth2",
+					AuthRequestOff:           true,
+					ClientMaxBodySize:        "0",
+					ProxyPass:                "http://vs_default_cafe_vs_exauth_default_external-auth-policy-route",
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders: []version2.Header{
+						{Name: "X-Auth-Request-Redirect", Value: "$request_uri"},
+						{Name: "Host", Value: "$host"},
+						{Name: "X-Scheme", Value: "$scheme"},
+					},
+					ServiceName: "vs_exauth_default_external-auth-policy-route",
+				},
+				{
+					Path:                     "/tea",
+					ProxyPass:                "http://vs_default_cafe_tea",
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ProxyNextUpstreamTries:   0,
+					ProxyInterceptErrors:     true,
+					HasKeepalive:             true,
+					ErrorPages: []version2.ErrorPage{
+						{
+							Name:         "/oauth2/signin",
+							Codes:        "401",
+							ResponseCode: 0,
+						},
+					},
+					ProxySSLName:            "tea-svc.default.svc",
+					ProxyPassRequestHeaders: true,
+					ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
+					ServiceName:             "tea-svc",
+					ExternalAuth: &version2.ExternalAuth{
+						URI: &version2.AuthURI{
+							Service:      "auth-server",
+							Upstream:     "vs_exauth_default_external-auth-policy-route",
+							Path:         "/oauth2/auth",
+							InternalPath: "/_external_auth/oauth2/auth",
+						},
+						SigninURL:              "/oauth2/signin",
+						SigninRedirectBasePath: "/oauth2",
+						Snippets:               "proxy_set_header X-Custom-Header \"custom-value\";",
+						ServicePorts:           nil,
+					},
+				},
+				{
+					Path:                     "/coffee",
+					ProxyPass:                "http://vs_default_cafe_coffee",
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ProxyNextUpstreamTries:   0,
+					HasKeepalive:             true,
+					ProxySSLName:             "coffee-svc.default.svc",
+					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
+					ServiceName:              "coffee-svc",
+				},
+			},
+		},
+	}
+
+	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
+		ServerTokens:    "off",
+		Keepalive:       16,
+		ServerSnippets:  []string{"# server snippet"},
+		ProxyProtocol:   true,
+		SetRealIPFrom:   []string{"0.0.0.0/0"},
+		RealIPHeader:    "X-Real-IP",
+		RealIPRecursive: true,
+	}
+
+	isPlus := true
+	isResolverConfigured := false
+	isWildcardEnabled := false
+	vsc := newVirtualServerConfigurator(
+		&baseCfgParams,
+		isPlus,
+		isResolverConfigured,
+		&StaticConfigParams{TLSPassthrough: true},
+		isWildcardEnabled,
+		&fakeBV,
+	)
+
+	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
+
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("GenerateVirtualServerConfig() mismatch (-want +got):\n%s", diff)
+	}
+
+	if len(warnings) != 0 {
+		t.Errorf("GenerateVirtualServerConfig returned warnings: %v", vsc.warnings)
+	}
+}
+
+// TestGenerateVirtualServerConfigExternalAuthMultipleRoutesNoDuplicateOAuth2 tests that when multiple routes
+// each reference different ExternalAuth policies with signin URLs, only a single /oauth2 location is generated.
+func TestGenerateVirtualServerConfigExternalAuthMultipleRoutesNoDuplicateOAuth2(t *testing.T) {
+	t.Parallel()
+
+	virtualServerEx := VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "cafe",
+				Namespace: "default",
+			},
+			Spec: conf_v1.VirtualServerSpec{
+				Host: "cafe.example.com",
+				Upstreams: []conf_v1.Upstream{
+					{
+						Name:    "tea",
+						Service: "tea-svc",
+						Port:    80,
+					},
+					{
+						Name:    "coffee",
+						Service: "coffee-svc",
+						Port:    80,
+					},
+				},
+				Routes: []conf_v1.Route{
+					{
+						Path: "/tea",
+						Action: &conf_v1.Action{
+							Pass: "tea",
+						},
+						Policies: []conf_v1.PolicyReference{
+							{
+								Name:      "external-auth-policy-tea",
+								Namespace: "default",
+							},
+						},
+					},
+					{
+						Path: "/coffee",
+						Action: &conf_v1.Action{
+							Pass: "coffee",
+						},
+						Policies: []conf_v1.PolicyReference{
+							{
+								Name:      "external-auth-policy-coffee",
+								Namespace: "default",
+							},
+						},
+					},
+				},
+			},
+		},
+		Policies: map[string]*conf_v1.Policy{
+			"default/external-auth-policy-tea": {
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "external-auth-policy-tea",
+					Namespace: "default",
+				},
+				Spec: conf_v1.PolicySpec{
+					ExternalAuth: &conf_v1.ExternalAuth{
+						AuthURI:         "/auth",
+						AuthServiceName: "auth-server-tea",
+						AuthSigninURI:   "/signin",
+					},
+				},
+			},
+			"default/external-auth-policy-coffee": {
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "external-auth-policy-coffee",
+					Namespace: "default",
+				},
+				Spec: conf_v1.PolicySpec{
+					ExternalAuth: &conf_v1.ExternalAuth{
+						AuthURI:         "/auth",
+						AuthServiceName: "auth-server-coffee",
+						AuthSigninURI:   "/signin",
+					},
+				},
+			},
+		},
+		Endpoints: map[string][]string{
+			"default/tea-svc:80":            {"10.0.0.20:80"},
+			"default/coffee-svc:80":         {"10.0.0.30:80"},
+			"default/auth-server-tea:80":    {"10.0.0.40:80"},
+			"default/auth-server-coffee:80": {"10.0.0.50:80"},
+		},
+	}
+
+	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
+		ServerTokens:    "off",
+		Keepalive:       16,
+		ServerSnippets:  []string{"# server snippet"},
+		ProxyProtocol:   true,
+		SetRealIPFrom:   []string{"0.0.0.0/0"},
+		RealIPHeader:    "X-Real-IP",
+		RealIPRecursive: true,
+	}
+
+	vsc := newVirtualServerConfigurator(
+		&baseCfgParams,
+		true,
+		false,
+		&StaticConfigParams{TLSPassthrough: true},
+		false,
+		&fakeBV,
+	)
+
+	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
+
+	// Count /oauth2 locations — there must be exactly one
+	oauth2Count := 0
+	for _, loc := range result.Server.Locations {
+		if loc.Path == "/oauth2" {
+			oauth2Count++
+		}
+	}
+	if oauth2Count != 1 {
+		t.Errorf("expected exactly 1 /oauth2 location, got %d", oauth2Count)
+	}
+
+	// Check for the expected duplicate external auth URI warning for the /coffee route
+	vsWarnings := warnings[virtualServerEx.VirtualServer]
+	if len(vsWarnings) == 0 {
+		t.Errorf("expected warning for duplicate external auth URI, but got none")
+	} else {
+		found := false
+		for _, warning := range vsWarnings {
+			if strings.Contains(warning, "Duplicate external auth URI /auth") && strings.Contains(warning, "/coffee") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected warning about 'Duplicate external auth URI /auth' for route '/coffee', got: %v", vsWarnings)
+		}
+	}
+}
+
+// TestGenerateVirtualServerConfigExternalAuthPolicyPlusSubroute tests ExternalAuth policy applied at the subroute
+// level (VirtualServerRoute) with NGINX Plus. ExternalAuth functionality is interchangeable between OSS and Plus —
+// the isPlus flag does not affect ExternalAuth configuration generation.
+func TestGenerateVirtualServerConfigExternalAuthPolicyPlusSubroute(t *testing.T) {
+	t.Parallel()
+
+	virtualServerEx := VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "cafe",
+				Namespace: "default",
+			},
+			Spec: conf_v1.VirtualServerSpec{
+				Host: "cafe.example.com",
+				Upstreams: []conf_v1.Upstream{
+					{
+						Name:    "coffee",
+						Service: "coffee-svc",
+						Port:    80,
+					},
+				},
+				Routes: []conf_v1.Route{
+					{
+						Path:  "/tea",
+						Route: "default/tea-vsr",
+					},
+					{
+						Path: "/coffee",
+						Action: &conf_v1.Action{
+							Pass: "coffee",
+						},
+					},
+				},
+			},
+		},
+		VirtualServerRoutes: []*conf_v1.VirtualServerRoute{
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "tea-vsr",
+					Namespace: "default",
+				},
+				Spec: conf_v1.VirtualServerRouteSpec{
+					Host: "cafe.example.com",
+					Upstreams: []conf_v1.Upstream{
+						{
+							Name:    "tea-v1",
+							Service: "tea-v1-svc",
+							Port:    80,
+						},
+						{
+							Name:    "tea-v2",
+							Service: "tea-v2-svc",
+							Port:    80,
+						},
+					},
+					Subroutes: []conf_v1.Route{
+						{
+							Path: "/tea/v1",
+							Policies: []conf_v1.PolicyReference{
+								{
+									Name:      "external-auth-policy-subroute",
+									Namespace: "default",
+								},
+							},
+							Action: &conf_v1.Action{
+								Pass: "tea-v1",
+							},
+						},
+						{
+							Path: "/tea/v2",
+							Action: &conf_v1.Action{
+								Pass: "tea-v2",
+							},
+						},
+					},
+				},
+			},
+		},
+		Policies: map[string]*conf_v1.Policy{
+			"default/external-auth-policy-subroute": {
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "external-auth-policy-subroute",
+					Namespace: "default",
+				},
+				Spec: conf_v1.PolicySpec{
+					ExternalAuth: &conf_v1.ExternalAuth{
+						AuthURI:         "/auth",
+						AuthServiceName: "auth-server",
+						AuthSigninURI:   "/signin",
+						AuthSnippets:    "proxy_set_header X-Custom-Header \"custom-value\";",
+					},
+				},
+			},
+		},
+		Endpoints: map[string][]string{
+			"default/coffee-svc:80": {
+				"10.0.0.30:80",
+			},
+			"default/tea-v1-svc:80": {
+				"10.0.0.21:80",
+			},
+			"default/tea-v2-svc:80": {
+				"10.0.0.22:80",
+			},
+			"default/auth-server:80": {
+				"10.0.0.40:80",
+			},
+		},
+	}
+
+	expected := version2.VirtualServerConfig{
+		Upstreams: []version2.Upstream{
+			{
+				UpstreamLabels: version2.UpstreamLabels{
+					Service:           "coffee-svc",
+					ResourceType:      "virtualserver",
+					ResourceName:      "cafe",
+					ResourceNamespace: "default",
+				},
+				Name: "vs_default_cafe_coffee",
+				Servers: []version2.UpstreamServer{
+					{
+						Address: "10.0.0.30:80",
+					},
+				},
+				Keepalive: 16,
+			},
+			{
+				UpstreamLabels: version2.UpstreamLabels{
+					Service:           "tea-v1-svc",
+					ResourceType:      "virtualserverroute",
+					ResourceName:      "tea-vsr",
+					ResourceNamespace: "default",
+				},
+				Name: "vs_default_cafe_vsr_default_tea-vsr_tea-v1",
+				Servers: []version2.UpstreamServer{
+					{
+						Address: "10.0.0.21:80",
+					},
+				},
+				Keepalive: 16,
+			},
+			{
+				UpstreamLabels: version2.UpstreamLabels{
+					Service:           "tea-v2-svc",
+					ResourceType:      "virtualserverroute",
+					ResourceName:      "tea-vsr",
+					ResourceNamespace: "default",
+				},
+				Name: "vs_default_cafe_vsr_default_tea-vsr_tea-v2",
+				Servers: []version2.UpstreamServer{
+					{
+						Address: "10.0.0.22:80",
+					},
+				},
+				Keepalive: 16,
+			},
+			{
+				UpstreamLabels: version2.UpstreamLabels{
+					Service:           "auth-server",
+					ResourceType:      "virtualserverroute",
+					ResourceName:      "tea-vsr",
+					ResourceNamespace: "default",
+				},
+				Name: "vs_default_cafe_vsr_default_tea-vsr_vs_exauth_default_external-auth-policy-subroute",
+				Servers: []version2.UpstreamServer{
+					{
+						Address: "10.0.0.40:80",
+					},
+				},
+				Keepalive: 16,
+			},
+		},
+		HTTPSnippets:  []string{},
+		LimitReqZones: []version2.LimitReqZone{},
+		Server: version2.Server{
+			ServerName:      "cafe.example.com",
+			StatusZone:      "cafe.example.com",
+			ProxyProtocol:   true,
+			ServerTokens:    "off",
+			RealIPHeader:    "X-Real-IP",
+			SetRealIPFrom:   []string{"0.0.0.0/0"},
+			RealIPRecursive: true,
+			Snippets:        []string{"# server snippet"},
+			TLSPassthrough:  true,
+			VSNamespace:     "default",
+			VSName:          "cafe",
+			Locations: []version2.Location{
+				{
+					Path:                     "/coffee",
+					ProxyPass:                "http://vs_default_cafe_coffee",
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ProxyNextUpstreamTries:   0,
+					HasKeepalive:             true,
+					ProxySSLName:             "coffee-svc.default.svc",
+					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
+					ServiceName:              "coffee-svc",
+				},
+				{
+					Path:                    "/_external_auth/auth",
+					Internal:                true,
+					Snippets:                []string{`proxy_set_header X-Custom-Header "custom-value";`},
+					ProxyPass:               "http://vs_default_cafe_vsr_default_tea-vsr_vs_exauth_default_external-auth-policy-subroute/auth",
+					ProxyPassRequestHeaders: true,
+					ProxyPassRequestBody:    "off",
+					ProxySetHeaders: []version2.Header{
+						{Name: "Content-Length", Value: "0"},
+						{Name: "Host", Value: "$host"},
+						{Name: "X-Scheme", Value: "$scheme"},
+					},
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ServiceName:              "auth-server",
+					ClientMaxBodySize:        "0",
+				},
+				{
+					Path:                    "/oauth2",
+					AuthRequestOff:          true,
+					ProxyPass:               "http://vs_default_cafe_vsr_default_tea-vsr_vs_exauth_default_external-auth-policy-subroute",
+					ProxyPassRequestHeaders: true,
+					ProxySetHeaders: []version2.Header{
+						{Name: "X-Auth-Request-Redirect", Value: "$request_uri"},
+						{Name: "Host", Value: "$host"},
+						{Name: "X-Scheme", Value: "$scheme"},
+					},
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ServiceName:              "vs_exauth_default_external-auth-policy-subroute",
+					ClientMaxBodySize:        "0",
+				},
+				{
+					Path:                     "/tea/v1",
+					ProxyPass:                "http://vs_default_cafe_vsr_default_tea-vsr_tea-v1",
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ProxyNextUpstreamTries:   0,
+					ProxyInterceptErrors:     true,
+					HasKeepalive:             true,
+					ErrorPages: []version2.ErrorPage{
+						{
+							Name:         "/signin",
+							Codes:        "401",
+							ResponseCode: 0,
+						},
+					},
+					ProxySSLName:            "tea-v1-svc.default.svc",
+					ProxyPassRequestHeaders: true,
+					ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
+					ServiceName:             "tea-v1-svc",
+					IsVSR:                   true,
+					VSRName:                 "tea-vsr",
+					VSRNamespace:            "default",
+					ExternalAuth: &version2.ExternalAuth{
+						URI: &version2.AuthURI{
+							Service:      "auth-server",
+							Upstream:     "vs_exauth_default_external-auth-policy-subroute",
+							Path:         "/auth",
+							InternalPath: "/_external_auth/auth",
+						},
+						SigninURL:              "/signin",
+						SigninRedirectBasePath: "/oauth2",
+						Snippets:               "proxy_set_header X-Custom-Header \"custom-value\";",
+						ServicePorts:           nil,
+					},
+				},
+				{
+					Path:                     "/tea/v2",
+					ProxyPass:                "http://vs_default_cafe_vsr_default_tea-vsr_tea-v2",
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ProxyNextUpstreamTries:   0,
+					HasKeepalive:             true,
+					ProxySSLName:             "tea-v2-svc.default.svc",
+					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
+					ServiceName:              "tea-v2-svc",
+					IsVSR:                    true,
+					VSRName:                  "tea-vsr",
+					VSRNamespace:             "default",
+				},
+			},
+		},
+	}
+
+	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
+		ServerTokens:    "off",
+		Keepalive:       16,
+		ServerSnippets:  []string{"# server snippet"},
+		ProxyProtocol:   true,
+		SetRealIPFrom:   []string{"0.0.0.0/0"},
+		RealIPHeader:    "X-Real-IP",
+		RealIPRecursive: true,
+	}
+
+	isPlus := true
+	isResolverConfigured := false
+	isWildcardEnabled := false
+	vsc := newVirtualServerConfigurator(
+		&baseCfgParams,
+		isPlus,
+		isResolverConfigured,
+		&StaticConfigParams{TLSPassthrough: true},
+		isWildcardEnabled,
 		&fakeBV,
 	)
 
@@ -3452,5 +4167,711 @@ func TestGenerateVirtualServerConfigWithRouteSelector(t *testing.T) {
 		if len(warnings) != 0 {
 			t.Errorf("GenerateVirtualServerConfig returned warnings: %v", vsc.warnings)
 		}
+	}
+}
+
+func TestGenerateExternalAuthLocation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		policiesCfg          policiesCfg
+		proxyURLUpstreamName string
+		cfgParams            *ConfigParams
+		expected             version2.Location
+	}{
+		{
+			name: "basic external auth without SSL",
+			policiesCfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI: &version2.AuthURI{
+						Service:      "auth-svc",
+						Upstream:     "ext_auth_default_my-auth",
+						Path:         "/auth",
+						InternalPath: "/_ext_auth_default_my-auth",
+					},
+					Snippets: "proxy_set_header X-Custom \"value\"",
+				},
+			},
+			proxyURLUpstreamName: "ext_auth_default_my-auth",
+			cfgParams: &ConfigParams{
+				Context:                  context.Background(),
+				ProxyConnectTimeout:      "10s",
+				ProxyReadTimeout:         "15s",
+				ProxySendTimeout:         "20s",
+				ProxyNextUpstreamTimeout: "5s",
+			},
+			expected: version2.Location{
+				Path:                    "/_ext_auth_default_my-auth",
+				Internal:                true,
+				Snippets:                []string{"proxy_set_header X-Custom \"value\""},
+				ProxyPass:               "http://ext_auth_default_my-auth/auth",
+				ProxyPassRequestHeaders: true,
+				ProxyPassRequestBody:    "off",
+				ProxySetHeaders: []version2.Header{
+					{Name: "Content-Length", Value: "0"},
+					{Name: "Host", Value: "$host"},
+					{Name: "X-Scheme", Value: "$scheme"},
+				},
+				ProxyConnectTimeout:      "10s",
+				ProxyReadTimeout:         "15s",
+				ProxySendTimeout:         "20s",
+				ClientMaxBodySize:        "0",
+				ProxyNextUpstream:        "error timeout",
+				ProxyNextUpstreamTimeout: "5s",
+				ServiceName:              "auth-svc",
+				IsVSR:                    false,
+			},
+		},
+		{
+			name: "external auth with SSL enabled",
+			policiesCfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI: &version2.AuthURI{
+						Service:      "auth-svc",
+						Upstream:     "ext_auth_default_my-auth",
+						Path:         "/auth",
+						InternalPath: "/_ext_auth_default_my-auth",
+					},
+					Snippets:   "",
+					SSLEnabled: true,
+				},
+			},
+			proxyURLUpstreamName: "ext_auth_default_my-auth",
+			cfgParams: &ConfigParams{
+				Context:                  context.Background(),
+				ProxyConnectTimeout:      "10s",
+				ProxyReadTimeout:         "15s",
+				ProxySendTimeout:         "20s",
+				ProxyNextUpstreamTimeout: "5s",
+			},
+			expected: version2.Location{
+				Path:                    "/_ext_auth_default_my-auth",
+				Internal:                true,
+				Snippets:                nil,
+				ProxyPass:               "https://ext_auth_default_my-auth/auth",
+				ProxyPassRequestHeaders: true,
+				ProxyPassRequestBody:    "off",
+				ProxySetHeaders: []version2.Header{
+					{Name: "Content-Length", Value: "0"},
+					{Name: "Host", Value: "$host"},
+					{Name: "X-Scheme", Value: "$scheme"},
+				},
+				ProxyConnectTimeout:      "10s",
+				ProxyReadTimeout:         "15s",
+				ProxySendTimeout:         "20s",
+				ClientMaxBodySize:        "0",
+				ProxyNextUpstream:        "error timeout",
+				ProxyNextUpstreamTimeout: "5s",
+				ServiceName:              "auth-svc",
+				IsVSR:                    false,
+			},
+		},
+		{
+			name: "external auth with SSL verify",
+			policiesCfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI: &version2.AuthURI{
+						Service:      "ns1/auth-svc",
+						Upstream:     "ext_auth_ns1_my-auth",
+						Path:         "/verify",
+						InternalPath: "/_ext_auth_ns1_my-auth",
+					},
+					SSLEnabled:     true,
+					SSLVerify:      true,
+					SSLVerifyDepth: 2,
+					SSLTrustedCert: "/etc/nginx/secrets/trusted-cert.pem",
+					SNIName:        "auth.example.com",
+				},
+			},
+			proxyURLUpstreamName: "ext_auth_ns1_my-auth",
+			cfgParams: &ConfigParams{
+				Context:                  context.Background(),
+				ProxyConnectTimeout:      "30s",
+				ProxyReadTimeout:         "30s",
+				ProxySendTimeout:         "30s",
+				ProxyNextUpstreamTimeout: "10s",
+			},
+			expected: version2.Location{
+				Path:                    "/_ext_auth_ns1_my-auth",
+				Internal:                true,
+				Snippets:                nil,
+				ProxyPass:               "https://ext_auth_ns1_my-auth/verify",
+				ProxyPassRequestHeaders: true,
+				ProxyPassRequestBody:    "off",
+				ProxySetHeaders: []version2.Header{
+					{Name: "Content-Length", Value: "0"},
+					{Name: "Host", Value: "$host"},
+					{Name: "X-Scheme", Value: "$scheme"},
+				},
+				ProxyConnectTimeout:        "30s",
+				ProxyReadTimeout:           "30s",
+				ProxySendTimeout:           "30s",
+				ClientMaxBodySize:          "0",
+				ProxyNextUpstream:          "error timeout",
+				ProxyNextUpstreamTimeout:   "10s",
+				ServiceName:                "auth-svc",
+				IsVSR:                      false,
+				ProxySSLVerify:             true,
+				ProxySSLVerifyDepth:        2,
+				ProxySSLTrustedCertificate: "/etc/nginx/secrets/trusted-cert.pem",
+				ProxySSLName:               "auth.example.com",
+			},
+		},
+		{
+			name: "external auth with multiline snippets",
+			policiesCfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI: &version2.AuthURI{
+						Service:      "auth-svc",
+						Upstream:     "ext_auth_default_my-auth",
+						Path:         "/auth",
+						InternalPath: "/_ext_auth_default_my-auth",
+					},
+					Snippets: "proxy_set_header X-Custom \"value\"\nproxy_set_header X-Another \"val2\"",
+				},
+			},
+			proxyURLUpstreamName: "ext_auth_default_my-auth",
+			cfgParams: &ConfigParams{
+				Context: context.Background(),
+			},
+			expected: version2.Location{
+				Path:                    "/_ext_auth_default_my-auth",
+				Internal:                true,
+				Snippets:                []string{"proxy_set_header X-Custom \"value\"", "proxy_set_header X-Another \"val2\""},
+				ProxyPass:               "http://ext_auth_default_my-auth/auth",
+				ProxyPassRequestHeaders: true,
+				ProxyPassRequestBody:    "off",
+				ProxySetHeaders: []version2.Header{
+					{Name: "Content-Length", Value: "0"},
+					{Name: "Host", Value: "$host"},
+					{Name: "X-Scheme", Value: "$scheme"},
+				},
+				ClientMaxBodySize:        "0",
+				ProxyNextUpstream:        "error timeout",
+				ProxyNextUpstreamTimeout: "0s",
+				ServiceName:              "auth-svc",
+				IsVSR:                    false,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			vsc := newVirtualServerConfigurator(tc.cfgParams, false, false, &StaticConfigParams{}, false, &fakeBV)
+			result := vsc.generateExternalAuthLocation(tc.policiesCfg, tc.proxyURLUpstreamName)
+			if diff := cmp.Diff(tc.expected, result); diff != "" {
+				t.Errorf("generateExternalAuthLocation() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateExternalAuthOAuth2Location(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		policiesCfg        policiesCfg
+		signinUpstreamName string
+		cfgParams          *ConfigParams
+		expected           version2.Location
+	}{
+		{
+			name: "basic OAuth2 location without SSL",
+			policiesCfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI: &version2.AuthURI{
+						Service:      "auth-svc",
+						Upstream:     "ext_auth_default_my-auth",
+						Path:         "/oauth2/auth",
+						InternalPath: "/_ext_auth_default_my-auth",
+					},
+					SigninURL:              "https://example.com/oauth2/start",
+					SigninRedirectBasePath: "/oauth2",
+				},
+			},
+			signinUpstreamName: "ext_auth_default_my-auth_signin",
+			cfgParams: &ConfigParams{
+				Context:                  context.Background(),
+				ProxyConnectTimeout:      "10s",
+				ProxyReadTimeout:         "15s",
+				ProxySendTimeout:         "20s",
+				ProxyNextUpstreamTimeout: "5s",
+			},
+			expected: version2.Location{
+				Path:           "/oauth2",
+				AuthRequestOff: true,
+				ProxyPass:      "http://ext_auth_default_my-auth_signin",
+				ProxySetHeaders: []version2.Header{
+					{Name: "X-Auth-Request-Redirect", Value: "$request_uri"},
+					{Name: "Host", Value: "$host"},
+					{Name: "X-Scheme", Value: "$scheme"},
+				},
+				ProxyConnectTimeout:      "10s",
+				ProxyReadTimeout:         "15s",
+				ProxySendTimeout:         "20s",
+				ClientMaxBodySize:        "0",
+				ProxyNextUpstream:        "error timeout",
+				ProxyNextUpstreamTimeout: "5s",
+				ServiceName:              "ext_auth_default_my-auth",
+				IsVSR:                    false,
+				ProxyPassRequestHeaders:  true,
+			},
+		},
+		{
+			name: "OAuth2 location with SSL enabled",
+			policiesCfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI: &version2.AuthURI{
+						Service:      "auth-svc",
+						Upstream:     "ext_auth_default_my-auth",
+						Path:         "/oauth2/auth",
+						InternalPath: "/_ext_auth_default_my-auth",
+					},
+					SigninURL:              "https://example.com/oauth2/start",
+					SigninRedirectBasePath: "/oauth2",
+					SSLEnabled:             true,
+				},
+			},
+			signinUpstreamName: "ext_auth_default_my-auth_signin",
+			cfgParams: &ConfigParams{
+				Context:                  context.Background(),
+				ProxyConnectTimeout:      "10s",
+				ProxyReadTimeout:         "15s",
+				ProxySendTimeout:         "20s",
+				ProxyNextUpstreamTimeout: "5s",
+			},
+			expected: version2.Location{
+				Path:           "/oauth2",
+				AuthRequestOff: true,
+				ProxyPass:      "https://ext_auth_default_my-auth_signin",
+				ProxySetHeaders: []version2.Header{
+					{Name: "X-Auth-Request-Redirect", Value: "$request_uri"},
+					{Name: "Host", Value: "$host"},
+					{Name: "X-Scheme", Value: "$scheme"},
+				},
+				ProxyConnectTimeout:      "10s",
+				ProxyReadTimeout:         "15s",
+				ProxySendTimeout:         "20s",
+				ClientMaxBodySize:        "0",
+				ProxyNextUpstream:        "error timeout",
+				ProxyNextUpstreamTimeout: "5s",
+				ServiceName:              "ext_auth_default_my-auth",
+				IsVSR:                    false,
+				ProxyPassRequestHeaders:  true,
+			},
+		},
+		{
+			name: "OAuth2 location with SSL verify",
+			policiesCfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI: &version2.AuthURI{
+						Service:      "ns1/auth-svc",
+						Upstream:     "ext_auth_ns1_my-auth",
+						Path:         "/oauth2/auth",
+						InternalPath: "/_ext_auth_ns1_my-auth",
+					},
+					SigninURL:              "https://example.com/oauth2/start",
+					SigninRedirectBasePath: "/oauth2",
+					SSLEnabled:             true,
+					SSLVerify:              true,
+					SSLVerifyDepth:         3,
+					SSLTrustedCert:         "/etc/nginx/secrets/trusted-cert.pem",
+					SNIName:                "auth.example.com",
+				},
+			},
+			signinUpstreamName: "ext_auth_ns1_my-auth_signin",
+			cfgParams: &ConfigParams{
+				Context:                  context.Background(),
+				ProxyConnectTimeout:      "30s",
+				ProxyReadTimeout:         "30s",
+				ProxySendTimeout:         "30s",
+				ProxyNextUpstreamTimeout: "10s",
+			},
+			expected: version2.Location{
+				Path:           "/oauth2",
+				AuthRequestOff: true,
+				ProxyPass:      "https://ext_auth_ns1_my-auth_signin",
+				ProxySetHeaders: []version2.Header{
+					{Name: "X-Auth-Request-Redirect", Value: "$request_uri"},
+					{Name: "Host", Value: "$host"},
+					{Name: "X-Scheme", Value: "$scheme"},
+				},
+				ProxyConnectTimeout:        "30s",
+				ProxyReadTimeout:           "30s",
+				ProxySendTimeout:           "30s",
+				ClientMaxBodySize:          "0",
+				ProxyNextUpstream:          "error timeout",
+				ProxyNextUpstreamTimeout:   "10s",
+				ServiceName:                "ext_auth_ns1_my-auth",
+				IsVSR:                      false,
+				ProxyPassRequestHeaders:    true,
+				ProxySSLVerify:             true,
+				ProxySSLVerifyDepth:        3,
+				ProxySSLTrustedCertificate: "/etc/nginx/secrets/trusted-cert.pem",
+				ProxySSLName:               "auth.example.com",
+			},
+		},
+		{
+			name: "OAuth2 location with empty timeout defaults",
+			policiesCfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					URI: &version2.AuthURI{
+						Service:      "auth-svc",
+						Upstream:     "ext_auth_default_my-auth",
+						Path:         "/oauth2/auth",
+						InternalPath: "/_ext_auth_default_my-auth",
+					},
+					SigninRedirectBasePath: "/oauth2",
+				},
+			},
+			signinUpstreamName: "ext_auth_default_my-auth_signin",
+			cfgParams: &ConfigParams{
+				Context: context.Background(),
+			},
+			expected: version2.Location{
+				Path:           "/oauth2",
+				AuthRequestOff: true,
+				ProxyPass:      "http://ext_auth_default_my-auth_signin",
+				ProxySetHeaders: []version2.Header{
+					{Name: "X-Auth-Request-Redirect", Value: "$request_uri"},
+					{Name: "Host", Value: "$host"},
+					{Name: "X-Scheme", Value: "$scheme"},
+				},
+				ClientMaxBodySize:        "0",
+				ProxyNextUpstream:        "error timeout",
+				ProxyNextUpstreamTimeout: "0s",
+				ServiceName:              "ext_auth_default_my-auth",
+				IsVSR:                    false,
+				ProxyPassRequestHeaders:  true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			vsc := newVirtualServerConfigurator(tc.cfgParams, false, false, &StaticConfigParams{}, false, &fakeBV)
+			result := vsc.generateExternalAuthOAuth2Location(tc.policiesCfg, tc.signinUpstreamName)
+			if diff := cmp.Diff(tc.expected, result); diff != "" {
+				t.Errorf("generateExternalAuthOAuth2Location() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetServerErrorPages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      policiesCfg
+		expected []version2.ErrorPage
+	}{
+		{
+			name: "nil ExternalAuth returns nil",
+			cfg: policiesCfg{
+				ExternalAuth: nil,
+			},
+			expected: nil,
+		},
+		{
+			name: "empty SigninURL returns nil",
+			cfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					SigninURL: "",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "non-empty SigninURL returns 401 error page",
+			cfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					SigninURL: "https://example.com/oauth2/start?rd=$scheme://$host$request_uri",
+				},
+			},
+			expected: []version2.ErrorPage{
+				{
+					Name:         "https://example.com/oauth2/start?rd=$scheme://$host$request_uri",
+					Codes:        "401",
+					ResponseCode: 0,
+				},
+			},
+		},
+		{
+			name: "simple SigninURL returns 401 error page",
+			cfg: policiesCfg{
+				ExternalAuth: &version2.ExternalAuth{
+					SigninURL: "https://auth.example.com/login",
+				},
+			},
+			expected: []version2.ErrorPage{
+				{
+					Name:         "https://auth.example.com/login",
+					Codes:        "401",
+					ResponseCode: 0,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := getServerErrorPages(tc.cfg)
+			if diff := cmp.Diff(tc.expected, result); diff != "" {
+				t.Errorf("getServerErrorPages() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateVirtualServerConfigExternalAuthPolicy(t *testing.T) {
+	t.Parallel()
+
+	virtualServerEx := VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "cafe",
+				Namespace: "default",
+			},
+			Spec: conf_v1.VirtualServerSpec{
+				Host: "cafe.example.com",
+				Policies: []conf_v1.PolicyReference{
+					{
+						Name:      "external-auth-policy",
+						Namespace: "default",
+					},
+				},
+				Upstreams: []conf_v1.Upstream{
+					{
+						Name:    "tea",
+						Service: "tea-svc",
+						Port:    80,
+					},
+					{
+						Name:    "coffee",
+						Service: "coffee-svc",
+						Port:    80,
+					},
+				},
+				Routes: []conf_v1.Route{
+					{
+						Path: "/tea",
+						Action: &conf_v1.Action{
+							Pass: "tea",
+						},
+					},
+					{
+						Path: "/coffee",
+						Action: &conf_v1.Action{
+							Pass: "coffee",
+						},
+					},
+				},
+			},
+		},
+		Policies: map[string]*conf_v1.Policy{
+			"default/external-auth-policy": {
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "external-auth-policy",
+					Namespace: "default",
+				},
+				Spec: conf_v1.PolicySpec{
+					ExternalAuth: &conf_v1.ExternalAuth{
+						AuthURI:         "/auth",
+						AuthServiceName: "auth-server",
+						AuthSigninURI:   "/signin",
+						AuthSnippets:    "proxy_set_header X-Custom-Header \"custom-value\";",
+					},
+				},
+			},
+		},
+		Endpoints: map[string][]string{
+			"default/tea-svc:80": {
+				"10.0.0.20:80",
+			},
+			"default/coffee-svc:80": {
+				"10.0.0.30:80",
+			},
+			"default/auth-server:80": {
+				"10.0.0.40:80",
+			},
+		},
+	}
+
+	expected := version2.VirtualServerConfig{
+		Upstreams: []version2.Upstream{
+			{
+				UpstreamLabels: version2.UpstreamLabels{
+					Service:           "coffee-svc",
+					ResourceType:      "virtualserver",
+					ResourceName:      "cafe",
+					ResourceNamespace: "default",
+				},
+				Name: "vs_default_cafe_coffee",
+				Servers: []version2.UpstreamServer{
+					{
+						Address: "10.0.0.30:80",
+					},
+				},
+				Keepalive: 16,
+			},
+			{
+				UpstreamLabels: version2.UpstreamLabels{
+					Service:           "tea-svc",
+					ResourceType:      "virtualserver",
+					ResourceName:      "cafe",
+					ResourceNamespace: "default",
+				},
+				Name: "vs_default_cafe_tea",
+				Servers: []version2.UpstreamServer{
+					{
+						Address: "10.0.0.20:80",
+					},
+				},
+				Keepalive: 16,
+			},
+			{
+				UpstreamLabels: version2.UpstreamLabels{
+					Service:           "auth-server",
+					ResourceType:      "virtualserver",
+					ResourceName:      "cafe",
+					ResourceNamespace: "default",
+				},
+				Name: "vs_default_cafe_vs_exauth_default_external-auth-policy",
+				Servers: []version2.UpstreamServer{
+					{
+						Address: "10.0.0.40:80",
+					},
+				},
+				Keepalive: 16,
+			},
+		},
+		HTTPSnippets:  []string{},
+		LimitReqZones: []version2.LimitReqZone{},
+		Server: version2.Server{
+			ServerName:      "cafe.example.com",
+			StatusZone:      "cafe.example.com",
+			ProxyProtocol:   true,
+			ServerTokens:    "off",
+			RealIPHeader:    "X-Real-IP",
+			SetRealIPFrom:   []string{"0.0.0.0/0"},
+			RealIPRecursive: true,
+			Snippets:        []string{"# server snippet"},
+			TLSPassthrough:  true,
+			VSNamespace:     "default",
+			VSName:          "cafe",
+			ExternalAuth: &version2.ExternalAuth{
+				URI: &version2.AuthURI{
+					Service:      "auth-server",
+					Upstream:     "vs_exauth_default_external-auth-policy",
+					Path:         "/auth",
+					InternalPath: "/_external_auth/auth",
+				},
+				SigninURL:              "/signin",
+				SigninRedirectBasePath: "/oauth2",
+				Snippets:               "proxy_set_header X-Custom-Header \"custom-value\";",
+				ServicePorts:           nil,
+			},
+			ErrorPages: []version2.ErrorPage{
+				{
+					Name:         "/signin",
+					Codes:        "401",
+					ResponseCode: 0,
+				},
+			},
+			Locations: []version2.Location{
+				{
+					Path:                    "/_external_auth/auth",
+					Internal:                true,
+					Snippets:                []string{`proxy_set_header X-Custom-Header "custom-value";`},
+					ProxyPass:               "http://vs_default_cafe_vs_exauth_default_external-auth-policy/auth",
+					ProxyPassRequestHeaders: true,
+					ProxyPassRequestBody:    "off",
+					ProxySetHeaders: []version2.Header{
+						{Name: "Content-Length", Value: "0"},
+						{Name: "Host", Value: "$host"},
+						{Name: "X-Scheme", Value: "$scheme"},
+					},
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ServiceName:              "auth-server",
+					ClientMaxBodySize:        "0",
+				},
+				{
+					Path:                     "/oauth2",
+					AuthRequestOff:           true,
+					ClientMaxBodySize:        "0",
+					ProxyPass:                "http://vs_default_cafe_vs_exauth_default_external-auth-policy",
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders: []version2.Header{
+						{Name: "X-Auth-Request-Redirect", Value: "$request_uri"},
+						{Name: "Host", Value: "$host"},
+						{Name: "X-Scheme", Value: "$scheme"},
+					},
+					ServiceName: "vs_exauth_default_external-auth-policy",
+				},
+				{
+					Path:                     "/tea",
+					ProxyPass:                "http://vs_default_cafe_tea",
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ProxyNextUpstreamTries:   0,
+					HasKeepalive:             true,
+					ProxySSLName:             "tea-svc.default.svc",
+					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
+					ServiceName:              "tea-svc",
+				},
+				{
+					Path:                     "/coffee",
+					ProxyPass:                "http://vs_default_cafe_coffee",
+					ProxyNextUpstream:        "error timeout",
+					ProxyNextUpstreamTimeout: "0s",
+					ProxyNextUpstreamTries:   0,
+					HasKeepalive:             true,
+					ProxySSLName:             "coffee-svc.default.svc",
+					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
+					ServiceName:              "coffee-svc",
+				},
+			},
+		},
+	}
+
+	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
+		ServerTokens:    "off",
+		Keepalive:       16,
+		ServerSnippets:  []string{"# server snippet"},
+		ProxyProtocol:   true,
+		SetRealIPFrom:   []string{"0.0.0.0/0"},
+		RealIPHeader:    "X-Real-IP",
+		RealIPRecursive: true,
+	}
+
+	vsc := newVirtualServerConfigurator(
+		&baseCfgParams,
+		false,
+		false,
+		&StaticConfigParams{TLSPassthrough: true},
+		false,
+		&fakeBV,
+	)
+
+	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
+
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("GenerateVirtualServerConfig() mismatch (-want +got):\n%s", diff)
+	}
+
+	if len(warnings) != 0 {
+		t.Errorf("GenerateVirtualServerConfig returned warnings: %v", vsc.warnings)
 	}
 }

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -188,7 +188,7 @@ type LoadBalancerController struct {
 	nginxConfigMapName            string
 	mgmtConfigMapName             string
 	ShuttingDown                  bool
-	endpointSliceWarnings         map[string]bool
+	endpointSliceWarnings         map[string]bool // see updateEndpointSliceWarningState
 }
 
 var keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
@@ -803,6 +803,16 @@ func (lbc *LoadBalancerController) virtualServerRequiresEndpointsUpdate(vsEx *co
 	for _, vsr := range vsEx.VirtualServerRoutes {
 		for _, upstream := range vsr.Spec.Upstreams {
 			if upstream.Service == serviceName && !upstream.UseClusterIP {
+				return true
+			}
+		}
+	}
+
+	// Check external auth services referenced by policies
+	for _, p := range vsEx.Policies {
+		if p.Spec.ExternalAuth != nil && p.Spec.ExternalAuth.AuthServiceName != "" {
+			_, resolvedName := configs.ParseServiceReference(p.Spec.ExternalAuth.AuthServiceName, p.Namespace)
+			if resolvedName == serviceName {
 				return true
 			}
 		}
@@ -2540,7 +2550,7 @@ func (lbc *LoadBalancerController) createIngressEx(ing *networking.Ingress, vali
 		}
 	}
 
-	lbc.generateExternalAuthEndpoints(policies, ing.Namespace, ingEx.Endpoints)
+	lbc.generateExternalAuthEndpoints(policies, ingEx.Endpoints)
 
 	return ingEx
 }
@@ -2612,6 +2622,10 @@ func (lbc *LoadBalancerController) createVirtualServerEx(virtualServer *conf_v1.
 	err = lbc.addOIDCTrustedCertSecretRefs(virtualServerEx.SecretRefs, policies)
 	if err != nil {
 		nl.Warnf(lbc.Logger, "Error getting OIDC trusted cert secrets for VirtualServer %v/%v: %v", virtualServer.Namespace, virtualServer.Name, err)
+	}
+	err = lbc.addExternalAuthTrustedCertSecretRefs(virtualServerEx.SecretRefs, policies)
+	if err != nil {
+		nl.Warnf(lbc.Logger, "Error getting ExternalAuth trusted cert secrets for VirtualServer %v/%v: %v", virtualServer.Namespace, virtualServer.Name, err)
 	}
 	err = lbc.addAPIKeySecretRefs(virtualServerEx.SecretRefs, policies)
 	if err != nil {
@@ -2751,6 +2765,11 @@ func (lbc *LoadBalancerController) createVirtualServerEx(virtualServer *conf_v1.
 			nl.Warnf(lbc.Logger, "Error getting OIDC trusted cert secrets for VirtualServer %v/%v: %v", virtualServer.Namespace, virtualServer.Name, err)
 		}
 
+		err = lbc.addExternalAuthTrustedCertSecretRefs(virtualServerEx.SecretRefs, vsRoutePolicies)
+		if err != nil {
+			nl.Warnf(lbc.Logger, "Error getting ExternalAuth trusted cert secrets for VirtualServer %v/%v: %v", virtualServer.Namespace, virtualServer.Name, err)
+		}
+
 		err = lbc.addAPIKeySecretRefs(virtualServerEx.SecretRefs, vsRoutePolicies)
 		if err != nil {
 			nl.Warnf(lbc.Logger, "Error getting APIKey secrets for VirtualServer %v/%v: %v", virtualServer.Namespace, virtualServer.Name, err)
@@ -2793,6 +2812,11 @@ func (lbc *LoadBalancerController) createVirtualServerEx(virtualServer *conf_v1.
 			err = lbc.addOIDCTrustedCertSecretRefs(virtualServerEx.SecretRefs, vsrSubroutePolicies)
 			if err != nil {
 				nl.Warnf(lbc.Logger, "Error getting OIDC trusted cert secrets for VirtualServerRoute %v/%v: %v", vsr.Namespace, vsr.Name, err)
+			}
+
+			err = lbc.addExternalAuthTrustedCertSecretRefs(virtualServerEx.SecretRefs, vsrSubroutePolicies)
+			if err != nil {
+				nl.Warnf(lbc.Logger, "Error getting ExternalAuth trusted cert secrets for VirtualServerRoute %v/%v: %v", vsr.Namespace, vsr.Name, err)
 			}
 
 			err = lbc.addAPIKeySecretRefs(virtualServerEx.SecretRefs, vsrSubroutePolicies)
@@ -2861,6 +2885,8 @@ func (lbc *LoadBalancerController) createVirtualServerEx(virtualServer *conf_v1.
 		}
 	}
 
+	lbc.generateExternalAuthEndpoints(policies, endpoints)
+
 	virtualServerEx.Endpoints = endpoints
 	virtualServerEx.VirtualServerRoutes = virtualServerRoutes
 	virtualServerEx.ExternalNameSvcs = externalNameSvcs
@@ -2870,14 +2896,13 @@ func (lbc *LoadBalancerController) createVirtualServerEx(virtualServer *conf_v1.
 	return &virtualServerEx
 }
 
-func (lbc *LoadBalancerController) generateExternalAuthEndpoints(policies []*conf_v1.Policy, defaultNamespace string, endpoints map[string][]string) {
+func (lbc *LoadBalancerController) generateExternalAuthEndpoints(policies []*conf_v1.Policy, endpoints map[string][]string) {
 	for _, p := range policies {
 		if p.Spec.ExternalAuth == nil || p.Spec.ExternalAuth.AuthServiceName == "" {
 			continue
 		}
 
-		ns, name := configs.ParseServiceReference(p.Spec.ExternalAuth.AuthServiceName, defaultNamespace)
-
+		ns, name := configs.ParseServiceReference(p.Spec.ExternalAuth.AuthServiceName, p.Namespace)
 		svc, err := lbc.getServiceFromInformer(ns, name)
 		if err != nil {
 			nl.Warnf(lbc.Logger, "Error getting Service for ExternalAuth %v in policy %v/%v: %v", p.Spec.ExternalAuth.AuthServiceName, p.Namespace, p.Name, err)
@@ -3269,8 +3294,11 @@ func findPoliciesForSecret(policies []*conf_v1.Policy, secretNamespace string, s
 			res = append(res, pol)
 		} else if pol.Spec.OIDC != nil && pol.Spec.OIDC.TrustedCertSecret == secretName && pol.Namespace == secretNamespace {
 			res = append(res, pol)
-		} else if pol.Spec.ExternalAuth != nil && pol.Spec.ExternalAuth.TrustedCertSecret == secretName && pol.Namespace == secretNamespace {
-			res = append(res, pol)
+		} else if pol.Spec.ExternalAuth != nil && pol.Spec.ExternalAuth.TrustedCertSecret != "" {
+			extAuthNs, extAuthName := configs.ParseResourceReference(pol.Spec.ExternalAuth.TrustedCertSecret, pol.Namespace)
+			if extAuthName == secretName && extAuthNs == secretNamespace {
+				res = append(res, pol)
+			}
 		} else if pol.Spec.APIKey != nil && pol.Spec.APIKey.ClientSecret == secretName && pol.Namespace == secretNamespace {
 			res = append(res, pol)
 		}

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -2684,7 +2684,7 @@ func TestUpdateEndpointSliceWarningState(t *testing.T) {
 func TestUpdateEndpointSliceWarningState_WarningToClearTransition(t *testing.T) {
 	t.Parallel()
 
-	// Verifies the full lifecycle: clean → warning → clean
+	// Verifies the full lifecycle: clean -> warning -> clean
 	lbc := &LoadBalancerController{
 		endpointSliceWarnings: make(map[string]bool),
 		recorder:              record.NewFakeRecorder(10),
@@ -2695,26 +2695,26 @@ func TestUpdateEndpointSliceWarningState_WarningToClearTransition(t *testing.T) 
 	svcResources := []Resource{resource}
 	resourceExes := configs.ExtendedResources{}
 
-	// Step 1: clean → clean (no-op)
+	// Step 1: clean -> clean (no-op)
 	lbc.updateEndpointSliceWarningState(svcResources, resourceExes, configs.Warnings{})
 	if len(lbc.endpointSliceWarnings) != 0 {
 		t.Fatalf("step 1: expected empty map, got %v", lbc.endpointSliceWarnings)
 	}
 
-	// Step 2: clean → warning
+	// Step 2: clean -> warning
 	warningCfg := configs.Warnings{&networking.Ingress{}: {"no endpoints for auth service"}}
 	lbc.updateEndpointSliceWarningState(svcResources, resourceExes, warningCfg)
 	if !lbc.endpointSliceWarnings["Ingress/default/my-ingress"] {
 		t.Fatalf("step 2: expected warning tracked, got %v", lbc.endpointSliceWarnings)
 	}
 
-	// Step 3: warning → clean (recovery)
+	// Step 3: warning -> clean (recovery)
 	lbc.updateEndpointSliceWarningState(svcResources, resourceExes, configs.Warnings{})
 	if len(lbc.endpointSliceWarnings) != 0 {
 		t.Fatalf("step 3: expected empty map after recovery, got %v", lbc.endpointSliceWarnings)
 	}
 
-	// Step 4: clean → clean again (should be silent)
+	// Step 4: clean -> clean again (should be silent)
 	lbc.updateEndpointSliceWarningState(svcResources, resourceExes, configs.Warnings{})
 	if len(lbc.endpointSliceWarnings) != 0 {
 		t.Fatalf("step 4: expected empty map, got %v", lbc.endpointSliceWarnings)
@@ -2854,6 +2854,28 @@ func TestFindPoliciesForSecret(t *testing.T) {
 			},
 		},
 	}
+	extAuthPol := &conf_v1.Policy{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "external-auth-policy",
+			Namespace: "default",
+		},
+		Spec: conf_v1.PolicySpec{
+			ExternalAuth: &conf_v1.ExternalAuth{
+				TrustedCertSecret: "ext-auth-secret",
+			},
+		},
+	}
+	extAuthCrossNsPol := &conf_v1.Policy{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "external-auth-cross-ns-policy",
+			Namespace: "default",
+		},
+		Spec: conf_v1.PolicySpec{
+			ExternalAuth: &conf_v1.ExternalAuth{
+				TrustedCertSecret: "other-ns/ext-auth-secret",
+			},
+		},
+	}
 
 	tests := []struct {
 		policies        []*conf_v1.Policy
@@ -2959,6 +2981,41 @@ func TestFindPoliciesForSecret(t *testing.T) {
 			secretName:      "oidc-secret",
 			expected:        []*conf_v1.Policy{oidcPol},
 			msg:             "Find policy in default ns, ignore other types",
+		},
+		{
+			policies:        []*conf_v1.Policy{extAuthPol},
+			secretNamespace: "default",
+			secretName:      "ext-auth-secret",
+			expected:        []*conf_v1.Policy{extAuthPol},
+			msg:             "Find external auth policy in same namespace",
+		},
+		{
+			policies:        []*conf_v1.Policy{extAuthCrossNsPol},
+			secretNamespace: "other-ns",
+			secretName:      "ext-auth-secret",
+			expected:        []*conf_v1.Policy{extAuthCrossNsPol},
+			msg:             "Find external auth policy with cross-namespace secret reference",
+		},
+		{
+			policies:        []*conf_v1.Policy{extAuthCrossNsPol},
+			secretNamespace: "default",
+			secretName:      "ext-auth-secret",
+			expected:        nil,
+			msg:             "Ignore external auth policy when secret namespace does not match cross-namespace reference",
+		},
+		{
+			policies:        []*conf_v1.Policy{extAuthCrossNsPol},
+			secretNamespace: "other-ns",
+			secretName:      "different-secret",
+			expected:        nil,
+			msg:             "Ignore external auth policy when secret name does not match",
+		},
+		{
+			policies:        []*conf_v1.Policy{jwtPol1, extAuthCrossNsPol},
+			secretNamespace: "other-ns",
+			secretName:      "ext-auth-secret",
+			expected:        []*conf_v1.Policy{extAuthCrossNsPol},
+			msg:             "Find cross-namespace external auth policy, ignore other types",
 		},
 	}
 	for _, test := range tests {
@@ -4122,7 +4179,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 	tests := []struct {
 		name              string
 		setupLBC          func(t *testing.T) *LoadBalancerController
-		defaultNamespace  string
 		policies          []*conf_v1.Policy
 		initialEndpoints  map[string][]string
 		expectedEndpoints map[string][]string
@@ -4130,30 +4186,26 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 		{
 			name:              "nil policies produces no endpoints",
 			setupLBC:          func(t *testing.T) *LoadBalancerController { return buildLBC(t, "default", nil, nil) },
-			defaultNamespace:  "default",
 			policies:          nil,
 			expectedEndpoints: map[string][]string{},
 		},
 		{
 			name:              "empty policies slice produces no endpoints",
 			setupLBC:          func(t *testing.T) *LoadBalancerController { return buildLBC(t, "default", nil, nil) },
-			defaultNamespace:  "default",
 			policies:          []*conf_v1.Policy{},
 			expectedEndpoints: map[string][]string{},
 		},
 		{
-			name:             "policy with nil ExternalAuth is skipped",
-			setupLBC:         func(t *testing.T) *LoadBalancerController { return buildLBC(t, "default", nil, nil) },
-			defaultNamespace: "default",
+			name:     "policy with nil ExternalAuth is skipped",
+			setupLBC: func(t *testing.T) *LoadBalancerController { return buildLBC(t, "default", nil, nil) },
 			policies: []*conf_v1.Policy{
 				{ObjectMeta: meta_v1.ObjectMeta{Name: "p1", Namespace: "default"}, Spec: conf_v1.PolicySpec{}},
 			},
 			expectedEndpoints: map[string][]string{},
 		},
 		{
-			name:             "policy with empty AuthServiceName is skipped",
-			setupLBC:         func(t *testing.T) *LoadBalancerController { return buildLBC(t, "default", nil, nil) },
-			defaultNamespace: "default",
+			name:     "policy with empty AuthServiceName is skipped",
+			setupLBC: func(t *testing.T) *LoadBalancerController { return buildLBC(t, "default", nil, nil) },
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "p1", Namespace: "default"},
@@ -4167,7 +4219,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{authSvc}, []*discovery_v1.EndpointSlice{authES80})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-policy", Namespace: "default"},
@@ -4183,7 +4234,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{multiPortSvc}, []*discovery_v1.EndpointSlice{multiPortES80, multiPortES9000})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-policy", Namespace: "default"},
@@ -4196,9 +4246,8 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name:             "service not found is handled gracefully",
-			setupLBC:         func(t *testing.T) *LoadBalancerController { return buildLBC(t, "default", nil, nil) },
-			defaultNamespace: "default",
+			name:     "service not found is handled gracefully",
+			setupLBC: func(t *testing.T) *LoadBalancerController { return buildLBC(t, "default", nil, nil) },
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-policy", Namespace: "default"},
@@ -4214,7 +4263,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{authSvc}, []*discovery_v1.EndpointSlice{authES80})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{ObjectMeta: meta_v1.ObjectMeta{Name: "p-nil", Namespace: "default"}, Spec: conf_v1.PolicySpec{}},
 				{
@@ -4235,7 +4283,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{authSvc}, []*discovery_v1.EndpointSlice{authES80})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-1", Namespace: "default"},
@@ -4255,7 +4302,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{authSvc}, []*discovery_v1.EndpointSlice{authES80})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-policy", Namespace: "default"},
@@ -4292,7 +4338,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 				}
 				return buildLBC(t, "custom-ns", []*api_v1.Service{svc}, []*discovery_v1.EndpointSlice{es})
 			},
-			defaultNamespace: "custom-ns",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-policy", Namespace: "custom-ns"},
@@ -4342,7 +4387,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 				}
 				return buildLBC(t, "default", []*api_v1.Service{svcA, svcB}, []*discovery_v1.EndpointSlice{esA, esB})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-a-pol", Namespace: "default"},
@@ -4363,7 +4407,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{authSvc}, []*discovery_v1.EndpointSlice{authES80})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "good", Namespace: "default"},
@@ -4384,7 +4427,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{multiPortSvc}, []*discovery_v1.EndpointSlice{multiPortES80, multiPortES9000})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-policy", Namespace: "default"},
@@ -4404,7 +4446,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{multiPortSvc}, []*discovery_v1.EndpointSlice{multiPortES80, multiPortES9000})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-policy", Namespace: "default"},
@@ -4425,7 +4466,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{authSvc}, []*discovery_v1.EndpointSlice{authES80})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-policy", Namespace: "default"},
@@ -4445,7 +4485,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{authSvc}, []*discovery_v1.EndpointSlice{authES80})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-policy", Namespace: "default"},
@@ -4465,7 +4504,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{authSvc, multiPortSvc}, []*discovery_v1.EndpointSlice{authES80, multiPortES80, multiPortES9000})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "policy-with-ports", Namespace: "default"},
@@ -4490,7 +4528,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 			setupLBC: func(t *testing.T) *LoadBalancerController {
 				return buildLBC(t, "default", []*api_v1.Service{multiPortSvc}, []*discovery_v1.EndpointSlice{multiPortES80, multiPortES9000})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "auth-policy", Namespace: "default"},
@@ -4533,7 +4570,6 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 				// Use "" as namespace key to simulate watching all namespaces (global informer)
 				return buildLBC(t, "", []*api_v1.Service{crossNsSvc}, []*discovery_v1.EndpointSlice{crossNsES})
 			},
-			defaultNamespace: "default",
 			policies: []*conf_v1.Policy{
 				{
 					ObjectMeta: meta_v1.ObjectMeta{Name: "ext-auth-policy", Namespace: "default"},
@@ -4560,7 +4596,7 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 				endpoints[k] = v
 			}
 
-			lbc.generateExternalAuthEndpoints(tc.policies, tc.defaultNamespace, endpoints)
+			lbc.generateExternalAuthEndpoints(tc.policies, endpoints)
 
 			if len(endpoints) != len(tc.expectedEndpoints) {
 				t.Fatalf("expected %d endpoint entries, got %d: %v", len(tc.expectedEndpoints), len(endpoints), endpoints)

--- a/internal/k8s/endpoint_slice.go
+++ b/internal/k8s/endpoint_slice.go
@@ -120,10 +120,11 @@ func (lbc *LoadBalancerController) syncEndpointSlices(task task) bool {
 				if lbc.virtualServerRequiresEndpointsUpdate(vsEx, svcName) {
 					resourcesFound = true
 					nl.Debugf(lbc.Logger, "Updating EndpointSlices for %v", resourceExes.VirtualServerExes)
-					err := lbc.configurator.UpdateEndpointsForVirtualServers(resourceExes.VirtualServerExes)
+					cfgWarnings, err := lbc.configurator.UpdateEndpointsForVirtualServers(resourceExes.VirtualServerExes)
 					if err != nil {
 						nl.Errorf(lbc.Logger, "Error updating EndpointSlices for %v: %v", resourceExes.VirtualServerExes, err)
 					}
+					lbc.updateEndpointSliceWarningState(svcResource, resourceExes, cfgWarnings)
 					break
 				}
 			}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ markers = [
     "policies",
     "policies_external_auth",
     "policies_external_auth_tls",
+    "policies_external_auth_vs",
+    "policies_external_auth_tls_vs",
     "policies_rl",
     "policies_rl_vs",
     "policies_rl_vsr",

--- a/tests/data/external-auth/route-subroute/virtual-server-route-invalid-subroute.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-route-invalid-subroute.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServerRoute
+metadata:
+  name: backends
+spec:
+  host: virtual-server-route.example.com
+  upstreams:
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  - name: backend3
+    service: backend3-svc
+    port: 80
+  subroutes:
+  - path: "/backends/backend1"
+    policies:
+    - name: external-auth-policy-invalid
+    action:
+      pass: backend1
+  - path: "/backends/backend3"
+    action:
+      pass: backend3

--- a/tests/data/external-auth/route-subroute/virtual-server-route-invalid-svc-subroute.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-route-invalid-svc-subroute.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServerRoute
+metadata:
+  name: backends
+spec:
+  host: virtual-server-route.example.com
+  upstreams:
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  - name: backend3
+    service: backend3-svc
+    port: 80
+  subroutes:
+  - path: "/backends/backend1"
+    policies:
+    - name: external-auth-policy-invalid-svc
+    action:
+      pass: backend1
+  - path: "/backends/backend3"
+    action:
+      pass: backend3

--- a/tests/data/external-auth/route-subroute/virtual-server-route-override-subroute.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-route-override-subroute.yaml
@@ -1,0 +1,23 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServerRoute
+metadata:
+  name: backends
+spec:
+  host: virtual-server-route.example.com
+  upstreams:
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  - name: backend3
+    service: backend3-svc
+    port: 80
+  subroutes:
+  - path: "/backends/backend1"
+    policies:
+    - name: external-auth-policy-valid-multi
+    - name: external-auth-policy-valid
+    action:
+      pass: backend1
+  - path: "/backends/backend3"
+    action:
+      pass: backend3

--- a/tests/data/external-auth/route-subroute/virtual-server-route-tls-multi-subroute.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-route-tls-multi-subroute.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServerRoute
+metadata:
+  name: backends
+spec:
+  host: virtual-server-route.example.com
+  upstreams:
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  - name: backend3
+    service: backend3-svc
+    port: 80
+  subroutes:
+  - path: "/backends/backend1"
+    policies:
+    - name: external-auth-policy-tls-multi
+    action:
+      pass: backend1
+  - path: "/backends/backend3"
+    action:
+      pass: backend3

--- a/tests/data/external-auth/route-subroute/virtual-server-route-tls-subroute.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-route-tls-subroute.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServerRoute
+metadata:
+  name: backends
+spec:
+  host: virtual-server-route.example.com
+  upstreams:
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  - name: backend3
+    service: backend3-svc
+    port: 80
+  subroutes:
+  - path: "/backends/backend1"
+    policies:
+    - name: external-auth-policy-tls
+    action:
+      pass: backend1
+  - path: "/backends/backend3"
+    action:
+      pass: backend3

--- a/tests/data/external-auth/route-subroute/virtual-server-route-valid-subroute-multi.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-route-valid-subroute-multi.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServerRoute
+metadata:
+  name: backends
+spec:
+  host: virtual-server-route.example.com
+  upstreams:
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  - name: backend3
+    service: backend3-svc
+    port: 80
+  subroutes:
+  - path: "/backends/backend1"
+    policies:
+    - name: external-auth-policy-valid-multi
+    action:
+      pass: backend1
+  - path: "/backends/backend3"
+    action:
+      pass: backend3

--- a/tests/data/external-auth/route-subroute/virtual-server-route-valid-subroute.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-route-valid-subroute.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServerRoute
+metadata:
+  name: backends
+spec:
+  host: virtual-server-route.example.com
+  upstreams:
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  - name: backend3
+    service: backend3-svc
+    port: 80
+  subroutes:
+  - path: "/backends/backend1"
+    policies:
+    - name: external-auth-policy-valid
+    action:
+      pass: backend1
+  - path: "/backends/backend3"
+    action:
+      pass: backend3

--- a/tests/data/external-auth/route-subroute/virtual-server-vsr-route-override.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-vsr-route-override.yaml
@@ -1,0 +1,13 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server-route
+spec:
+  host: virtual-server-route.example.com
+  routes:
+  - path: "/backends"
+    policies:
+    - name: external-auth-policy-valid
+    route: backends
+  - path: "/backend2"
+    route: backend2-namespace/backend2

--- a/tests/data/external-auth/route-subroute/virtual-server-vsr-spec-override.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-vsr-spec-override.yaml
@@ -1,0 +1,13 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server-route
+spec:
+  host: virtual-server-route.example.com
+  policies:
+  - name: external-auth-policy-valid
+  routes:
+  - path: "/backends"
+    route: backends
+  - path: "/backend2"
+    route: backend2-namespace/backend2

--- a/tests/data/external-auth/route-subroute/virtual-server-vsr-tls-route-override.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-vsr-tls-route-override.yaml
@@ -1,0 +1,13 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server-route
+spec:
+  host: virtual-server-route.example.com
+  routes:
+  - path: "/backends"
+    policies:
+    - name: external-auth-policy-tls
+    route: backends
+  - path: "/backend2"
+    route: backend2-namespace/backend2

--- a/tests/data/external-auth/route-subroute/virtual-server-vsr-tls-spec-override.yaml
+++ b/tests/data/external-auth/route-subroute/virtual-server-vsr-tls-spec-override.yaml
@@ -1,0 +1,13 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server-route
+spec:
+  host: virtual-server-route.example.com
+  policies:
+  - name: external-auth-policy-tls
+  routes:
+  - path: "/backends"
+    route: backends
+  - path: "/backend2"
+    route: backend2-namespace/backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-cross-ns.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-cross-ns.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-cross-ns
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-custom-port.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-custom-port.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-custom-port
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-multi-1.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-multi-1.yaml
@@ -1,0 +1,23 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-valid-multi
+  - name: external-auth-policy-valid
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-multi-2.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-multi-2.yaml
@@ -1,0 +1,23 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-valid
+  - name: external-auth-policy-valid-multi
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-signin.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-signin.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-signin
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-single-invalid-pol.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-single-invalid-pol.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-invalid
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-single-invalid-svc.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-single-invalid-svc.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-invalid-svc
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-single.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-single.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-valid
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-tls-multi-1.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-tls-multi-1.yaml
@@ -1,0 +1,23 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-tls
+  - name: external-auth-policy-tls-multi
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-tls-multi-2.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-tls-multi-2.yaml
@@ -1,0 +1,23 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-tls-multi
+  - name: external-auth-policy-tls
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/data/external-auth/spec/virtual-server-policy-tls.yaml
+++ b/tests/data/external-auth/spec/virtual-server-policy-tls.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  policies:
+  - name: external-auth-policy-tls
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/suite/test_external_auth_policies_tls_vs.py
+++ b/tests/suite/test_external_auth_policies_tls_vs.py
@@ -44,6 +44,7 @@ ext_auth_vs_tls_multi_2_src = f"{TEST_DATA}/external-auth/spec/virtual-server-po
 
 @pytest.mark.policies
 @pytest.mark.policies_external_auth
+@pytest.mark.policies_external_auth_tls
 @pytest.mark.policies_external_auth_vs
 @pytest.mark.policies_external_auth_tls_vs
 @pytest.mark.parametrize(

--- a/tests/suite/test_external_auth_policies_tls_vs.py
+++ b/tests/suite/test_external_auth_policies_tls_vs.py
@@ -1,0 +1,716 @@
+import pytest
+import requests
+from settings import TEST_DATA
+from suite.utils.external_auth_utils import (
+    build_ext_auth_headers,
+    ext_auth_pol_tls_bad_sni_src,
+    ext_auth_pol_tls_basic_src,
+    ext_auth_pol_tls_cross_ns_ca_src,
+    ext_auth_pol_tls_custom_port_src,
+    ext_auth_pol_tls_default_sni_src,
+    ext_auth_pol_tls_disabled_src,
+    ext_auth_pol_tls_full_multi_src,
+    ext_auth_pol_tls_full_src,
+    ext_auth_pol_tls_no_trusted_cert_src,
+    ext_auth_pol_tls_nonexistent_ca_src,
+    ext_auth_pol_tls_signin_src,
+    ext_auth_pol_tls_verify_no_ssl_src,
+    ext_auth_pol_tls_wrong_ca_type_src,
+    ext_auth_tls_backend_src,
+    ext_auth_tls_wrong_ca_src,
+    invalid_credentials,
+    valid_auth_headers,
+    valid_credentials,
+)
+from suite.utils.policy_resources_utils import read_policy
+from suite.utils.resources_utils import (
+    create_secret_from_yaml,
+    delete_items_from_yaml,
+    delete_secret,
+    ensure_response_from_backend,
+    wait_before_test,
+)
+from suite.utils.vs_vsr_resources_utils import (
+    apply_and_assert_valid_vs,
+    apply_and_assert_warning_vs,
+    read_vs,
+)
+
+# TLS VS specs
+ext_auth_vs_tls_src = f"{TEST_DATA}/external-auth/spec/virtual-server-policy-tls.yaml"
+ext_auth_vs_tls_multi_1_src = f"{TEST_DATA}/external-auth/spec/virtual-server-policy-tls-multi-1.yaml"
+ext_auth_vs_tls_multi_2_src = f"{TEST_DATA}/external-auth/spec/virtual-server-policy-tls-multi-2.yaml"
+
+
+@pytest.mark.policies
+@pytest.mark.policies_external_auth
+@pytest.mark.policies_external_auth_vs
+@pytest.mark.policies_external_auth_tls_vs
+@pytest.mark.parametrize(
+    "crd_ingress_controller, virtual_server_setup",
+    [
+        (
+            {
+                "type": "complete",
+                "extra_args": [
+                    f"-enable-custom-resources",
+                    f"-enable-leader-election=false",
+                ],
+            },
+            {
+                "example": "virtual-server",
+                "app_type": "simple",
+            },
+        )
+    ],
+    indirect=True,
+)
+class TestExternalAuthPoliciesTLS:
+    """Test external-auth policies with TLS configurations for VirtualServer."""
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_basic_src], True)], indirect=True)
+    def test_tls_ssl_enabled_only(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test external-auth policy with sslEnabled: true only (no certificate verification).
+        The IC connects to the auth backend over HTTPS but does not verify its certificate.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_full_src], True)], indirect=True)
+    def test_tls_full_verify(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test external-auth policy with full TLS verification:
+        sslEnabled, sslVerify, sslVerifyDepth, sniName, and trustedCertSecret.
+        Verifies the policy and VirtualServer are accepted as Valid.
+        """
+        _, policy_names = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        policy_info = read_policy(kube_apis.custom_objects, test_namespace, policy_names[0])
+        assert policy_info["status"]["state"] == "Valid"
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+
+    @pytest.mark.parametrize("credentials", [valid_credentials, invalid_credentials, None])
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_full_src], True)], indirect=True)
+    def test_tls_credentials(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+        credentials,
+    ):
+        """
+        Test external-auth policy with full TLS using valid, invalid, and no credentials.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        if credentials == valid_credentials:
+            assert resp.status_code == 200
+            assert "Request ID:" in resp.text
+        else:
+            assert resp.status_code == 401
+            assert "Authorization Required" in resp.text
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_disabled_src], True)], indirect=True)
+    def test_tls_http_fallback(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that a TLS-capable backend still serves HTTP when sslEnabled is explicitly false.
+        The IC connects over HTTP (port 80) even though the backend also listens on HTTPS (port 443).
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_verify_no_ssl_src], True, False)], indirect=True)
+    def test_tls_verify_without_ssl_enabled(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that sslVerify: true without sslEnabled: true causes the VS to
+        enter Warning state. Although the CRD accepts this combination (no
+        x-kubernetes-validations rule unlike OIDC) and the controller's TLS
+        verify path is gated by SSLEnabled && SSLVerify (policy.go:309),
+        the IC treats this as an invalid configuration, resulting in HTTP 500.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert resp.status_code == 500
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_custom_port_src], True)], indirect=True)
+    def test_tls_custom_port(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test external-auth policy with sslEnabled and authServicePorts: [8443].
+        The IC uses the custom service port 8443 instead of the default 443.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_signin_src], True)], indirect=True)
+    def test_tls_signin_uri(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test external-auth policy with sslEnabled and authSigninURI.
+        Verifies the policy and VS are accepted as Valid and that
+        authenticated requests still pass through correctly over TLS.
+        """
+        _, policy_names = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        policy_info = read_policy(kube_apis.custom_objects, test_namespace, policy_names[0])
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert policy_info["status"]["state"] == "Valid"
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_nonexistent_ca_src], True)], indirect=True)
+    def test_tls_nonexistent_ca_secret(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that referencing a non-existent trustedCertSecret results in
+        VS Warning state and HTTP 500 responses.
+        Controller path: policy.go:324-328 (secret not found).
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert resp.status_code == 500
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_wrong_ca_type_src], True)], indirect=True)
+    def test_tls_wrong_ca_secret_type(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that referencing a trustedCertSecret with wrong type (kubernetes.io/tls
+        instead of nginx.org/ca) results in VS Warning state and HTTP 500 responses.
+        Controller path: policy.go:334-337 (wrong secret type).
+        """
+        print("Create wrong-type CA secret")
+        wrong_secret = create_secret_from_yaml(kube_apis.v1, test_namespace, ext_auth_tls_wrong_ca_src)
+
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        delete_secret(kube_apis.v1, wrong_secret, test_namespace)
+
+        assert resp.status_code == 500
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_cross_ns_ca_src], True)], indirect=True)
+    def test_tls_cross_ns_nonexistent_ca(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that referencing a trustedCertSecret in a non-existent namespace
+        (fakens/external-auth-ca-secret) results in VS Warning and HTTP 500.
+        Controller path: policy.go:324-328 (secret not found in cross-ns lookup).
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert resp.status_code == 500
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_bad_sni_src], True)], indirect=True)
+    def test_tls_bad_sni_name(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that an incorrect sniName (wrong-name.example.com) causes TLS
+        verification failure at runtime. The VS is accepted as Valid because
+        the config is syntactically correct, but NGINX's proxy_ssl_verify
+        rejects the connection since the cert SAN (external-auth-tls) does not
+        match the requested SNI name. The auth_request module returns HTTP 500
+        (not 502) for subrequest failures.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert resp.status_code == 500
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_no_trusted_cert_src], True)], indirect=True)
+    def test_tls_verify_no_trusted_cert(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that sslVerify: true without trustedCertSecret falls back to the
+        system CA bundle. Since the auth backend uses a self-signed certificate,
+        the system CA cannot verify it, causing NGINX's proxy_ssl_verify to
+        reject the connection. The auth_request module returns HTTP 500 (not
+        502) for subrequest failures. The VS remains Valid.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert resp.status_code == 500
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_default_sni_src], True)], indirect=True)
+    def test_tls_default_sni_mismatch(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that omitting sniName with sslVerify causes a TLS verification failure.
+        When sniName is not specified, the controller defaults to
+        '<svcName>.<svcNs>.svc' (policy.go:351-356). This default name does not
+        match the server certificate SAN (external-auth-tls), so NGINX's
+        proxy_ssl_verify rejects the connection. The auth_request module returns
+        HTTP 500 (not 502) for subrequest failures. The VS remains Valid.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert resp.status_code == 500
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_full_src], True)], indirect=True)
+    def test_tls_delete_ca_secret(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that deleting the CA secret (trustedCertSecret) after a working
+        TLS setup causes the VirtualServer to transition to Warning state.
+        The IC watches the referenced secret and reconfigures NGINX when it
+        is removed, resulting in HTTP 500 for subsequent requests.
+        """
+        secret_names, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Before delete - Status: {resp1.status_code}")
+
+        print("Delete CA secret")
+        delete_secret(kube_apis.v1, secret_names[2], test_namespace)  # ca_secret
+        wait_before_test()
+
+        resp2 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"After delete - Status: {resp2.status_code}")
+
+        crd_info = read_vs(
+            kube_apis.custom_objects,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+        )
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 500
+        assert crd_info["status"]["state"] == "Warning"
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_full_src], True)], indirect=True)
+    def test_tls_delete_server_tls_secret(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test behavior after deleting the server TLS secret (external-auth-server-tls-secret).
+        This secret is mounted as a volume in the backend pod, not directly referenced
+        by the IC policy. After deletion:
+        - The running backend pod retains the TLS cert in memory (nginx keeps it loaded).
+        - The IC configuration is unaffected (it references trustedCertSecret, not the server cert).
+        - Requests continue to succeed until the backend pod is restarted.
+        """
+        secret_names, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Before delete - Status: {resp1.status_code}")
+
+        print("Delete server TLS secret")
+        delete_secret(kube_apis.v1, secret_names[1], test_namespace)  # tls_secret
+        wait_before_test()
+
+        resp2 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"After delete - Status: {resp2.status_code}")
+
+        crd_info = read_vs(
+            kube_apis.custom_objects,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+        )
+
+        assert resp1.status_code == 200
+        # Backend retains cert in memory; IC config unchanged; request should still succeed
+        assert resp2.status_code == 200
+        assert crd_info["status"]["state"] == "Valid"
+
+    @pytest.mark.parametrize(
+        "ext_auth_setup", [([ext_auth_pol_tls_full_src, ext_auth_pol_tls_full_multi_src], True)], indirect=True
+    )
+    def test_tls_policy_override(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that when multiple TLS policies are applied, the first listed policy
+        takes precedence. Both TLS policies reference the same backend with the same
+        TLS config, so both orderings should succeed with valid credentials.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        print("Patch vs with TLS multi policies (tls first, tls-multi second)")
+        # Multiple policies in same context -> VS Warning (first policy wins, second is ignored)
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_multi_1_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Order 1 - Status: {resp1.status_code}")
+
+        print("Patch vs with TLS multi policies (tls-multi first, tls second)")
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_multi_2_src,
+        )
+
+        resp2 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Order 2 - Status: {resp2.status_code}")
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_tls_full_src], True)], indirect=True)
+    def test_tls_delete_backend(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that requests fail when the TLS external auth backend service is deleted.
+        After the backend is removed, the IC can no longer proxy auth subrequests,
+        resulting in HTTP 500.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_tls_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Before delete - Status: {resp1.status_code}")
+
+        print("Delete TLS external auth backend")
+        delete_items_from_yaml(kube_apis, ext_auth_tls_backend_src, test_namespace)
+        wait_before_test()
+
+        resp2 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"After delete - Status: {resp2.status_code}")
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 500

--- a/tests/suite/test_external_auth_policies_vs.py
+++ b/tests/suite/test_external_auth_policies_vs.py
@@ -1,0 +1,526 @@
+import pytest
+import requests
+from kubernetes.client.rest import ApiException
+from settings import TEST_DATA
+from suite.utils.external_auth_utils import (
+    build_ext_auth_headers,
+    ext_auth_backend_src,
+    ext_auth_pol_custom_port_src,
+    ext_auth_pol_invalid_src,
+    ext_auth_pol_invalid_svc_src,
+    ext_auth_pol_signin_src,
+    ext_auth_pol_valid_multi_src,
+    ext_auth_pol_valid_src,
+    invalid_credentials,
+    valid_auth_headers,
+    valid_credentials,
+)
+from suite.utils.policy_resources_utils import (
+    create_policy_from_yaml,
+    delete_policy,
+    read_policy,
+)
+from suite.utils.resources_utils import (
+    delete_items_from_yaml,
+    ensure_response_from_backend,
+    scale_deployment,
+    wait_before_test,
+    wait_until_all_pods_are_ready,
+)
+from suite.utils.vs_vsr_resources_utils import (
+    apply_and_assert_valid_vs,
+    apply_and_assert_warning_vs,
+)
+
+# VS spec file paths
+ext_auth_vs_single_src = f"{TEST_DATA}/external-auth/spec/virtual-server-policy-single.yaml"
+ext_auth_vs_single_invalid_svc_src = f"{TEST_DATA}/external-auth/spec/virtual-server-policy-single-invalid-svc.yaml"
+ext_auth_vs_multi_1_src = f"{TEST_DATA}/external-auth/spec/virtual-server-policy-multi-1.yaml"
+ext_auth_vs_multi_2_src = f"{TEST_DATA}/external-auth/spec/virtual-server-policy-multi-2.yaml"
+ext_auth_vs_signin_src = f"{TEST_DATA}/external-auth/spec/virtual-server-policy-signin.yaml"
+ext_auth_vs_custom_port_src = f"{TEST_DATA}/external-auth/spec/virtual-server-policy-custom-port.yaml"
+
+
+@pytest.mark.policies
+@pytest.mark.policies_external_auth
+@pytest.mark.policies_external_auth_vs
+@pytest.mark.parametrize(
+    "crd_ingress_controller, virtual_server_setup",
+    [
+        (
+            {
+                "type": "complete",
+                "extra_args": [
+                    f"-enable-custom-resources",
+                    f"-enable-leader-election=false",
+                ],
+            },
+            {
+                "example": "virtual-server",
+                "app_type": "simple",
+            },
+        )
+    ],
+    indirect=True,
+)
+class TestExternalAuthPolicies:
+    @pytest.mark.parametrize("credentials", [valid_credentials, invalid_credentials, None])
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_valid_src],)], indirect=True)
+    def test_external_auth_policy_credentials(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+        credentials,
+    ):
+        """
+        Test external-auth policy with valid credentials, invalid credentials, and no credentials.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_single_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp.status_code)
+
+        if credentials == valid_credentials:
+            assert resp.status_code == 200
+            assert "Request ID:" in resp.text
+        else:
+            assert resp.status_code == 401
+            assert "Authorization Required" in resp.text
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_valid_src],)], indirect=True)
+    def test_external_auth_policy_valid(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test external-auth policy with a valid policy is accepted and proxies correctly.
+        """
+        _, policy_names = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        policy_info = read_policy(kube_apis.custom_objects, test_namespace, policy_names[0])
+        assert (
+            policy_info["status"]
+            and policy_info["status"]["reason"] == "AddedOrUpdated"
+            and policy_info["status"]["state"] == "Valid"
+        )
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_single_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp.status_code)
+
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+
+    @pytest.mark.smoke
+    def test_external_auth_policy_invalid_rejected_by_crd(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+    ):
+        """
+        Test that a policy with an invalid authURI (no leading slash) is rejected
+        at the CRD validation level by the Kubernetes API server.
+        """
+        with pytest.raises(ApiException) as exc_info:
+            create_policy_from_yaml(kube_apis.custom_objects, ext_auth_pol_invalid_src, test_namespace)
+
+        assert exc_info.value.status == 422
+        assert "authURI" in exc_info.value.body
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_invalid_svc_src],)], indirect=True)
+    def test_external_auth_policy_nonexistent_svc(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test external-auth policy that references a non-existent service.
+
+        NGINX's auth_request module returns 500 when the subrequest fails
+        (e.g. connection refused because the backend service does not exist).
+        This is the expected "fail closed" behavior -- requests are denied
+        rather than allowed when the auth service is unreachable.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_single_invalid_svc_src,
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp.status_code)
+
+        assert resp.status_code == 500
+        assert "Internal Server Error" in resp.text
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_valid_src],)], indirect=True)
+    def test_external_auth_policy_delete_policy(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test if requests result in 500 when the external auth policy is deleted.
+        """
+        _, policy_names = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_single_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp1.status_code)
+
+        delete_policy(kube_apis.custom_objects, policy_names[0], test_namespace)
+        wait_before_test()
+
+        resp2 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp2.status_code)
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 500
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_valid_src],)], indirect=True)
+    def test_external_auth_policy_delete_backend(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test if requests fail when the external auth backend service is deleted.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_single_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp1.status_code)
+
+        print("Delete external auth backend")
+        delete_items_from_yaml(kube_apis, ext_auth_backend_src, test_namespace)
+
+        resp2 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp2.status_code)
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 500
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_valid_src],)], indirect=True)
+    def test_external_auth_policy_endpoint_recovery(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that the VirtualServer recovers after external auth backend endpoints
+        disappear (e.g. pod restart). The flow is:
+          1. Healthy baseline -> 200
+          2. Scale backend to 0 replicas -> 500 (no endpoints)
+          3. Scale backend back to 1 replica -> 200 (recovered)
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_single_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        # Phase 1: healthy baseline
+        resp1 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Phase 1 (healthy): {resp1.status_code}")
+
+        # Phase 2: scale backend to 0 -- endpoints disappear -> 500
+        print("Scale external-auth deployment to 0")
+        scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "external-auth", test_namespace, 0)
+        wait_before_test()
+        resp2 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Phase 2 (no endpoints): {resp2.status_code}")
+
+        # Phase 3: scale back to 1 -- endpoints recover -> 200
+        print("Scale external-auth deployment back to 1")
+        scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "external-auth", test_namespace, 1)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        # Poll until the full auth path (backend + auth subrequest) returns 200,
+        # giving NGINX time to pick up the recovered endpoints and reload.
+        resp3 = None
+        for _ in range(30):
+            r = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+            if r.status_code == 200:
+                resp3 = r
+                break
+            wait_before_test(1)
+        if resp3 is None:
+            resp3 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Phase 3 (recovered): {resp3.status_code}")
+
+        assert resp1.status_code == 200, f"Phase 1: expected 200, got {resp1.status_code}"
+        assert resp2.status_code == 500, f"Phase 2: expected 500, got {resp2.status_code}"
+        assert resp3.status_code == 200, f"Phase 3: expected 200 after recovery, got {resp3.status_code}"
+
+    @pytest.mark.parametrize(
+        "ext_auth_setup", [([ext_auth_pol_valid_src, ext_auth_pol_valid_multi_src],)], indirect=True
+    )
+    def test_external_auth_policy_override(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test if the first referenced policy takes precedence when multiple policies are applied.
+        Both policies reference the same external auth backend but with different names.
+        The first policy listed wins in each context (spec or route).
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        print("Patch vs with multiple policies in spec context (multi first, valid second)")
+        # Multiple policies in same context -> VS Warning (first policy wins, second is ignored)
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_multi_1_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp1.status_code)
+
+        print("Patch vs with multiple policies in spec context (valid first, multi second)")
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_multi_2_src,
+        )
+
+        resp2 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp2.status_code)
+
+        # Both policies reference the same auth backend, so both should succeed with valid creds.
+        # The first policy listed is the one applied; both use the same service so result is the same.
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+
+    @pytest.mark.parametrize(
+        "ext_auth_setup", [([ext_auth_pol_valid_src, ext_auth_pol_valid_multi_src],)], indirect=True
+    )
+    def test_external_auth_policy_override_spec(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test that a route-level policy takes precedence over a spec-level policy.
+        Spec has valid-multi, route has valid. Both reference the same backend.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        # Both policies reference the same external auth backend, so we verify both orderings succeed
+        # Multiple policies in same context -> VS Warning (first policy wins, second is ignored)
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_multi_1_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp1.status_code)
+
+        apply_and_assert_warning_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_multi_2_src,
+        )
+
+        resp2 = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp2.status_code)
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_signin_src],)], indirect=True)
+    def test_external_auth_policy_signin_uri(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test external-auth policy with authSigninURI set.
+        Verifies the policy and VS are accepted as Valid, and that
+        authenticated requests still pass through correctly.
+
+        Note: This test does NOT verify the actual signin redirect behavior
+        (error_page 401 -> internal redirect to authSigninURI) because the full
+        signin flow requires a real OAuth2 proxy deployed at authSigninRedirectBasePath
+        (default "/oauth2"). Without it, the error_page internal redirect to "/signin"
+        hits the same auth-protected location and produces another 401, making the
+        redirect behavior non-testable in this environment. Instead, we test that
+        the authSigninURI configuration is accepted and applied correctly.
+        """
+        _, policy_names = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_signin_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        policy_info = read_policy(kube_apis.custom_objects, test_namespace, policy_names[0])
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        assert policy_info["status"]["state"] == "Valid"
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+
+    @pytest.mark.parametrize("ext_auth_setup", [([ext_auth_pol_custom_port_src],)], indirect=True)
+    def test_external_auth_policy_custom_port(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        virtual_server_setup,
+        test_namespace,
+        ext_auth_setup,
+        ext_auth_restore_vs,
+    ):
+        """
+        Test external-auth policy with authServicePorts set to a custom port.
+        """
+        _, _ = ext_auth_setup
+        headers = build_ext_auth_headers(virtual_server_setup.vs_host, valid_credentials)
+
+        apply_and_assert_valid_vs(
+            kube_apis,
+            virtual_server_setup.namespace,
+            virtual_server_setup.vs_name,
+            ext_auth_vs_custom_port_src,
+        )
+        ensure_response_from_backend(
+            virtual_server_setup.backend_1_url,
+            virtual_server_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
+        print(resp.status_code)
+
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text

--- a/tests/suite/test_external_auth_policies_vsr.py
+++ b/tests/suite/test_external_auth_policies_vsr.py
@@ -1,0 +1,1002 @@
+import pytest
+import requests
+from kubernetes.client.rest import ApiException
+from settings import TEST_DATA
+from suite.utils.external_auth_utils import (
+    ext_auth_backend_src,
+    ext_auth_pol_invalid_src,
+    ext_auth_pol_invalid_svc_src,
+    ext_auth_pol_tls_bad_sni_src,
+    ext_auth_pol_tls_basic_src,
+    ext_auth_pol_tls_full_multi_src,
+    ext_auth_pol_tls_full_src,
+    ext_auth_pol_tls_no_trusted_cert_src,
+    ext_auth_pol_tls_nonexistent_ca_src,
+    ext_auth_pol_tls_wrong_ca_type_src,
+    ext_auth_pol_valid_multi_src,
+    ext_auth_pol_valid_src,
+    ext_auth_tls_backend_src,
+    ext_auth_tls_wrong_ca_src,
+    invalid_credentials,
+    setup_ext_auth,
+    teardown_ext_auth,
+    valid_auth_headers,
+    valid_credentials,
+)
+from suite.utils.policy_resources_utils import create_policy_from_yaml, delete_policy, read_policy
+from suite.utils.resources_utils import (
+    create_secret_from_yaml,
+    delete_items_from_yaml,
+    delete_secret,
+    ensure_response_from_backend,
+    wait_before_test,
+)
+from suite.utils.vs_vsr_resources_utils import patch_v_s_route_from_yaml, patch_virtual_server_from_yaml, read_vsr
+
+std_vs_src = f"{TEST_DATA}/virtual-server-route/standard/virtual-server.yaml"
+std_vsr_src = f"{TEST_DATA}/virtual-server-route/route-multiple.yaml"
+
+# VSR spec file paths
+ext_auth_vsr_valid_src = f"{TEST_DATA}/external-auth/route-subroute/virtual-server-route-valid-subroute.yaml"
+ext_auth_vsr_valid_multi_src = (
+    f"{TEST_DATA}/external-auth/route-subroute/virtual-server-route-valid-subroute-multi.yaml"
+)
+ext_auth_vsr_invalid_svc_src = (
+    f"{TEST_DATA}/external-auth/route-subroute/virtual-server-route-invalid-svc-subroute.yaml"
+)
+ext_auth_vsr_override_src = f"{TEST_DATA}/external-auth/route-subroute/virtual-server-route-override-subroute.yaml"
+ext_auth_vs_override_spec_src = f"{TEST_DATA}/external-auth/route-subroute/virtual-server-vsr-spec-override.yaml"
+ext_auth_vs_override_route_src = f"{TEST_DATA}/external-auth/route-subroute/virtual-server-vsr-route-override.yaml"
+
+# TLS VSR specs
+ext_auth_vsr_tls_src = f"{TEST_DATA}/external-auth/route-subroute/virtual-server-route-tls-subroute.yaml"
+ext_auth_vsr_tls_multi_src = f"{TEST_DATA}/external-auth/route-subroute/virtual-server-route-tls-multi-subroute.yaml"
+ext_auth_vs_tls_spec_override_src = (
+    f"{TEST_DATA}/external-auth/route-subroute/virtual-server-vsr-tls-spec-override.yaml"
+)
+ext_auth_vs_tls_route_override_src = (
+    f"{TEST_DATA}/external-auth/route-subroute/virtual-server-vsr-tls-route-override.yaml"
+)
+
+
+@pytest.mark.policies
+@pytest.mark.policies_external_auth
+@pytest.mark.policies_external_auth_vs
+@pytest.mark.parametrize(
+    "crd_ingress_controller, v_s_route_setup",
+    [
+        (
+            {
+                "type": "complete",
+                "extra_args": [
+                    f"-enable-custom-resources",
+                    f"-enable-leader-election=false",
+                ],
+            },
+            {"example": "virtual-server-route"},
+        )
+    ],
+    indirect=True,
+)
+class TestExternalAuthPoliciesVsr:
+    def teardown(self, kube_apis, namespace, secret_names, policy_names, v_s_route_setup):
+        """Delete policy, auth backend, secret and restore standard VSR."""
+        teardown_ext_auth(kube_apis, namespace, secret_names, policy_names)
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            std_vsr_src,
+            v_s_route_setup.route_m.namespace,
+        )
+
+    @pytest.mark.parametrize("credentials", [valid_credentials, invalid_credentials, None])
+    def test_external_auth_policy_credentials(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+        credentials,
+    ):
+        """
+        Test external-auth policy on VSR with valid credentials, invalid credentials, and no credentials.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            credentials,
+            [ext_auth_pol_valid_src],
+            v_s_route_setup.vs_host,
+        )
+
+        print(f"Patch vsr with policy: {ext_auth_vsr_valid_src}")
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_valid_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(resp.status_code)
+
+        self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
+
+        if credentials == valid_credentials:
+            assert resp.status_code == 200
+            assert "Request ID:" in resp.text
+        else:
+            assert resp.status_code == 401
+            assert "Authorization Required" in resp.text
+
+    @pytest.mark.smoke
+    def test_external_auth_policy_valid(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test external-auth policy on VSR with a valid policy is accepted and proxies correctly.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_valid_src],
+            v_s_route_setup.vs_host,
+        )
+
+        print(f"Patch vsr with policy: {ext_auth_vsr_valid_src}")
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_valid_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(resp.status_code)
+
+        policy_info = read_policy(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, policy_names[0])
+        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+
+        self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
+
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+        assert crd_info["status"]["state"] == "Valid"
+        assert (
+            policy_info["status"]
+            and policy_info["status"]["reason"] == "AddedOrUpdated"
+            and policy_info["status"]["state"] == "Valid"
+        )
+
+    @pytest.mark.smoke
+    def test_external_auth_policy_invalid_rejected_by_crd(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test that a policy with an invalid authURI (no leading slash) is rejected
+        at the CRD validation level by the Kubernetes API server.
+        """
+        with pytest.raises(ApiException) as exc_info:
+            create_policy_from_yaml(
+                kube_apis.custom_objects, ext_auth_pol_invalid_src, v_s_route_setup.route_m.namespace
+            )
+
+        assert exc_info.value.status == 422
+        assert "authURI" in exc_info.value.body
+
+    def test_external_auth_policy_nonexistent_svc(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test external-auth policy on VSR that references a non-existent service.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_invalid_svc_src],
+            v_s_route_setup.vs_host,
+        )
+
+        print(f"Patch vsr with policy: {ext_auth_vsr_invalid_svc_src}")
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_invalid_svc_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(resp.status_code)
+
+        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+
+        self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
+
+        assert resp.status_code == 500
+        assert "Internal Server Error" in resp.text
+        assert crd_info["status"]["state"] == "Warning"
+
+    def test_external_auth_policy_delete_policy(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test if requests result in 500 when the external auth policy is deleted.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_valid_src],
+            v_s_route_setup.vs_host,
+        )
+
+        print(f"Patch vsr with policy: {ext_auth_vsr_valid_src}")
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_valid_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(resp1.status_code)
+
+        delete_policy(kube_apis.custom_objects, policy_names[0], v_s_route_setup.route_m.namespace)
+        wait_before_test()
+
+        resp2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(resp2.status_code)
+
+        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+
+        delete_items_from_yaml(kube_apis, ext_auth_backend_src, v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[0], v_s_route_setup.route_m.namespace)
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            std_vsr_src,
+            v_s_route_setup.route_m.namespace,
+        )
+
+        assert resp1.status_code == 200
+        assert "Request ID:" in resp1.text
+        assert crd_info["status"]["state"] == "Warning"
+        assert f"{v_s_route_setup.route_m.namespace}/{policy_names[0]} is missing" in crd_info["status"]["message"]
+        assert resp2.status_code == 500
+        assert "Internal Server Error" in resp2.text
+
+    def test_external_auth_policy_override(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test if the first referenced policy takes precedence when multiple policies
+        are applied on the same subroute context.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_valid_src, ext_auth_pol_valid_multi_src],
+            v_s_route_setup.vs_host,
+        )
+
+        print(f"Patch vsr with override policies: {ext_auth_vsr_override_src}")
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_override_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(resp.status_code)
+
+        read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+
+        delete_policy(kube_apis.custom_objects, policy_names[0], v_s_route_setup.route_m.namespace)
+        delete_policy(kube_apis.custom_objects, policy_names[1], v_s_route_setup.route_m.namespace)
+        delete_items_from_yaml(kube_apis, ext_auth_backend_src, v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[0], v_s_route_setup.route_m.namespace)
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            std_vsr_src,
+            v_s_route_setup.route_m.namespace,
+        )
+
+        # Both policies reference the same auth backend, so with valid creds the first policy wins
+        # and the request should succeed
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+
+    @pytest.mark.parametrize("vs_src", [ext_auth_vs_override_route_src, ext_auth_vs_override_spec_src])
+    def test_external_auth_policy_override_vs_vsr(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+        vs_src,
+    ):
+        """
+        Test that a policy specified in vsr:subroute takes preference over a policy specified in:
+        1. vs:spec (policy at spec level)
+        2. vs:route (policy at route level)
+        Both policies reference the same external auth backend.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_valid_src, ext_auth_pol_valid_multi_src],
+            v_s_route_setup.vs_host,
+        )
+
+        print(f"Patch vsr with policy: {ext_auth_vsr_valid_multi_src}")
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_valid_multi_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        patch_virtual_server_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.vs_name,
+            vs_src,
+            v_s_route_setup.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            headers=headers,
+        )
+        print(resp.status_code)
+
+        delete_policy(kube_apis.custom_objects, policy_names[0], v_s_route_setup.route_m.namespace)
+        delete_policy(kube_apis.custom_objects, policy_names[1], v_s_route_setup.route_m.namespace)
+        delete_items_from_yaml(kube_apis, ext_auth_backend_src, v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[0], v_s_route_setup.route_m.namespace)
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            std_vsr_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        patch_virtual_server_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.vs_name,
+            std_vs_src,
+            v_s_route_setup.namespace,
+        )
+
+        # The subroute policy (valid-multi) should take precedence over VS-level policy (valid).
+        # Both reference the same backend, so request succeeds with valid creds.
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+
+
+@pytest.mark.policies
+@pytest.mark.policies_external_auth
+@pytest.mark.policies_external_auth_vs
+@pytest.mark.parametrize(
+    "crd_ingress_controller, v_s_route_setup",
+    [
+        (
+            {
+                "type": "complete",
+                "extra_args": [
+                    f"-enable-custom-resources",
+                    f"-enable-leader-election=false",
+                ],
+            },
+            {"example": "virtual-server-route"},
+        )
+    ],
+    indirect=True,
+)
+class TestExternalAuthPoliciesVsrTLS:
+    """TLS-specific external auth policy tests for VirtualServerRoute."""
+
+    def teardown(self, kube_apis, namespace, secret_names, policy_names, v_s_route_setup):
+        """Delete TLS policy, backend, all secrets, and restore standard VSR."""
+        teardown_ext_auth(kube_apis, namespace, secret_names, policy_names, tls=True)
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            std_vsr_src,
+            v_s_route_setup.route_m.namespace,
+        )
+
+    # ------------------------------------------------------------------
+    # Positive TLS tests
+    # ------------------------------------------------------------------
+
+    def test_tls_ssl_enabled_only(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test TLS with sslEnabled: true only (encryption, no verification).
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_tls_basic_src],
+            v_s_route_setup.vs_host,
+            tls=True,
+        )
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_tls_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
+
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+
+    @pytest.mark.smoke
+    def test_tls_full_verify(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test full TLS verification: sslEnabled + sslVerify + sslVerifyDepth + sniName + trustedCertSecret.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_tls_full_src],
+            v_s_route_setup.vs_host,
+            tls=True,
+        )
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_tls_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        policy_info = read_policy(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, policy_names[0])
+        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+
+        self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
+
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text
+        assert crd_info["status"]["state"] == "Valid"
+        assert (
+            policy_info["status"]
+            and policy_info["status"]["reason"] == "AddedOrUpdated"
+            and policy_info["status"]["state"] == "Valid"
+        )
+
+    @pytest.mark.parametrize("credentials", [valid_credentials, invalid_credentials, None])
+    def test_tls_credentials(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+        credentials,
+    ):
+        """
+        Test full TLS external auth with valid, invalid, and no credentials.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            credentials,
+            [ext_auth_pol_tls_full_src],
+            v_s_route_setup.vs_host,
+            tls=True,
+        )
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_tls_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
+
+        if credentials == valid_credentials:
+            assert resp.status_code == 200
+            assert "Request ID:" in resp.text
+        else:
+            assert resp.status_code == 401
+            assert "Authorization Required" in resp.text
+
+    # ------------------------------------------------------------------
+    # Controller error tests (VS Warning, HTTP 500)
+    # ------------------------------------------------------------------
+
+    def test_tls_nonexistent_ca_secret(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test TLS policy referencing a non-existent trustedCertSecret.
+        Controller rejects config: VSR Warning, HTTP 500.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_tls_nonexistent_ca_src],
+            v_s_route_setup.vs_host,
+            tls=True,
+        )
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_tls_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+        print(f"VSR state: {crd_info['status']['state']}")
+
+        self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
+
+        assert resp.status_code == 500
+        assert crd_info["status"]["state"] == "Warning"
+
+    def test_tls_wrong_ca_secret_type(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test TLS policy with trustedCertSecret pointing to a kubernetes.io/tls secret
+        instead of nginx.org/ca. Controller rejects: VSR Warning, HTTP 500.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_tls_wrong_ca_type_src],
+            v_s_route_setup.vs_host,
+            tls=True,
+        )
+
+        # Also create the wrong-type secret so it exists but has the wrong type
+        wrong_secret = create_secret_from_yaml(
+            kube_apis.v1, v_s_route_setup.route_m.namespace, ext_auth_tls_wrong_ca_src
+        )
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_tls_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+        print(f"VSR state: {crd_info['status']['state']}")
+
+        delete_secret(kube_apis.v1, wrong_secret, v_s_route_setup.route_m.namespace)
+        self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
+
+        assert resp.status_code == 500
+        assert crd_info["status"]["state"] == "Warning"
+
+    # ------------------------------------------------------------------
+    # Runtime TLS failure tests (VS Valid, HTTP 500 via auth_request)
+    # ------------------------------------------------------------------
+
+    def test_tls_bad_sni_name(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test TLS with mismatched sniName. Config is valid but TLS handshake fails at
+        runtime. NGINX auth_request returns 500 for subrequest failures.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_tls_bad_sni_src],
+            v_s_route_setup.vs_host,
+            tls=True,
+        )
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_tls_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+        print(f"VSR state: {crd_info['status']['state']}")
+
+        self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
+
+        assert resp.status_code == 500
+        assert crd_info["status"]["state"] == "Valid"
+
+    def test_tls_verify_no_trusted_cert(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test TLS with sslVerify: true but no trustedCertSecret. System CA bundle
+        cannot verify the self-signed cert, causing auth_request failure (500).
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_tls_no_trusted_cert_src],
+            v_s_route_setup.vs_host,
+            tls=True,
+        )
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_tls_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+        print(f"VSR state: {crd_info['status']['state']}")
+
+        self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
+
+        assert resp.status_code == 500
+        assert crd_info["status"]["state"] == "Valid"
+
+    # ------------------------------------------------------------------
+    # Lifecycle / destructive tests
+    # ------------------------------------------------------------------
+
+    def test_tls_delete_policy(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test that requests return 500 after the TLS external auth policy is deleted.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_tls_full_src],
+            v_s_route_setup.vs_host,
+            tls=True,
+        )
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_tls_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"Before delete: {resp1.status_code}")
+
+        delete_policy(kube_apis.custom_objects, policy_names[0], v_s_route_setup.route_m.namespace)
+        wait_before_test()
+
+        resp2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"After delete: {resp2.status_code}")
+
+        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+
+        delete_items_from_yaml(kube_apis, ext_auth_tls_backend_src, v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[0], v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[1], v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[2], v_s_route_setup.route_m.namespace)
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            std_vsr_src,
+            v_s_route_setup.route_m.namespace,
+        )
+
+        assert resp1.status_code == 200
+        assert "Request ID:" in resp1.text
+        assert crd_info["status"]["state"] == "Warning"
+        assert f"{v_s_route_setup.route_m.namespace}/{policy_names[0]} is missing" in crd_info["status"]["message"]
+        assert resp2.status_code == 500
+
+    def test_tls_delete_backend(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+    ):
+        """
+        Test that requests fail after the TLS external auth backend service is deleted.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_tls_full_src],
+            v_s_route_setup.vs_host,
+            tls=True,
+        )
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_tls_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp1 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"Before delete: {resp1.status_code}")
+
+        print("Delete TLS external auth backend")
+        delete_items_from_yaml(kube_apis, ext_auth_tls_backend_src, v_s_route_setup.route_m.namespace)
+        wait_before_test()
+
+        resp2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"After delete: {resp2.status_code}")
+
+        # Clean up (backend already deleted above)
+        delete_policy(kube_apis.custom_objects, policy_names[0], v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[0], v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[1], v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[2], v_s_route_setup.route_m.namespace)
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            std_vsr_src,
+            v_s_route_setup.route_m.namespace,
+        )
+
+        assert resp1.status_code == 200
+        assert "Request ID:" in resp1.text
+        assert resp2.status_code == 500
+
+    # ------------------------------------------------------------------
+    # Override / precedence test
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vs_src", [ext_auth_vs_tls_route_override_src, ext_auth_vs_tls_spec_override_src])
+    def test_tls_policy_override_vs_vsr(
+        self,
+        kube_apis,
+        crd_ingress_controller,
+        v_s_route_app_setup,
+        v_s_route_setup,
+        test_namespace,
+        vs_src,
+    ):
+        """
+        Test that a TLS policy on VSR subroute takes precedence over a TLS policy
+        specified at VS spec or VS route level.
+        """
+        req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
+        secret_names, policy_names, headers = setup_ext_auth(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            valid_credentials,
+            [ext_auth_pol_tls_full_src, ext_auth_pol_tls_full_multi_src],
+            v_s_route_setup.vs_host,
+            tls=True,
+        )
+
+        print(f"Patch vsr with TLS multi policy: {ext_auth_vsr_tls_multi_src}")
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            ext_auth_vsr_tls_multi_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        patch_virtual_server_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.vs_name,
+            vs_src,
+            v_s_route_setup.namespace,
+        )
+        wait_before_test()
+        ensure_response_from_backend(
+            f"{req_url}{v_s_route_setup.route_m.paths[0]}",
+            v_s_route_setup.vs_host,
+            additional_headers=valid_auth_headers(),
+        )
+
+        resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
+        print(f"Status: {resp.status_code}")
+
+        delete_policy(kube_apis.custom_objects, policy_names[0], v_s_route_setup.route_m.namespace)
+        delete_policy(kube_apis.custom_objects, policy_names[1], v_s_route_setup.route_m.namespace)
+        delete_items_from_yaml(kube_apis, ext_auth_tls_backend_src, v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[0], v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[1], v_s_route_setup.route_m.namespace)
+        delete_secret(kube_apis.v1, secret_names[2], v_s_route_setup.route_m.namespace)
+
+        patch_v_s_route_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.route_m.name,
+            std_vsr_src,
+            v_s_route_setup.route_m.namespace,
+        )
+        patch_virtual_server_from_yaml(
+            kube_apis.custom_objects,
+            v_s_route_setup.vs_name,
+            std_vs_src,
+            v_s_route_setup.namespace,
+        )
+
+        # The subroute TLS policy (tls-multi) should take precedence over VS-level TLS policy (tls).
+        # Both reference the same auth backend, so request succeeds with valid creds.
+        assert resp.status_code == 200
+        assert "Request ID:" in resp.text

--- a/tests/suite/test_external_auth_policies_vsr.py
+++ b/tests/suite/test_external_auth_policies_vsr.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 from kubernetes.client.rest import ApiException
 from settings import TEST_DATA
+from suite.utils.custom_assertions import assert_valid_vsr, assert_vsr_status
 from suite.utils.external_auth_utils import (
     ext_auth_backend_src,
     ext_auth_pol_invalid_src,
@@ -31,7 +32,7 @@ from suite.utils.resources_utils import (
     ensure_response_from_backend,
     wait_before_test,
 )
-from suite.utils.vs_vsr_resources_utils import patch_v_s_route_from_yaml, patch_virtual_server_from_yaml, read_vsr
+from suite.utils.vs_vsr_resources_utils import patch_v_s_route_from_yaml, patch_virtual_server_from_yaml
 
 std_vs_src = f"{TEST_DATA}/virtual-server-route/standard/virtual-server.yaml"
 std_vsr_src = f"{TEST_DATA}/virtual-server-route/route-multiple.yaml"
@@ -176,13 +177,12 @@ class TestExternalAuthPoliciesVsr:
         print(resp.status_code)
 
         policy_info = read_policy(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, policy_names[0])
-        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+        assert_valid_vsr(kube_apis, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
 
         self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
 
         assert resp.status_code == 200
         assert "Request ID:" in resp.text
-        assert crd_info["status"]["state"] == "Valid"
         assert (
             policy_info["status"]
             and policy_info["status"]["reason"] == "AddedOrUpdated"
@@ -242,13 +242,12 @@ class TestExternalAuthPoliciesVsr:
         resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
         print(resp.status_code)
 
-        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+        assert_vsr_status(kube_apis, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name, "Warning")
 
         self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
 
         assert resp.status_code == 500
         assert "Internal Server Error" in resp.text
-        assert crd_info["status"]["state"] == "Warning"
 
     def test_external_auth_policy_delete_policy(
         self,
@@ -293,7 +292,13 @@ class TestExternalAuthPoliciesVsr:
         resp2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
         print(resp2.status_code)
 
-        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+        assert_vsr_status(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            v_s_route_setup.route_m.name,
+            "Warning",
+            expected_messages=[f"{v_s_route_setup.route_m.namespace}/{policy_names[0]} is missing"],
+        )
 
         delete_items_from_yaml(kube_apis, ext_auth_backend_src, v_s_route_setup.route_m.namespace)
         delete_secret(kube_apis.v1, secret_names[0], v_s_route_setup.route_m.namespace)
@@ -306,8 +311,6 @@ class TestExternalAuthPoliciesVsr:
 
         assert resp1.status_code == 200
         assert "Request ID:" in resp1.text
-        assert crd_info["status"]["state"] == "Warning"
-        assert f"{v_s_route_setup.route_m.namespace}/{policy_names[0]} is missing" in crd_info["status"]["message"]
         assert resp2.status_code == 500
         assert "Internal Server Error" in resp2.text
 
@@ -348,8 +351,6 @@ class TestExternalAuthPoliciesVsr:
 
         resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
         print(resp.status_code)
-
-        read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
 
         delete_policy(kube_apis.custom_objects, policy_names[0], v_s_route_setup.route_m.namespace)
         delete_policy(kube_apis.custom_objects, policy_names[1], v_s_route_setup.route_m.namespace)
@@ -561,13 +562,12 @@ class TestExternalAuthPoliciesVsrTLS:
         print(f"Status: {resp.status_code}")
 
         policy_info = read_policy(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, policy_names[0])
-        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+        assert_valid_vsr(kube_apis, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
 
         self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
 
         assert resp.status_code == 200
         assert "Request ID:" in resp.text
-        assert crd_info["status"]["state"] == "Valid"
         assert (
             policy_info["status"]
             and policy_info["status"]["reason"] == "AddedOrUpdated"
@@ -659,13 +659,11 @@ class TestExternalAuthPoliciesVsrTLS:
         resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
         print(f"Status: {resp.status_code}")
 
-        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
-        print(f"VSR state: {crd_info['status']['state']}")
+        assert_vsr_status(kube_apis, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name, "Warning")
 
         self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
 
         assert resp.status_code == 500
-        assert crd_info["status"]["state"] == "Warning"
 
     def test_tls_wrong_ca_secret_type(
         self,
@@ -705,14 +703,12 @@ class TestExternalAuthPoliciesVsrTLS:
         resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
         print(f"Status: {resp.status_code}")
 
-        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
-        print(f"VSR state: {crd_info['status']['state']}")
+        assert_vsr_status(kube_apis, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name, "Warning")
 
         delete_secret(kube_apis.v1, wrong_secret, v_s_route_setup.route_m.namespace)
         self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
 
         assert resp.status_code == 500
-        assert crd_info["status"]["state"] == "Warning"
 
     # ------------------------------------------------------------------
     # Runtime TLS failure tests (VS Valid, HTTP 500 via auth_request)
@@ -751,13 +747,11 @@ class TestExternalAuthPoliciesVsrTLS:
         resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
         print(f"Status: {resp.status_code}")
 
-        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
-        print(f"VSR state: {crd_info['status']['state']}")
+        assert_valid_vsr(kube_apis, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
 
         self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
 
         assert resp.status_code == 500
-        assert crd_info["status"]["state"] == "Valid"
 
     def test_tls_verify_no_trusted_cert(
         self,
@@ -792,13 +786,11 @@ class TestExternalAuthPoliciesVsrTLS:
         resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
         print(f"Status: {resp.status_code}")
 
-        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
-        print(f"VSR state: {crd_info['status']['state']}")
+        assert_valid_vsr(kube_apis, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
 
         self.teardown(kube_apis, v_s_route_setup.route_m.namespace, secret_names, policy_names, v_s_route_setup)
 
         assert resp.status_code == 500
-        assert crd_info["status"]["state"] == "Valid"
 
     # ------------------------------------------------------------------
     # Lifecycle / destructive tests
@@ -847,7 +839,13 @@ class TestExternalAuthPoliciesVsrTLS:
         resp2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers)
         print(f"After delete: {resp2.status_code}")
 
-        crd_info = read_vsr(kube_apis.custom_objects, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name)
+        assert_vsr_status(
+            kube_apis,
+            v_s_route_setup.route_m.namespace,
+            v_s_route_setup.route_m.name,
+            "Warning",
+            expected_messages=[f"{v_s_route_setup.route_m.namespace}/{policy_names[0]} is missing"],
+        )
 
         delete_items_from_yaml(kube_apis, ext_auth_tls_backend_src, v_s_route_setup.route_m.namespace)
         delete_secret(kube_apis.v1, secret_names[0], v_s_route_setup.route_m.namespace)
@@ -862,8 +860,6 @@ class TestExternalAuthPoliciesVsrTLS:
 
         assert resp1.status_code == 200
         assert "Request ID:" in resp1.text
-        assert crd_info["status"]["state"] == "Warning"
-        assert f"{v_s_route_setup.route_m.namespace}/{policy_names[0]} is missing" in crd_info["status"]["message"]
         assert resp2.status_code == 500
 
     def test_tls_delete_backend(

--- a/tests/suite/test_external_auth_policies_vsr.py
+++ b/tests/suite/test_external_auth_policies_vsr.py
@@ -445,6 +445,7 @@ class TestExternalAuthPoliciesVsr:
 
 @pytest.mark.policies
 @pytest.mark.policies_external_auth
+@pytest.mark.policies_external_auth_tls
 @pytest.mark.policies_external_auth_vs
 @pytest.mark.parametrize(
     "crd_ingress_controller, v_s_route_setup",

--- a/tests/suite/test_v_s_route.py
+++ b/tests/suite/test_v_s_route.py
@@ -5,6 +5,7 @@ from settings import TEST_DATA
 from suite.utils.custom_assertions import (
     assert_event_and_count,
     assert_event_and_get_count,
+    assert_event_count_increased,
     assert_event_with_full_equality_and_count,
     assert_valid_vs,
     assert_valid_vsr,
@@ -13,8 +14,10 @@ from suite.utils.resources_utils import (
     create_service_with_name,
     delete_service,
     get_events,
+    get_events_for_object,
     get_first_pod_name,
     get_vs_nginx_template_conf,
+    print_events,
     read_service,
     replace_service,
     wait_before_test,
@@ -58,10 +61,21 @@ def assert_locations_not_in_config(config, paths):
     indirect=True,
 )
 class TestVirtualServerRoute:
-    @pytest.mark.flaky(max_runs=3)
     def test_responses_and_events_in_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup, v_s_route_app_setup
     ):
+        assert_valid_vs(
+            kube_apis,
+            v_s_route_setup.namespace,
+            v_s_route_setup.vs_name,
+        )
+
+        assert_valid_vsr(
+            kube_apis,
+            v_s_route_setup.route_s.namespace,
+            v_s_route_setup.route_s.name,
+        )
+
         req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
         ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
         vs_name = f"{v_s_route_setup.namespace}/{v_s_route_setup.vs_name}"
@@ -83,14 +97,22 @@ class TestVirtualServerRoute:
         resp_1 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers={"host": v_s_route_setup.vs_host})
         resp_2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[1]}", headers={"host": v_s_route_setup.vs_host})
         resp_3 = requests.get(f"{req_url}{v_s_route_setup.route_s.paths[0]}", headers={"host": v_s_route_setup.vs_host})
-        events_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
-        events_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
+        events_vsr_1 = get_events_for_object(
+            kube_apis.v1, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name
+        )
+        events_vs = get_events_for_object(kube_apis.v1, v_s_route_setup.namespace, v_s_route_setup.vs_name)
+        events_vsr_2 = get_events_for_object(
+            kube_apis.v1, v_s_route_setup.route_s.namespace, v_s_route_setup.route_s.name
+        )
+        print_events(events_vsr_1)
+        print_events(events_vs)
+        print_events(events_vsr_2)
         assert_responses_and_server_name(resp_1, resp_2, resp_3)
         assert_locations_in_config(initial_config, v_s_route_setup.route_m.paths)
         assert_locations_in_config(initial_config, v_s_route_setup.route_s.paths)
-        initial_count_vsr_1 = assert_event_and_get_count(vsr_1_event_text, events_ns_1)
-        initial_count_vs = assert_event_and_get_count(vs_event_text, events_ns_1)
-        initial_count_vsr_2 = assert_event_and_get_count(vsr_2_event_text, events_ns_2)
+        initial_count_vsr_1 = assert_event_and_get_count(vsr_1_event_text, events_vsr_1)
+        initial_count_vs = assert_event_and_get_count(vs_event_text, events_vs)
+        initial_count_vsr_2 = assert_event_and_get_count(vsr_2_event_text, events_vsr_2)
 
         print("\nStep 2: update multiple VSRoute and check")
         patch_v_s_route_from_yaml(
@@ -105,12 +127,20 @@ class TestVirtualServerRoute:
         resp_2 = requests.get(f"{req_url}{new_vsr_paths[1]}", headers={"host": v_s_route_setup.vs_host})
         resp_3 = requests.get(f"{req_url}{v_s_route_setup.route_s.paths[0]}", headers={"host": v_s_route_setup.vs_host})
         assert_responses_and_server_name(resp_1, resp_2, resp_3)
-        events_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
-        events_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        assert_event_and_count(vsr_1_event_text, initial_count_vsr_1 + 1, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 1, events_ns_1)
+        events_vsr_1 = get_events_for_object(
+            kube_apis.v1, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name
+        )
+        events_vs = get_events_for_object(kube_apis.v1, v_s_route_setup.namespace, v_s_route_setup.vs_name)
+        events_vsr_2 = get_events_for_object(
+            kube_apis.v1, v_s_route_setup.route_s.namespace, v_s_route_setup.route_s.name
+        )
+        print_events(events_vsr_1)
+        print_events(events_vs)
+        print_events(events_vsr_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, initial_count_vsr_1, events_vsr_1)
+        current_vs_count = assert_event_count_increased(vs_event_text, initial_count_vs, events_vs)
         # 2nd VSRoute gets an event about update too
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 1, events_ns_2)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, initial_count_vsr_2, events_vsr_2)
 
         print("\nStep 3: restore VSRoute and check")
         patch_v_s_route_from_yaml(
@@ -124,11 +154,19 @@ class TestVirtualServerRoute:
         resp_2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[1]}", headers={"host": v_s_route_setup.vs_host})
         resp_3 = requests.get(f"{req_url}{v_s_route_setup.route_s.paths[0]}", headers={"host": v_s_route_setup.vs_host})
         assert_responses_and_server_name(resp_1, resp_2, resp_3)
-        events_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
-        events_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        assert_event_and_count(vsr_1_event_text, initial_count_vsr_1 + 2, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 2, events_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 2, events_ns_2)
+        events_vsr_1 = get_events_for_object(
+            kube_apis.v1, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name
+        )
+        events_vs = get_events_for_object(kube_apis.v1, v_s_route_setup.namespace, v_s_route_setup.vs_name)
+        events_vsr_2 = get_events_for_object(
+            kube_apis.v1, v_s_route_setup.route_s.namespace, v_s_route_setup.route_s.name
+        )
+        print_events(events_vsr_1)
+        print_events(events_vs)
+        print_events(events_vsr_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, events_vsr_1)
+        current_vs_count = assert_event_count_increased(vs_event_text, current_vs_count, events_vs)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_vsr_2)
 
         print("\nStep 4: update one backend service port and check")
         svc_1 = read_service(kube_apis.v1, "backend1-svc", v_s_route_setup.route_m.namespace)
@@ -139,11 +177,19 @@ class TestVirtualServerRoute:
         resp_2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[1]}", headers={"host": v_s_route_setup.vs_host})
         assert resp_1.status_code == 502
         assert resp_2.status_code == 200
-        events_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
-        events_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        assert_event_and_count(vsr_1_event_text, initial_count_vsr_1 + 3, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 3, events_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 3, events_ns_2)
+        events_vsr_1 = get_events_for_object(
+            kube_apis.v1, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name
+        )
+        events_vs = get_events_for_object(kube_apis.v1, v_s_route_setup.namespace, v_s_route_setup.vs_name)
+        events_vsr_2 = get_events_for_object(
+            kube_apis.v1, v_s_route_setup.route_s.namespace, v_s_route_setup.route_s.name
+        )
+        print_events(events_vsr_1)
+        print_events(events_vs)
+        print_events(events_vsr_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, events_vsr_1)
+        current_vs_count = assert_event_count_increased(vs_event_text, current_vs_count, events_vs)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_vsr_2)
 
         print("\nStep 5: restore backend service and check")
         svc_1 = read_service(kube_apis.v1, "backend1-svc", v_s_route_setup.route_m.namespace)
@@ -154,11 +200,19 @@ class TestVirtualServerRoute:
         resp_2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[1]}", headers={"host": v_s_route_setup.vs_host})
         assert resp_1.status_code == 200
         assert resp_2.status_code == 200
-        events_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
-        events_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        assert_event_and_count(vsr_1_event_text, initial_count_vsr_1 + 4, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 4, events_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 4, events_ns_2)
+        events_vsr_1 = get_events_for_object(
+            kube_apis.v1, v_s_route_setup.route_m.namespace, v_s_route_setup.route_m.name
+        )
+        events_vs = get_events_for_object(kube_apis.v1, v_s_route_setup.namespace, v_s_route_setup.vs_name)
+        events_vsr_2 = get_events_for_object(
+            kube_apis.v1, v_s_route_setup.route_s.namespace, v_s_route_setup.route_s.name
+        )
+        print_events(events_vsr_1)
+        print_events(events_vs)
+        print_events(events_vsr_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, events_vsr_1)
+        current_vs_count = assert_event_count_increased(vs_event_text, current_vs_count, events_vs)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_vsr_2)
 
         print("\nStep 6: remove VSRoute and check")
         delete_v_s_route(kube_apis.custom_objects, v_s_route_setup.route_m.name, v_s_route_setup.namespace)
@@ -179,11 +233,12 @@ class TestVirtualServerRoute:
         events_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
         events_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
         assert_locations_not_in_config(new_config, v_s_route_setup.route_m.paths)
-        assert_event_and_count(vsr_1_event_text, initial_count_vsr_1 + 4, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 4, events_ns_1)
+        # reset count to 0 because we want to check that the event is added, not just updated, and the event is about deletion of the VSRoute, not about update, so count is not increased but just set to 0 because the event is updated, not added
+        current_vsr1_count = assert_event_and_get_count(vsr_1_event_text, events_ns_1)
+        current_vs_count = assert_event_and_get_count(vs_event_text, events_ns_1)
         # a warning event because the VS references a non-existing VSR
         assert_event_with_full_equality_and_count(vs_warning_event_text, 1, events_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 5, events_ns_2)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_ns_2)
 
         print("\nStep 7: restore VSRoute and check")
         create_v_s_route_from_yaml(
@@ -204,9 +259,12 @@ class TestVirtualServerRoute:
         events_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
         events_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
         assert_locations_in_config(new_config, v_s_route_setup.route_m.paths)
-        assert_event_and_count(vsr_1_event_text, 1, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 5, events_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 6, events_ns_2)
+        # reset count to 1 because we want to check that the event is added, not just updated
+        current_vsr1_count = assert_event_and_get_count(vsr_1_event_text, events_ns_1)
+        # restore of the VSRoute gets an event about update but not about add, so count is not increased but just set to 1 because the event is updated, not added
+        current_vs_count = assert_event_and_get_count(vs_event_text, events_ns_1)
+        # restore of the 2nd VSRoute gets an event about update too
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_ns_2)
 
         print("\nStep 8: remove one backend service and check")
         delete_service(kube_apis.v1, "backend1-svc", v_s_route_setup.route_m.namespace)
@@ -219,9 +277,9 @@ class TestVirtualServerRoute:
         assert resp_3.status_code == 200
         events_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
         events_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        assert_event_and_count(vsr_1_event_text, 2, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 6, events_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 7, events_ns_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, events_ns_1)
+        current_vs_count = assert_event_and_get_count(vs_event_text, events_ns_1)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_ns_2)
 
         print("\nStep 9: restore backend service and check")
         create_service_with_name(kube_apis.v1, v_s_route_setup.route_m.namespace, "backend1-svc")
@@ -232,9 +290,9 @@ class TestVirtualServerRoute:
         assert_responses_and_server_name(resp_1, resp_2, resp_3)
         events_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
         events_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        assert_event_and_count(vsr_1_event_text, 3, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 7, events_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 8, events_ns_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, events_ns_1)
+        current_vs_count = assert_event_and_get_count(vs_event_text, events_ns_1)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_ns_2)
 
         print("\nStep 10: remove VS and check")
         delete_virtual_server(kube_apis.custom_objects, v_s_route_setup.vs_name, v_s_route_setup.namespace)
@@ -247,9 +305,9 @@ class TestVirtualServerRoute:
         assert resp_3.status_code == 404
         list0_list_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
         list0_list_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        assert_event_and_count(vsr_1_event_text, 3, list0_list_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 7, list0_list_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 8, list0_list_ns_2)
+        current_vsr1_count = assert_event_and_get_count(vsr_1_event_text, list0_list_ns_1)
+        current_vs_count = assert_event_and_get_count(vs_event_text, list0_list_ns_1)
+        current_vsr2_count = assert_event_and_get_count(vsr_2_event_text, list0_list_ns_2)
 
         print("\nStep 11: restore VS and check")
         create_virtual_server_from_yaml(
@@ -264,9 +322,9 @@ class TestVirtualServerRoute:
         assert_responses_and_server_name(resp_1, resp_2, resp_3)
         list1_list_ns_1 = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
         list1_list_ns_2 = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        assert_event_and_count(vsr_1_event_text, 4, list1_list_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, 1, list1_list_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 9, list1_list_ns_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, list1_list_ns_1)
+        current_vs_count = assert_event_and_get_count(vs_event_text, list1_list_ns_1)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, list1_list_ns_2)
 
 
 @pytest.mark.vsr
@@ -459,7 +517,6 @@ class TestVirtualServerRouteSelector:
         vsr_2_name = f"{v_s_route_selector_setup.route_s.namespace}/{v_s_route_selector_setup.route_s.name}"
         vsr_1_event_text = f"Configuration for {vsr_1_name} was added or updated"
         vs_event_text = f"Configuration for {vs_name} was added or updated"
-        vs_warning_event_text = f"Configuration for {vs_name} was added or updated with warning(s): VirtualServerRoute {vsr_1_name} doesn't exist or invalid"
         vsr_2_event_text = f"Configuration for {vsr_2_name} was added or updated"
         initial_config = get_vs_nginx_template_conf(
             kube_apis.v1,
@@ -480,17 +537,24 @@ class TestVirtualServerRouteSelector:
         resp_3 = requests.get(
             f"{req_url}{v_s_route_selector_setup.route_s.paths[0]}", headers={"host": v_s_route_selector_setup.vs_host}
         )
-        events_ns_1 = get_events(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
-        events_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
-        events_vs = get_events(kube_apis.v1, v_s_route_selector_setup.namespace)
+        events_vsr_1 = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.route_m.namespace, v_s_route_selector_setup.route_m.name
+        )
+        events_vs = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.namespace, v_s_route_selector_setup.vs_name
+        )
+        events_vsr_2 = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.route_s.namespace, v_s_route_selector_setup.route_s.name
+        )
+        print_events(events_vsr_1)
+        print_events(events_vs)
+        print_events(events_vsr_2)
         assert_responses_and_server_name(resp_1, resp_2, resp_3)
         assert_locations_in_config(initial_config, v_s_route_selector_setup.route_m.paths)
         assert_locations_in_config(initial_config, v_s_route_selector_setup.route_s.paths)
-        initial_count_vsr_1 = assert_event_and_get_count(vsr_1_event_text, events_ns_1)
+        initial_count_vsr_1 = assert_event_and_get_count(vsr_1_event_text, events_vsr_1)
         initial_count_vs = assert_event_and_get_count(vs_event_text, events_vs)
-        initial_count_vsr_2 = assert_event_and_get_count(vsr_2_event_text, events_ns_2)
-
-        print(f"{initial_count_vsr_1}, {initial_count_vs}, {initial_count_vsr_2}, {vs_warning_event_text}")
+        initial_count_vsr_2 = assert_event_and_get_count(vsr_2_event_text, events_vsr_2)
 
         print("\nStep 2: update multiple VSRoute and check")
         patch_v_s_route_from_yaml(
@@ -507,13 +571,22 @@ class TestVirtualServerRouteSelector:
             f"{req_url}{v_s_route_selector_setup.route_s.paths[0]}", headers={"host": v_s_route_selector_setup.vs_host}
         )
         assert_responses_and_server_name(resp_1, resp_2, resp_3)
-        events_ns_1 = get_events(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
-        events_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
-        events_vs = get_events(kube_apis.v1, v_s_route_selector_setup.namespace)
-        assert_event_and_count(vsr_1_event_text, initial_count_vsr_1 + 1, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 1, events_vs)
+        events_vsr_1 = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.route_m.namespace, v_s_route_selector_setup.route_m.name
+        )
+        events_vs = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.namespace, v_s_route_selector_setup.vs_name
+        )
+        events_vsr_2 = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.route_s.namespace, v_s_route_selector_setup.route_s.name
+        )
+        print_events(events_vsr_1)
+        print_events(events_vs)
+        print_events(events_vsr_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, initial_count_vsr_1, events_vsr_1)
+        current_vs_count = assert_event_count_increased(vs_event_text, initial_count_vs, events_vs)
         # 2nd VSRoute gets an event about update too
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 1, events_ns_2)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, initial_count_vsr_2, events_vsr_2)
 
         print("\nStep 3: restore VSRoute and check")
         patch_v_s_route_from_yaml(
@@ -533,12 +606,21 @@ class TestVirtualServerRouteSelector:
             f"{req_url}{v_s_route_selector_setup.route_s.paths[0]}", headers={"host": v_s_route_selector_setup.vs_host}
         )
         assert_responses_and_server_name(resp_1, resp_2, resp_3)
-        events_ns_1 = get_events(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
-        events_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
-        events_vs = get_events(kube_apis.v1, v_s_route_selector_setup.namespace)
-        assert_event_and_count(vsr_1_event_text, initial_count_vsr_1 + 2, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 2, events_vs)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 2, events_ns_2)
+        events_vsr_1 = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.route_m.namespace, v_s_route_selector_setup.route_m.name
+        )
+        events_vs = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.namespace, v_s_route_selector_setup.vs_name
+        )
+        events_vsr_2 = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.route_s.namespace, v_s_route_selector_setup.route_s.name
+        )
+        print_events(events_vsr_1)
+        print_events(events_vs)
+        print_events(events_vsr_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, events_vsr_1)
+        current_vs_count = assert_event_count_increased(vs_event_text, current_vs_count, events_vs)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_vsr_2)
 
         print("\nStep 4: update one backend service port and check")
         svc_1 = read_service(kube_apis.v1, "backend1-svc", v_s_route_selector_setup.route_m.namespace)
@@ -553,12 +635,21 @@ class TestVirtualServerRouteSelector:
         )
         assert resp_1.status_code == 502
         assert resp_2.status_code == 200
-        events_ns_1 = get_events(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
-        events_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
-        events_vs = get_events(kube_apis.v1, v_s_route_selector_setup.namespace)
-        assert_event_and_count(vsr_1_event_text, initial_count_vsr_1 + 3, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 3, events_vs)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 3, events_ns_2)
+        events_vsr_1 = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.route_m.namespace, v_s_route_selector_setup.route_m.name
+        )
+        events_vs = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.namespace, v_s_route_selector_setup.vs_name
+        )
+        events_vsr_2 = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.route_s.namespace, v_s_route_selector_setup.route_s.name
+        )
+        print_events(events_vsr_1)
+        print_events(events_vs)
+        print_events(events_vsr_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, events_vsr_1)
+        current_vs_count = assert_event_count_increased(vs_event_text, current_vs_count, events_vs)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_vsr_2)
 
         print("\nStep 5: restore backend service and check")
         svc_1 = read_service(kube_apis.v1, "backend1-svc", v_s_route_selector_setup.route_m.namespace)
@@ -573,12 +664,21 @@ class TestVirtualServerRouteSelector:
         )
         assert resp_1.status_code == 200
         assert resp_2.status_code == 200
-        events_ns_1 = get_events(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
-        events_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
-        events_vs = get_events(kube_apis.v1, v_s_route_selector_setup.namespace)
-        assert_event_and_count(vsr_1_event_text, initial_count_vsr_1 + 4, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 4, events_vs)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 4, events_ns_2)
+        events_vsr_1 = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.route_m.namespace, v_s_route_selector_setup.route_m.name
+        )
+        events_vs = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.namespace, v_s_route_selector_setup.vs_name
+        )
+        events_vsr_2 = get_events_for_object(
+            kube_apis.v1, v_s_route_selector_setup.route_s.namespace, v_s_route_selector_setup.route_s.name
+        )
+        print_events(events_vsr_1)
+        print_events(events_vs)
+        print_events(events_vsr_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, events_vsr_1)
+        current_vs_count = assert_event_count_increased(vs_event_text, current_vs_count, events_vs)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_vsr_2)
 
         print("\nStep 6: remove VSRoute and check")
         delete_v_s_route(
@@ -607,11 +707,8 @@ class TestVirtualServerRouteSelector:
         events_ns_1 = get_events(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
         events_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
         assert_locations_not_in_config(new_config, v_s_route_selector_setup.route_m.paths)
-        assert_event_and_count(vsr_1_event_text, initial_count_vsr_1 + 4, events_ns_1)
-        # assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 4, events_ns_1)
-        # # a warning event because the VS references a non-existing VSR
-        # assert_event_with_full_equality_and_count(vs_warning_event_text, 1, events_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 5, events_ns_2)
+        current_vsr1_count = assert_event_and_get_count(vsr_1_event_text, events_ns_1)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_ns_2)
 
         print("\nStep 7: restore VSRoute and check")
         create_v_s_route_from_yaml(
@@ -641,9 +738,9 @@ class TestVirtualServerRouteSelector:
         events_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
         events_vs = get_events(kube_apis.v1, v_s_route_selector_setup.namespace)
         assert_locations_in_config(new_config, v_s_route_selector_setup.route_m.paths)
-        assert_event_and_count(vsr_1_event_text, 1, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 6, events_vs)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 6, events_ns_2)
+        current_vsr1_count = assert_event_and_get_count(vsr_1_event_text, events_ns_1)
+        current_vs_count = assert_event_and_get_count(vs_event_text, events_vs)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_ns_2)
 
         print("\nStep 8: remove one backend service and check")
         delete_service(kube_apis.v1, "backend1-svc", v_s_route_selector_setup.route_m.namespace)
@@ -663,9 +760,9 @@ class TestVirtualServerRouteSelector:
         events_ns_1 = get_events(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
         events_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
         events_vs = get_events(kube_apis.v1, v_s_route_selector_setup.namespace)
-        assert_event_and_count(vsr_1_event_text, 2, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 7, events_vs)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 7, events_ns_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, events_ns_1)
+        current_vs_count = assert_event_and_get_count(vs_event_text, events_vs)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_ns_2)
 
         print("\nStep 9: restore backend service and check")
         create_service_with_name(kube_apis.v1, v_s_route_selector_setup.route_m.namespace, "backend1-svc")
@@ -683,9 +780,9 @@ class TestVirtualServerRouteSelector:
         events_ns_1 = get_events(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
         events_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
         events_vs = get_events(kube_apis.v1, v_s_route_selector_setup.namespace)
-        assert_event_and_count(vsr_1_event_text, 3, events_ns_1)
-        assert_event_with_full_equality_and_count(vs_event_text, initial_count_vs + 8, events_vs)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 8, events_ns_2)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, events_ns_1)
+        current_vs_count = assert_event_and_get_count(vs_event_text, events_vs)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, events_ns_2)
 
         print("\nStep 10: remove VS and check")
         delete_virtual_server(
@@ -706,8 +803,8 @@ class TestVirtualServerRouteSelector:
         assert resp_3.status_code == 404
         list0_list_ns_1 = get_events(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
         list0_list_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
-        assert_event_and_count(vsr_1_event_text, 3, list0_list_ns_1)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 8, list0_list_ns_2)
+        current_vsr1_count = assert_event_and_get_count(vsr_1_event_text, list0_list_ns_1)
+        current_vsr2_count = assert_event_and_get_count(vsr_2_event_text, list0_list_ns_2)
 
         print("\nStep 11: restore VS and check")
         create_virtual_server_from_yaml(
@@ -728,6 +825,6 @@ class TestVirtualServerRouteSelector:
         assert_responses_and_server_name(resp_1, resp_2, resp_3)
         list1_list_ns_1 = get_events(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
         list1_list_ns_2 = get_events(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
-        assert_event_and_count(vsr_1_event_text, 4, list1_list_ns_1)
+        current_vsr1_count = assert_event_count_increased(vsr_1_event_text, current_vsr1_count, list1_list_ns_1)
         assert_event_with_full_equality_and_count(vs_event_text, 1, list1_list_ns_2)
-        assert_event_and_count(vsr_2_event_text, initial_count_vsr_2 + 9, list1_list_ns_2)
+        current_vsr2_count = assert_event_count_increased(vsr_2_event_text, current_vsr2_count, list1_list_ns_2)

--- a/tests/suite/utils/custom_assertions.py
+++ b/tests/suite/utils/custom_assertions.py
@@ -21,19 +21,19 @@ def assert_no_new_events(old_list, new_list):
             pytest.fail(f'Expected: no new events. There is a new event found:"{new_list[i].message}". Exiting...')
 
 
-def assert_event_count_increased(event_text, count, events_list) -> None:
+def assert_event_count_increased(event_text, count, events_list) -> int:
     """
-    Search for the event in the list and verify its counter is more than the expected value.
+    Search for the event in the list and verify its counter is more than the expected value, return the new count.
 
     :param event_text: event text
     :param count: expected value
     :param events_list: list of events
-    :return:
+    :return: event.count
     """
     for i in range(len(events_list) - 1, -1, -1):
         if event_text in events_list[i].message:
             assert events_list[i].count > count
-            return
+            return events_list[i].count
     pytest.fail(f'Failed to find the event "{event_text}" in the list. Exiting...')
 
 

--- a/tests/suite/utils/external_auth_utils.py
+++ b/tests/suite/utils/external_auth_utils.py
@@ -9,7 +9,6 @@ from suite.utils.policy_resources_utils import (
     setup_policy_backend,
     teardown_policy_backend,
 )
-from suite.utils.vs_vsr_resources_utils import delete_and_create_vs_from_yaml
 from suite.utils.resources_utils import (
     create_example_app,
     create_items_from_yaml,
@@ -19,6 +18,7 @@ from suite.utils.resources_utils import (
     wait_for_reload,
     wait_until_all_pods_are_ready,
 )
+from suite.utils.vs_vsr_resources_utils import delete_and_create_vs_from_yaml
 from suite.utils.yaml_utils import get_first_ingress_host_from_yaml
 
 logger = logging.getLogger(__name__)
@@ -325,6 +325,7 @@ def ext_auth_ingress(
 
     request.addfinalizer(fin)
     return ing
+
 
 @pytest.fixture
 def ext_auth_restore_vs(kube_apis, virtual_server_setup):

--- a/tests/suite/utils/external_auth_utils.py
+++ b/tests/suite/utils/external_auth_utils.py
@@ -9,6 +9,7 @@ from suite.utils.policy_resources_utils import (
     setup_policy_backend,
     teardown_policy_backend,
 )
+from suite.utils.vs_vsr_resources_utils import delete_and_create_vs_from_yaml
 from suite.utils.resources_utils import (
     create_example_app,
     create_items_from_yaml,
@@ -63,6 +64,8 @@ ext_auth_pol_tls_signin_src = f"{TEST_DATA}/external-auth/policies/external-auth
 ext_auth_pol_tls_disabled_src = f"{TEST_DATA}/external-auth/policies/external-auth-policy-tls-disabled.yaml"
 ext_auth_pol_tls_full_multi_src = f"{TEST_DATA}/external-auth/policies/external-auth-policy-tls-full-multi.yaml"
 
+# Standard VS (used to restore VS state after tests)
+std_vs_src = f"{TEST_DATA}/virtual-server/standard/virtual-server.yaml"
 
 # ---------------------------------------------------------------------------
 # Ingress setup helper
@@ -144,6 +147,77 @@ def build_ext_auth_headers(vs_host, credentials=None):
 
 
 def _teardown_ext_auth_resources(kube_apis, namespace, secret_names, policy_names, *, tls=False):
+    """Teardown external auth backend (HTTP or TLS).
+
+    Args:
+        kube_apis: KubeApis instance.
+        namespace: Kubernetes namespace.
+        secret_names: List of secret names to delete.
+        policy_names: List of policy names to delete.
+        tls: If True, use TLS backend YAML for deletion.
+    """
+    teardown_policy_backend(
+        kube_apis,
+        namespace,
+        backend_yaml=ext_auth_tls_backend_src if tls else ext_auth_backend_src,
+        secret_names=secret_names,
+        policy_names=policy_names,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Setup / teardown helpers
+# ---------------------------------------------------------------------------
+
+
+def setup_ext_auth(
+    kube_apis,
+    namespace,
+    credentials,
+    policy_yamls,
+    vs_host,
+    *,
+    tls=False,
+    validate_policies=True,
+):
+    """Setup external auth backend (HTTP or TLS) with policies and request headers.
+
+    Args:
+        kube_apis: KubeApis instance.
+        namespace: Kubernetes namespace.
+        credentials: Path to credentials file, or None for no-auth requests.
+        policy_yamls: List of policy YAML file paths (1 or more).
+        vs_host: The VirtualServer/VSR host header value.
+        tls: If True, deploy TLS backend with server TLS and CA secrets.
+        validate_policies: If True, wait for each policy to reach Valid state.
+
+    Returns:
+        (secret_names: list[str], policy_names: list[str], headers: dict)
+    """
+    if tls:
+        secret_yamls = [
+            ext_auth_backend_secret_src,
+            ext_auth_tls_server_secret_src,
+            ext_auth_tls_ca_secret_src,
+        ]
+        backend_yaml = ext_auth_tls_backend_src
+    else:
+        secret_yamls = [ext_auth_backend_secret_src]
+        backend_yaml = ext_auth_backend_src
+
+    secret_names, policy_names = setup_policy_backend(
+        kube_apis,
+        namespace,
+        secret_yamls=secret_yamls,
+        backend_yaml=backend_yaml,
+        policy_yamls=policy_yamls,
+        validate_policies=validate_policies,
+    )
+    headers = build_ext_auth_headers(vs_host, credentials)
+    return secret_names, policy_names, headers
+
+
+def teardown_ext_auth(kube_apis, namespace, secret_names, policy_names, *, tls=False):
     """Teardown external auth backend (HTTP or TLS).
 
     Args:
@@ -251,3 +325,22 @@ def ext_auth_ingress(
 
     request.addfinalizer(fin)
     return ing
+
+@pytest.fixture
+def ext_auth_restore_vs(kube_apis, virtual_server_setup):
+    """Restore the standard VirtualServer spec after each test.
+
+    This ensures the VS is returned to its baseline state even when a test
+    raises an exception mid-way through.
+    """
+    yield
+
+    try:
+        delete_and_create_vs_from_yaml(
+            kube_apis.custom_objects,
+            virtual_server_setup.vs_name,
+            std_vs_src,
+            virtual_server_setup.namespace,
+        )
+    except Exception:
+        logger.debug("ext_auth_restore_vs teardown: ignoring error during VS restore")

--- a/tests/suite/utils/external_auth_utils.py
+++ b/tests/suite/utils/external_auth_utils.py
@@ -212,6 +212,7 @@ def setup_ext_auth(
         backend_yaml=backend_yaml,
         policy_yamls=policy_yamls,
         validate_policies=validate_policies,
+        wait_for_service="external-auth-svc",
     )
     headers = build_ext_auth_headers(vs_host, credentials)
     return secret_names, policy_names, headers
@@ -278,6 +279,7 @@ def ext_auth_setup(request, kube_apis, test_namespace):
         backend_yaml=backend_yaml,
         policy_yamls=policy_yamls,
         validate_policies=validate_policies,
+        wait_for_service="external-auth-svc",
     )
 
     def fin():

--- a/tests/suite/utils/policy_resources_utils.py
+++ b/tests/suite/utils/policy_resources_utils.py
@@ -12,6 +12,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_item_removal,
+    get_service_endpoint,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -88,7 +89,9 @@ def apply_and_wait_for_valid_policy(kube_apis, namespace, policy_yaml, retry_cou
     )
 
 
-def setup_policy_backend(kube_apis, namespace, *, secret_yamls, backend_yaml, policy_yamls, validate_policies=True):
+def setup_policy_backend(
+    kube_apis, namespace, *, secret_yamls, backend_yaml, policy_yamls, validate_policies=True, wait_for_service=None
+):
     """Deploy a backend with secrets and create policies.
 
     Generic setup function that can be used for any policy type (external-auth,
@@ -102,6 +105,9 @@ def setup_policy_backend(kube_apis, namespace, *, secret_yamls, backend_yaml, po
         policy_yamls: List of YAML file paths for policies to create.
         validate_policies: If True (default), wait for each policy to reach Valid state.
             Set to False for tests that expect the policy to be Invalid/Rejected.
+        wait_for_service: If set, wait for this service name's endpoints to be registered
+            before returning. Use this when the controller must see endpoints before the
+            VS/VSR is patched, to avoid a transient Warning from endpoint propagation lag.
 
     Returns:
         (secret_names, policy_names) -- lists of created resource names.
@@ -115,6 +121,10 @@ def setup_policy_backend(kube_apis, namespace, *, secret_yamls, backend_yaml, po
     print(f"Deploy backend from {backend_yaml}")
     create_items_from_yaml(kube_apis, backend_yaml, namespace)
     wait_until_all_pods_are_ready(kube_apis.v1, namespace)
+
+    if wait_for_service:
+        print(f"Waiting for endpoints of service '{wait_for_service}' to be ready...")
+        get_service_endpoint(kube_apis, wait_for_service, namespace)
 
     policy_names = []
     for yaml_path in policy_yamls:


### PR DESCRIPTION
This pull request introduces support for configuring external authentication (ExternalAuth) in NGINX via the Policy custom resource. 

**Examples:**

* Added a new example in `examples/custom-resources/external-auth-oauth2/README.md` that demonstrates how to set up and use the ExternalAuth policy with both HTTP Basic Auth and OAuth2 Proxy (GitHub) for different routes in a VirtualServer.
* Included a sample `basic-auth-policy.yaml` showing how to configure an ExternalAuth policy for HTTP Basic authentication, using TLS and certificate verification.

These changes make it easier to secure NGINX routes with external authentication providers, supporting both basic and advanced authentication flows.

docs: https://github.com/nginx/documentation/pull/1838

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
