### PR TITLE
Add no-basic-auth-locations for ACME challenges behind basic auth

### DIFF
--- a/examples/ingress-resources/basic-auth/README.md
+++ b/examples/ingress-resources/basic-auth/README.md
@@ -86,7 +86,53 @@ URI: /coffee
 Request ID: f91f15d1af17556e552557df2f5a0dd2
 ```
 
-## Example 2: a Separate Htpasswd Per Path
+## Example 2: Basic Auth with ACME/Let's Encrypt (cert-manager)
+
+When using Basic Auth together with cert-manager for automatic TLS certificates, the ACME HTTP-01 challenge path
+`/.well-known/acme-challenge/` must be excluded from authentication. Otherwise, the ACME validation server receives a
+401 response and certificate issuance fails.
+
+Use the `nginx.org/no-basic-auth-locations` annotation to exempt the ACME challenge path from Basic Auth:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cafe-ingress
+  annotations:
+    nginx.org/basic-auth-secret: "cafe-passwd"
+    nginx.org/basic-auth-realm: "Cafe App"
+    nginx.org/no-basic-auth-locations: "/.well-known/acme-challenge/"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - cafe.example.com
+    secretName: cafe-tls
+  rules:
+  - host: cafe.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: cafe-svc
+            port:
+              number: 80
+```
+
+The annotation accepts a comma-separated list of paths. It can also be set globally via the ConfigMap key
+`no-basic-auth-locations`.
+
+> **Note**: When combined with `nginx.org/ssl-redirect: "true"`, also set
+> `acme.cert-manager.io/http01-edit-in-place: "true"` so cert-manager inserts the challenge path into the existing
+> Ingress instead of creating a separate one. ACME validators (Let's Encrypt, Pebble, cert-manager's self-check) follow
+> HTTP-to-HTTPS redirects with insecure TLS verification, so the redirect itself is not a problem — but the inserted
+> challenge location must not inherit the server-level `auth_basic`.
+
+## Example 3: a Separate Htpasswd Per Path
 
 In the following example we enable Basic Auth validation for the [mergeable Ingresses](../mergeable-ingress-types) with
 a separate Basic Auth user:password list per path:

--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -50,6 +50,9 @@ const UseClusterIPAnnotation = "nginx.org/use-cluster-ip"
 // SSLRedirectAnnotation is the annotation where the SSL redirect boolean is specified.
 const SSLRedirectAnnotation = "nginx.org/ssl-redirect"
 
+// NoBasicAuthLocationsAnnotation is the annotation where paths exempt from basic auth are specified.
+const NoBasicAuthLocationsAnnotation = "nginx.org/no-basic-auth-locations"
+
 // HTTPRedirectCodeAnnotation is the annotation where the HTTP redirect code is specified.
 const HTTPRedirectCodeAnnotation = "nginx.org/http-redirect-code"
 
@@ -342,6 +345,10 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 		} else {
 			cfgParams.SSLRedirect = sslRedirect
 		}
+	}
+
+	if noBasicAuthLocations, exists := ingEx.Ingress.Annotations[NoBasicAuthLocationsAnnotation]; exists {
+		cfgParams.NoBasicAuthLocations = ParseLocationList(noBasicAuthLocations)
 	}
 
 	if httpRedirectCode, exists := ingEx.Ingress.Annotations[HTTPRedirectCodeAnnotation]; exists {

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -89,6 +89,7 @@ type ConfigParams struct {
 	ProxyNextUpstreamTries                 *uint64
 	RedirectToHTTPS                        bool
 	HTTPRedirectCode                       int
+	NoBasicAuthLocations                   []string
 	ResolverAddresses                      []string
 	ResolverIPV6                           bool
 	ResolverTimeout                        string

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -170,6 +170,10 @@ func ParseConfigMap(ctx context.Context, cfgm *v1.ConfigMap, nginxPlus bool, has
 		}
 	}
 
+	if noBasicAuthLocations, exists := cfgm.Data["no-basic-auth-locations"]; exists {
+		cfgParams.NoBasicAuthLocations = ParseLocationList(noBasicAuthLocations)
+	}
+
 	if hsts, exists, err := GetMapKeyAsBool(cfgm.Data, "hsts", cfgm); exists {
 		if err != nil {
 			nl.Error(l, err)

--- a/internal/configs/configmaps_test.go
+++ b/internal/configs/configmaps_test.go
@@ -2987,6 +2987,46 @@ func TestParseConfigMapWithHTTPRedirectCode(t *testing.T) {
 	}
 }
 
+func TestParseConfigMapNoBasicAuthLocations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		configMap map[string]string
+		expected  []string
+		msg       string
+	}{
+		{
+			configMap: map[string]string{},
+			expected:  nil,
+			msg:       "default when key absent",
+		},
+		{
+			configMap: map[string]string{"no-basic-auth-locations": "/custom"},
+			expected:  []string{"/custom"},
+			msg:       "single custom path",
+		},
+		{
+			configMap: map[string]string{"no-basic-auth-locations": "/a,/b"},
+			expected:  []string{"/a", "/b"},
+			msg:       "multiple paths",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.msg, func(t *testing.T) {
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-config",
+					Namespace: "nginx-ingress",
+				},
+				Data: test.configMap,
+			}
+			result, _ := ParseConfigMap(context.Background(), cm, false, false, false, false, false, makeEventLogger())
+			assert.Equal(t, test.expected, result.NoBasicAuthLocations, test.msg)
+		})
+	}
+}
+
 func makeEventLogger() record.EventRecorder {
 	return record.NewFakeRecorder(1024)
 }

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -398,6 +398,7 @@ func generateNginxCfg(ncp NginxCfgParams) (version1.IngressNginxConfig, Warnings
 			Deny:                   policyCfg.Deny,
 			WAF:                    policyCfg.WAF,
 			PoliciesErrorReturn:    policyCfg.ErrorReturn,
+			NoBasicAuthLocations: cfgParams.NoBasicAuthLocations,
 		}
 
 		warnings := addSSLConfig(&server, ncp.ingEx.Ingress, rule.Host, ncp.ingEx.Ingress.Spec.TLS, ncp.ingEx.SecretRefs, ncp.isWildcardEnabled)

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -142,6 +142,60 @@ func TestGenerateNginxCfgForBasicAuth(t *testing.T) {
 	}
 }
 
+func TestGenerateNginxCfgForNoBasicAuthLocationsDefault(t *testing.T) {
+	t.Parallel()
+	cafeIngressEx := createCafeIngressEx()
+
+	configParams := NewDefaultConfigParams(context.Background(), false)
+
+	result, warnings := generateNginxCfg(NginxCfgParams{
+		staticParams:         &StaticConfigParams{},
+		ingEx:                &cafeIngressEx,
+		apResources:          nil,
+		dosResource:          nil,
+		isMinion:             false,
+		isPlus:               false,
+		BaseCfgParams:        configParams,
+		isResolverConfigured: false,
+		isWildcardEnabled:    false,
+	})
+
+	if result.Servers[0].NoBasicAuthLocations != nil {
+		t.Errorf("generateNginxCfg NoBasicAuthLocations = %v, want nil", result.Servers[0].NoBasicAuthLocations)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("generateNginxCfg returned warnings: %v", warnings)
+	}
+}
+
+func TestGenerateNginxCfgForNoBasicAuthLocationsAnnotation(t *testing.T) {
+	t.Parallel()
+	cafeIngressEx := createCafeIngressEx()
+	cafeIngressEx.Ingress.Annotations["nginx.org/no-basic-auth-locations"] = "/custom-auth,/another"
+
+	configParams := NewDefaultConfigParams(context.Background(), false)
+
+	result, warnings := generateNginxCfg(NginxCfgParams{
+		staticParams:         &StaticConfigParams{},
+		ingEx:                &cafeIngressEx,
+		apResources:          nil,
+		dosResource:          nil,
+		isMinion:             false,
+		isPlus:               false,
+		BaseCfgParams:        configParams,
+		isResolverConfigured: false,
+		isWildcardEnabled:    false,
+	})
+
+	expected := []string{"/custom-auth", "/another"}
+	if !reflect.DeepEqual(result.Servers[0].NoBasicAuthLocations, expected) {
+		t.Errorf("generateNginxCfg NoBasicAuthLocations = %v, want %v", result.Servers[0].NoBasicAuthLocations, expected)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("generateNginxCfg returned warnings: %v", warnings)
+	}
+}
+
 func TestGenerateNginxCfgForAppRoot(t *testing.T) {
 	t.Parallel()
 	cafeIngressEx := createCafeIngressEx()

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -320,6 +320,19 @@ func parsePort(value string) (int, error) {
 	return int(port), nil
 }
 
+// ParseLocationList parses a comma-separated list of location paths,
+// trimming whitespace from each entry and skipping empty entries.
+func ParseLocationList(s string) []string {
+	var locations []string
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			locations = append(locations, part)
+		}
+	}
+	return locations
+}
+
 // ParseServiceList ensures that the string is a comma-separated list of services
 func ParseServiceList(s string) map[string]bool {
 	services := make(map[string]bool)

--- a/internal/configs/parsing_helpers_test.go
+++ b/internal/configs/parsing_helpers_test.go
@@ -98,6 +98,43 @@ func TestParseServicesFromString(t *testing.T) {
 	}
 }
 
+func TestParseLocationList(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		input string
+		want  []string
+	}{
+		{
+			input: "",
+			want:  nil,
+		},
+		{
+			input: "/.well-known/acme-challenge/",
+			want:  []string{"/.well-known/acme-challenge/"},
+		},
+		{
+			input: "/.well-known/acme-challenge/,/health",
+			want:  []string{"/.well-known/acme-challenge/", "/health"},
+		},
+		{
+			input: " /a , /b ",
+			want:  []string{"/a", "/b"},
+		},
+		{
+			input: "/path1,,/path2",
+			want:  []string{"/path1", "/path2"},
+		},
+	}
+
+	for _, tc := range tt {
+		got := ParseLocationList(tc.input)
+		if !cmp.Equal(tc.want, got) {
+			t.Error(cmp.Diff(tc.want, got))
+		}
+	}
+}
+
 func TestParsePortList_FailsOnBogusStrings(t *testing.T) {
 	t.Parallel()
 

--- a/internal/configs/version1/__snapshots__/template_test.snap
+++ b/internal/configs/version1/__snapshots__/template_test.snap
@@ -1444,6 +1444,66 @@ server {
 
 ---
 
+[TestExecuteTemplate_ForIngressForNGINXPlusWithNoBasicAuthLocations - 1]
+# configuration for default/auth-ingress
+upstream test {
+    zone test 256k;
+    server 127.0.0.1:8181 max_fails=0 fail_timeout=1s max_conns=0 slow_start=5s;
+}
+
+
+server {
+
+    server_tokens "off";
+
+    server_name auth.example.com;
+
+    status_zone ;
+    set $resource_type "ingress";
+    set $resource_name "auth-ingress";
+    set $resource_namespace "default";
+    set $service "-";
+
+    
+    auth_basic "Protected";
+    auth_basic_user_file /etc/nginx/secrets/htpasswd;
+
+    
+    location /.well-known/acme-challenge/ {
+        auth_basic off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://test;
+    }
+    location / {
+        set $service "";
+        status_zone "";
+        proxy_http_version 1.1;
+
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 10s;
+        proxy_send_timeout 10s;
+        client_max_body_size 1m;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_pass http://test;
+        
+    }
+    
+}
+
+---
+
 [TestExecuteTemplate_ForIngressForNGINXPlusWithPoliciesErrorReturnLocation - 1]
 # configuration for default/cafe-ingress
 upstream test {
@@ -2768,6 +2828,60 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header X-Forwarded-Proto https;
+        proxy_buffering off;
+        proxy_pass http://test;
+        
+    }
+    
+}
+
+---
+
+[TestExecuteTemplate_ForIngressForNGINXWithNoBasicAuthLocations - 1]
+# configuration for default/auth-ingress
+upstream test {
+    zone test 256k;
+    server 127.0.0.1:8181 max_fails=0 fail_timeout=1s max_conns=0;
+}
+
+
+
+server {
+
+    server_tokens off;
+
+    server_name auth.example.com;
+
+    set $resource_type "ingress";
+    set $resource_name "auth-ingress";
+    set $resource_namespace "default";
+    set $service "-";
+    auth_basic "Protected";
+    auth_basic_user_file /etc/nginx/secrets/htpasswd;
+    location /.well-known/acme-challenge/ {
+        auth_basic off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://test;
+    }
+    location / {
+        set $service "";
+        proxy_http_version 1.1;
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 10s;
+        proxy_send_timeout 10s;
+        client_max_body_size 1m;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_buffering off;
         proxy_pass http://test;
         

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -141,6 +141,8 @@ type Server struct {
 	DisableIPV6 bool
 
 	AppRoot string
+
+	NoBasicAuthLocations []string
 }
 
 // JWTRedirectLocation describes a location for redirecting client requests to a login URL for JWT Authentication.

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -242,6 +242,25 @@ server {
 		return 302 {{$location.LoginURL}};
 	}
 	{{end -}}
+	{{- if and $server.BasicAuth (gt (len $server.NoBasicAuthLocations) 0)}}
+	{{- range $path := $server.NoBasicAuthLocations}}
+	location {{ $path }} {
+		auth_basic off;
+		{{- if gt (len $server.Locations) 0}}
+		{{- with index $server.Locations 0}}
+		proxy_http_version 1.1;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Host $host;
+		proxy_set_header X-Forwarded-Port $server_port;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_pass {{ .ProxyPass }};
+		{{- end}}
+		{{- end}}
+	}
+	{{- end}}
+	{{- end -}}
 
 	{{range $location := $server.Locations}}
 	location {{  makeLocationPath $location $.Ingress.Annotations | printf }} {
@@ -313,10 +332,14 @@ server {
 		auth_jwt "{{.Realm}}"{{if $jwt.Token}} token={{$jwt.Token}}{{end}};
 		{{- end}}
 
+		{{- if and $server.BasicAuth (pathMatchesAnyPrefix $location.Path $server.NoBasicAuthLocations)}}
+		auth_basic off;
+		{{- else}}
 		{{- with $location.BasicAuth }}
 		auth_basic {{ printf "%q" .Realm }};
 		auth_basic_user_file {{ .Secret }};
 		{{- end }}
+		{{- end}}
 
 		grpc_connect_timeout {{$location.ProxyConnectTimeout}};
 		grpc_read_timeout {{$location.ProxyReadTimeout}};
@@ -365,10 +388,14 @@ server {
 		{{- end}}
 		{{- end}}
 
+		{{- if and $server.BasicAuth (pathMatchesAnyPrefix $location.Path $server.NoBasicAuthLocations)}}
+		auth_basic off;
+		{{- else}}
 		{{- with $location.BasicAuth }}
 		auth_basic {{ printf "%q" .Realm }};
 		auth_basic_user_file {{ .Secret }};
 		{{- end }}
+		{{- end}}
 
 		proxy_connect_timeout {{$location.ProxyConnectTimeout}};
 		proxy_read_timeout {{$location.ProxyReadTimeout}};

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -158,6 +158,26 @@ server {
 	}
 	{{- end }}
 
+	{{- if and $server.BasicAuth (gt (len $server.NoBasicAuthLocations) 0)}}
+	{{- range $path := $server.NoBasicAuthLocations}}
+	location {{ $path }} {
+		auth_basic off;
+		{{- if gt (len $server.Locations) 0}}
+		{{- with index $server.Locations 0}}
+		proxy_http_version 1.1;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Host $host;
+		proxy_set_header X-Forwarded-Port $server_port;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_pass {{ .ProxyPass }};
+		{{- end}}
+		{{- end}}
+	}
+	{{- end}}
+	{{- end}}
+
 	{{- range $location := $server.Locations}}
 	location {{  makeLocationPath $location $.Ingress.Annotations | printf }} {
 		set $service "{{$location.ServiceName}}";
@@ -207,10 +227,14 @@ server {
 		{{- range $value := $location.LocationSnippets}}
 		{{$value}}{{- end}}
 
+		{{- if and $server.BasicAuth (pathMatchesAnyPrefix $location.Path $server.NoBasicAuthLocations)}}
+		auth_basic off;
+		{{- else}}
 		{{- with $location.BasicAuth }}
 		auth_basic {{ printf "%q" .Realm }};
 		auth_basic_user_file {{ .Secret }};
 		{{- end }}
+		{{- end}}
 
 		grpc_connect_timeout {{$location.ProxyConnectTimeout}};
 		grpc_read_timeout {{$location.ProxyReadTimeout}};
@@ -250,10 +274,14 @@ server {
 		{{- end}}
 		{{- range $value := $location.LocationSnippets}}
 		{{$value}}{{- end}}
+		{{- if and $server.BasicAuth (pathMatchesAnyPrefix $location.Path $server.NoBasicAuthLocations)}}
+		auth_basic off;
+		{{- else}}
 		{{- with $location.BasicAuth }}
 		auth_basic {{ printf "%q" .Realm }};
 		auth_basic_user_file {{ .Secret }};
 		{{- end }}
+		{{- end}}
 		proxy_connect_timeout {{$location.ProxyConnectTimeout}};
 		proxy_read_timeout {{$location.ProxyReadTimeout}};
 		proxy_send_timeout {{$location.ProxySendTimeout}};

--- a/internal/configs/version1/template_helper.go
+++ b/internal/configs/version1/template_helper.go
@@ -154,6 +154,25 @@ func extractOriginalPath(processedPath string) string {
 	return processedPath
 }
 
+// pathMatchesAnyPrefix returns true if path starts with any of the given prefixes.
+// Strips nginx location modifiers (both quoted and unquoted forms) before matching.
+func pathMatchesAnyPrefix(path string, prefixes []string) bool {
+	// First try extractOriginalPath for quoted forms: ~ "^/path", = "/path"
+	cleanPath := extractOriginalPath(path)
+
+	// Also handle unquoted forms: = /path, ~ /path, ~* /path
+	cleanPath = strings.TrimPrefix(cleanPath, "= ")
+	cleanPath = strings.TrimPrefix(cleanPath, "~* ")
+	cleanPath = strings.TrimPrefix(cleanPath, "~ ")
+
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(cleanPath, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 var helperFunctions = template.FuncMap{
 	"split":              split,
 	"trim":               trim,
@@ -165,6 +184,7 @@ var helperFunctions = template.FuncMap{
 	"replaceAll":         strings.ReplaceAll,
 	"makeLocationPath":   makeLocationPath,
 	"makeRewritePattern": makeRewritePattern,
+	"pathMatchesAnyPrefix": pathMatchesAnyPrefix,
 	"makeSecretPath":     commonhelpers.MakeSecretPath,
 	"makeOnOffFromBool":  commonhelpers.MakeOnOffFromBool,
 	"boolToPointerBool":  commonhelpers.BoolToPointerBool,

--- a/internal/configs/version1/template_helper_test.go
+++ b/internal/configs/version1/template_helper_test.go
@@ -755,3 +755,91 @@ func TestMakeRewritePattern_WithComplexPatterns(t *testing.T) {
 		})
 	}
 }
+
+func TestPathMatchesAnyPrefix(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name     string
+		path     string
+		prefixes []string
+		want     bool
+	}{
+		{
+			name:     "no match",
+			path:     "/tea",
+			prefixes: []string{"/.well-known/acme-challenge/"},
+			want:     false,
+		},
+		{
+			name:     "prefix match",
+			path:     "/.well-known/acme-challenge/abc",
+			prefixes: []string{"/.well-known/acme-challenge/"},
+			want:     true,
+		},
+		{
+			name:     "exact prefix match",
+			path:     "/.well-known/acme-challenge/",
+			prefixes: []string{"/.well-known/acme-challenge/"},
+			want:     true,
+		},
+		{
+			name:     "strips exact modifier",
+			path:     "= /.well-known/acme-challenge/token",
+			prefixes: []string{"/.well-known/acme-challenge/"},
+			want:     true,
+		},
+		{
+			name:     "strips case-sensitive regex modifier",
+			path:     "~ /.well-known/acme-challenge/",
+			prefixes: []string{"/.well-known/acme-challenge/"},
+			want:     true,
+		},
+		{
+			name:     "strips case-insensitive regex modifier",
+			path:     "~* /.well-known/acme-challenge/",
+			prefixes: []string{"/.well-known/acme-challenge/"},
+			want:     true,
+		},
+		{
+			name:     "strips quoted exact modifier",
+			path:     `= "/.well-known/acme-challenge/token"`,
+			prefixes: []string{"/.well-known/acme-challenge/"},
+			want:     true,
+		},
+		{
+			name:     "strips quoted regex modifier",
+			path:     `~ "^/.well-known/acme-challenge/"`,
+			prefixes: []string{"/.well-known/acme-challenge/"},
+			want:     true,
+		},
+		{
+			name:     "empty prefixes",
+			path:     "/tea",
+			prefixes: []string{},
+			want:     false,
+		},
+		{
+			name:     "nil prefixes",
+			path:     "/tea",
+			prefixes: nil,
+			want:     false,
+		},
+		{
+			name:     "multiple prefixes second matches",
+			path:     "/health/check",
+			prefixes: []string{"/.well-known/acme-challenge/", "/health"},
+			want:     true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := pathMatchesAnyPrefix(tc.path, tc.prefixes)
+			if got != tc.want {
+				t.Errorf("pathMatchesAnyPrefix(%q, %v) = %v, want %v", tc.path, tc.prefixes, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -5522,3 +5522,117 @@ func TestExecuteTemplate_ForIngressForNGINXPlusWithPoliciesErrorReturnLocation(t
 	snaps.MatchSnapshot(t, bufString)
 	t.Log(bufString)
 }
+
+func TestExecuteTemplate_ForIngressForNGINXWithNoBasicAuthLocations(t *testing.T) {
+	t.Parallel()
+
+	tmpl := newNGINXIngressTmpl(t)
+	buf := &bytes.Buffer{}
+
+	cfg := IngressNginxConfig{
+		Servers: []Server{
+			{
+				Name:         "auth.example.com",
+				ServerTokens: "off",
+				BasicAuth: &BasicAuth{
+					Realm:  "Protected",
+					Secret: "/etc/nginx/secrets/htpasswd",
+				},
+				NoBasicAuthLocations: []string{"/.well-known/acme-challenge/"},
+				Locations: []Location{
+					{
+						Path:                "/",
+						Upstream:            testUpstream,
+						ProxyConnectTimeout: "10s",
+						ProxyReadTimeout:    "10s",
+						ProxySendTimeout:    "10s",
+						ClientMaxBodySize:   "1m",
+						ProxyPass:           "http://test",
+					},
+				},
+			},
+		},
+		Upstreams: []Upstream{testUpstream},
+		Ingress: Ingress{
+			Name:      "auth-ingress",
+			Namespace: "default",
+		},
+	}
+
+	err := tmpl.Execute(buf, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bufString := buf.String()
+
+	if !strings.Contains(bufString, "location /.well-known/acme-challenge/") {
+		t.Error("want exempt location block for ACME challenge path")
+	}
+	if !strings.Contains(bufString, "auth_basic off;") {
+		t.Error("want auth_basic off in exempt location")
+	}
+	if !strings.Contains(bufString, `auth_basic "Protected";`) {
+		t.Error("want auth_basic enabled for non-exempt locations")
+	}
+
+	snaps.MatchSnapshot(t, bufString)
+	t.Log(bufString)
+}
+
+func TestExecuteTemplate_ForIngressForNGINXPlusWithNoBasicAuthLocations(t *testing.T) {
+	t.Parallel()
+
+	tmpl := newNGINXPlusIngressTmpl(t)
+	buf := &bytes.Buffer{}
+
+	cfg := IngressNginxConfig{
+		Servers: []Server{
+			{
+				Name:         "auth.example.com",
+				ServerTokens: "off",
+				BasicAuth: &BasicAuth{
+					Realm:  "Protected",
+					Secret: "/etc/nginx/secrets/htpasswd",
+				},
+				NoBasicAuthLocations: []string{"/.well-known/acme-challenge/"},
+				Locations: []Location{
+					{
+						Path:                "/",
+						Upstream:            testUpstream,
+						ProxyConnectTimeout: "10s",
+						ProxyReadTimeout:    "10s",
+						ProxySendTimeout:    "10s",
+						ClientMaxBodySize:   "1m",
+						ProxyPass:           "http://test",
+					},
+				},
+			},
+		},
+		Upstreams: []Upstream{testUpstream},
+		Ingress: Ingress{
+			Name:      "auth-ingress",
+			Namespace: "default",
+		},
+	}
+
+	err := tmpl.Execute(buf, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bufString := buf.String()
+
+	if !strings.Contains(bufString, "location /.well-known/acme-challenge/") {
+		t.Error("want exempt location block for ACME challenge path")
+	}
+	if !strings.Contains(bufString, "auth_basic off;") {
+		t.Error("want auth_basic off in exempt location")
+	}
+	if !strings.Contains(bufString, `auth_basic "Protected";`) {
+		t.Error("want auth_basic enabled for non-exempt locations")
+	}
+
+	snaps.MatchSnapshot(t, bufString)
+	t.Log(bufString)
+}

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -50,6 +50,7 @@ const (
 	upstreamZoneSizeAnnotation            = "nginx.org/upstream-zone-size"
 	basicAuthSecretAnnotation             = "nginx.org/basic-auth-secret" // #nosec G101
 	basicAuthRealmAnnotation              = "nginx.org/basic-auth-realm"
+	noBasicAuthLocationsAnnotation        = "nginx.org/no-basic-auth-locations"
 	listenPortsAnnotation                 = "nginx.org/listen-ports"
 	listenPortsSSLAnnotation              = "nginx.org/listen-ports-ssl"
 	keepaliveAnnotation                   = "nginx.org/keepalive"
@@ -258,6 +259,9 @@ var (
 		basicAuthRealmAnnotation: {
 			validateRelatedAnnotation(basicAuthSecretAnnotation, validateNoop),
 			validateRealmAnnotation,
+		},
+		noBasicAuthLocationsAnnotation: {
+			validateRelatedAnnotation(basicAuthSecretAnnotation, validateNoop),
 		},
 		configs.JWTRealmAnnotation: {
 			validatePlusOnlyAnnotation,


### PR DESCRIPTION
### Proposed changes
    
When an Ingress has basic auth enabled together with cert-manager and the acme.cert-manager.io/http01-edit-in-place: "true" annotation, cert-manager inserts the ACME HTTP-01 challenge as a pathType: Exact path on the same Ingress. The inserted location inherits the server-level auth_basic and returns 401, blocking certificate issuance.

Add a new ConfigMap key "no-basic-auth-locations" and per-Ingress annotation "nginx.org/no-basic-auth-locations" that take a comma-separated list of path prefixes. The template emits an explicit "auth_basic off;" exempt location block for each prefix and also disables basic auth on any regular location whose path matches a prefix (covers the cert-manager exact path that edit-in-place inserts).

Both the ConfigMap key and the annotation default to empty (opt-in), so no behavior changes for existing users. To allow ACME challenges through basic auth, set:

  ConfigMap (cluster-wide):
    no-basic-auth-locations: "/.well-known/acme-challenge/"

  Or per-Ingress:
    nginx.org/no-basic-auth-locations: "/.well-known/acme-challenge/"

Fixes #926
Fixes #2698
Fixes #9600


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
