### PR TITLE
Add -oidc-template-path flag

### DIFF
--- a/cmd/nginx-ingress/flags.go
+++ b/cmd/nginx-ingress/flags.go
@@ -114,6 +114,10 @@ var (
 		`Path to the TransportServer NGINX configuration template for a TransportServer resource.
 	(default for NGINX "nginx.transportserver.tmpl"; default for NGINX Plus "nginx-plus.transportserver.tmpl")`)
 
+	oidcTemplatePath = flag.String("oidc-template-path", "",
+		`Path to the OIDC NGINX configuration template.
+	(default for NGINX Plus "oidc.tmpl")`)
+
 	externalService = flag.String("external-service", "",
 		`Specifies the name of the service with the type LoadBalancer through which the Ingress Controller pods are exposed externally.
 	The external address of the service is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources. For Ingress resources only: Requires -report-ingress-status.`)

--- a/cmd/nginx-ingress/flags.go
+++ b/cmd/nginx-ingress/flags.go
@@ -278,6 +278,11 @@ func initValidate(ctx context.Context) {
 		*mgmtConfigMap = ""
 	}
 
+	if *oidcTemplatePath != "" && !*nginxPlus {
+		nl.Warn(l, "oidc-template-path flag is for NGINX Plus, oidc template path will not be used")
+		*oidcTemplatePath = ""
+	}
+
 	mustValidateInitialChecks(ctx)
 	mustValidateWatchedNamespaces(ctx)
 	mustValidateFlags(ctx)

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -568,6 +568,9 @@ func createTemplateExecutors(ctx context.Context) (*version1.TemplateExecutor, *
 	if *transportServerTemplatePath != "" {
 		nginxTransportServerTemplatePath = *transportServerTemplatePath
 	}
+	if *oidcTemplatePath != "" {
+		nginxOIDCConfTemplatePath = *oidcTemplatePath
+	}
 
 	templateExecutor, err := version1.NewTemplateExecutor(nginxConfTemplatePath, nginxIngressTemplatePath)
 	if err != nil {


### PR DESCRIPTION
### Proposed changes

Add `-oidc-template-path` CLI flag to allow overriding the OIDC template path,
consistent with the existing flags for main, ingress, virtualserver, and
transportserver templates.

- Add flag definition and wiring for template path override
- Add Plus-only validation that warns and clears the flag on OSS

Closes #9589

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork