### PR TITLE
Github actions workflow improvements

### DIFF
--- a/.github/scripts/variables.sh
+++ b/.github/scripts/variables.sh
@@ -12,6 +12,9 @@ if [ "$PWD" != "$ROOTDIR" ]; then
     cd "$ROOTDIR";
 fi
 
+# renovate: datasource=docker depName=kindest/node
+K8S_LATEST_VERSION=1.35.1
+
 get_docker_md5() {
   docker_md5=$(find build .github/data/version.txt internal/configs/njs internal/configs/oidc -type f ! -name "*.md" -exec md5sum {} + | LC_ALL=C sort  | md5sum | awk '{ print $1 }')
   echo "${docker_md5:0:8}"
@@ -58,6 +61,10 @@ get_additional_tag() {
   fi
 }
 
+get_k8s_latest_version() {
+  echo "$K8S_LATEST_VERSION"
+}
+
 case $INPUT in
   docker_md5)
     echo "docker_md5=$(get_docker_md5)"
@@ -77,6 +84,10 @@ case $INPUT in
 
   additional_tag)
     echo "additional_tag=$(get_additional_tag)"
+    ;;
+
+  k8s_latest_version)
+    echo "k8s_latest=$(get_k8s_latest_version)"
     ;;
 
   *)

--- a/.github/scripts/variables.sh
+++ b/.github/scripts/variables.sh
@@ -65,6 +65,16 @@ get_k8s_latest_version() {
   echo "$K8S_LATEST_VERSION"
 }
 
+# Outputs docs_only=true if all changed files match doc paths (*.md, docs/**, examples/**)
+get_docs_only() {
+  non_doc_files=$(git diff --name-only HEAD^ | grep -Ev '(\.md$|^docs/|^examples/)')
+  if [ -z "$non_doc_files" ]; then
+    echo "docs_only=true"
+  else
+    echo "docs_only=false"
+  fi
+}
+
 case $INPUT in
   docker_md5)
     echo "docker_md5=$(get_docker_md5)"
@@ -88,6 +98,10 @@ case $INPUT in
 
   k8s_latest_version)
     echo "k8s_latest=$(get_k8s_latest_version)"
+    ;;
+
+  docs_only)
+    get_docs_only
     ;;
 
   *)

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -47,6 +47,10 @@ on:
         description: Whether to write built images to cache
         type: boolean
         default: false
+      read-from-cache:
+        description: Whether to read from cache when building images
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -213,6 +217,7 @@ jobs:
       ic-version: ${{ inputs.ic-version }}
       runner: ${{ inputs.runner }}
       write-to-cache: ${{ inputs.write-to-cache }}
+      read-from-cache: ${{ inputs.read-from-cache }}
     permissions:
       contents: read
       actions: read
@@ -241,6 +246,7 @@ jobs:
       ic-version: ${{ inputs.ic-version }}
       runner: ${{ inputs.runner }}
       write-to-cache: ${{ inputs.write-to-cache }}
+      read-from-cache: ${{ inputs.read-from-cache }}
     permissions:
       contents: read
       id-token: write
@@ -268,6 +274,7 @@ jobs:
       ic-version: ${{ inputs.ic-version }}
       runner: ${{ inputs.runner }}
       write-to-cache: ${{ inputs.write-to-cache }}
+      read-from-cache: ${{ inputs.read-from-cache }}
     permissions:
       contents: read
       id-token: write # gcr login

--- a/.github/workflows/build-oss.yml
+++ b/.github/workflows/build-oss.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: boolean
         default: false
+      read-from-cache:
+        description: Whether to read from cache when building images
+        required: false
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -214,7 +219,7 @@ jobs:
         with:
           file: build/Dockerfile
           context: "."
-          cache-from: type=gha,scope=${{ inputs.image }}
+          cache-from: ${{ inputs.read-from-cache && format('type=gha,scope={0}', inputs.image) || '' }}
           cache-to: ${{ inputs.write-to-cache && format('type=gha,scope={0},mode=max', inputs.image) || '' }}
           target: goreleaser${{ inputs.authenticated && '-prebuilt' || '' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: boolean
         default: false
+      read-from-cache:
+        description: Whether to read from cache when building images
+        required: false
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -242,7 +247,7 @@ jobs:
         with:
           file: build/Dockerfile
           context: "."
-          cache-from: type=gha,scope=${{ inputs.image }}${{ steps.nap_modules.outputs.name != '' && format('-{0}', steps.nap_modules.outputs.name) || '' }}
+          cache-from: ${{ inputs.read-from-cache && format('type=gha,scope={0}{1}', inputs.image, steps.nap_modules.outputs.name != '' && format('-{0}', steps.nap_modules.outputs.name) || '' ) || '' }}
           cache-to: ${{ inputs.write-to-cache && format('type=gha,scope={0}{1},mode=max', inputs.image, steps.nap_modules.outputs.name != '' && format('-{0}', steps.nap_modules.outputs.name) || '' ) || '' }}
           target: ${{ inputs.target }}${{ inputs.authenticated && '-prebuilt' || '' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,7 @@ jobs:
     permissions:
       contents: read
     needs: checks
+    if: ${{ needs.checks.outputs.docs_only != 'true' }}
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -202,19 +203,6 @@ jobs:
         with:
           go-version-file: go.mod
         if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
-
-      - name: Setup netrc
-        run: |
-          cat <<EOF > $HOME/.netrc
-          machine azr.artifactory.f5net.com
-              login ${{ secrets.ARTIFACTORY_USER }}
-              password ${{ secrets.ARTIFACTORY_TOKEN }}
-          EOF
-          chmod 600 $HOME/.netrc
-        if: >-
-          inputs.force ||
-          (needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.forked_workflow != 'true')
 
       - name: Check if go.mod and go.sum are up to date
         run: go mod tidy && git diff --exit-code -- go.mod go.sum
@@ -240,10 +228,6 @@ jobs:
           export PATH=$PATH:$(go env GOPATH)/bin
           make telemetry-schema && git diff --name-only --exit-code internal/telemetry
         if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
-
-      - name: Cleanup netrc
-        run: rm -f $HOME/.netrc
-        if: ${{ always() }}
 
   unit-tests:
     name: Unit Tests
@@ -298,24 +282,13 @@ jobs:
           needs.checks.outputs.binary_cache_hit != 'true' &&
           inputs.run_tests != false
 
-      - name: Setup netrc
-        run: |
-          cat <<EOF > $HOME/.netrc
-          machine azr.artifactory.f5net.com
-              login ${{ secrets.ARTIFACTORY_USER }}
-              password ${{ secrets.ARTIFACTORY_TOKEN }}
-          EOF
-          chmod 600 $HOME/.netrc
-        if: >-
-          needs.checks.outputs.docs_only != 'true' &&
-          (inputs.force ||
-          (needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.forked_workflow != 'true'))
-
       - name: Generate secrets for tests
         run: |
           make secrets
-        if: ${{ needs.checks.outputs.docs_only != 'true' }}
+        if: >-
+          needs.checks.outputs.docs_only != 'true' &&
+          needs.checks.outputs.binary_cache_hit != 'true' &&
+          inputs.run_tests != false
 
       - name: Run Tests
         run: make cover
@@ -334,10 +307,6 @@ jobs:
           inputs.run_tests != false &&
           needs.checks.outputs.docs_only != 'true'
 
-      - name: Cleanup netrc
-        run: rm -f $HOME/.netrc
-        if: ${{ always() }}
-
   staticcheck:
     name: Static Check
     runs-on: ubuntu-24.04
@@ -351,58 +320,16 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Azure login
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
-        with:
-          client-id: ${{ secrets.AZURE_VAULT_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_VAULT_SUBSCRIPTION_ID }}
-        if: >-
-          needs.checks.outputs.docs_only != 'true' &&
-          (inputs.force ||
-          (needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.forked_workflow != 'true'))
-
-      - name: Setup secrets
-        id: secrets
-        run: |
-          echo "Setting secrets for job"
-          CODECOV_TOKEN=$(az keyvault secret show --name code-cov --vault-name ${{ secrets.NIC_KEYVAULT_NAME }} --query value -o tsv)
-          echo "::add-mask::$CODECOV_TOKEN"
-          echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> $GITHUB_OUTPUT
-        if: >-
-          needs.checks.outputs.docs_only != 'true' &&
-          (inputs.force ||
-          (needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.forked_workflow != 'true'))
-
       - name: Setup Golang Environment
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-        if: >-
-          needs.checks.outputs.docs_only != 'true' &&
-          needs.checks.outputs.binary_cache_hit != 'true' &&
-          inputs.run_tests != false
-
-      - name: Setup netrc
-        run: |
-          cat <<EOF > $HOME/.netrc
-          machine azr.artifactory.f5net.com
-              login ${{ secrets.ARTIFACTORY_USER }}
-              password ${{ secrets.ARTIFACTORY_TOKEN }}
-          EOF
-          chmod 600 $HOME/.netrc
-        if: >-
-          needs.checks.outputs.docs_only != 'true' &&
-          (inputs.force ||
-          (needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.forked_workflow != 'true'))
+        if: inputs.force || needs.checks.outputs.binary_cache_hit != 'true'
 
       - name: Generate secrets for tests
         run: |
           make secrets
-        if: ${{ needs.checks.outputs.docs_only != 'true' }}
+        if: inputs.force || needs.checks.outputs.binary_cache_hit != 'true'
 
       - name: Run Static Check
         uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
@@ -410,10 +337,7 @@ jobs:
           version: "2026.1" # renovate: datasource=github-releases depName=dominikh/go-tools
           install-go: false
           use-cache: true
-
-      - name: Cleanup netrc
-        run: rm -f $HOME/.netrc
-        if: ${{ always() }}
+        if: inputs.force || needs.checks.outputs.binary_cache_hit != 'true'
 
   govulncheck:
     name: Vulnerability Check
@@ -428,30 +352,18 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup netrc
-        run: |
-          cat <<EOF > $HOME/.netrc
-          machine azr.artifactory.f5net.com
-              login ${{ secrets.ARTIFACTORY_USER }}
-              password ${{ secrets.ARTIFACTORY_TOKEN }}
-          EOF
-          chmod 600 $HOME/.netrc
-        if: ${{ needs.checks.outputs.forked_workflow != 'true' }}
-
       - name: Setup Golang Environment
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+        if: inputs.force || needs.checks.outputs.binary_cache_hit != 'true'
 
       - name: Run govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
           repo-checkout: false
           cache: true
-
-      - name: Cleanup netrc
-        run: rm -f $HOME/.netrc
-        if: ${{ always() }}
+        if: inputs.force || needs.checks.outputs.binary_cache_hit != 'true'
 
   build-artifacts:
     name: Build Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
       contents: read
     needs: checks
     if: >-
+      inputs.force == 'true' ||
       needs.checks.outputs.run_tests == 'true' &&
       needs.checks.outputs.binary_cache_hit == 'false'
     env:
@@ -256,6 +257,7 @@ jobs:
         with:
           version: 'v3.18.6'
         if: >-
+          inputs.force == 'true' ||
           needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'
 
@@ -266,6 +268,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_VAULT_SUBSCRIPTION_ID }}
         if: >-
+          inputs.force == 'true' ||
           needs.checks.outputs.forked_workflow == 'false' &&
           (needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false')
@@ -278,6 +281,7 @@ jobs:
           echo "::add-mask::$CODECOV_TOKEN"
           echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> $GITHUB_OUTPUT
         if: >-
+          inputs.force == 'true' ||
           needs.checks.outputs.forked_workflow == 'false' &&
           (needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false')
@@ -287,6 +291,7 @@ jobs:
         with:
           go-version-file: go.mod
         if: >-
+          inputs.force == 'true' ||
           needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'
 
@@ -294,6 +299,7 @@ jobs:
         run: |
           make secrets
         if: >-
+          inputs.force == 'true' ||
           needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'
 
@@ -310,6 +316,7 @@ jobs:
           files: ./coverage.txt
           token: ${{ steps.secrets.outputs.CODECOV_TOKEN }} # required
         if: >-
+          inputs.force == 'true' ||
           (needs.checks.outputs.forked_workflow == 'false' &&
           (needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'))
@@ -321,6 +328,7 @@ jobs:
       contents: read
     needs: checks
     if: >-
+      inputs.force == 'true' ||
       needs.checks.outputs.run_tests == 'true' &&
       needs.checks.outputs.binary_cache_hit == 'false'
     env:
@@ -352,6 +360,7 @@ jobs:
       contents: read
     needs: checks
     if: >-
+      inputs.force == 'true' ||
       needs.checks.outputs.run_tests == 'true' &&
       needs.checks.outputs.binary_cache_hit == 'false'
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
           client-id: ${{ secrets.AZURE_VAULT_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_VAULT_SUBSCRIPTION_ID }}
-        if: ${{ inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true') }}
+        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
 
       - name: Setup secrets
         id: secrets
@@ -276,13 +276,13 @@ jobs:
           CODECOV_TOKEN=$(az keyvault secret show --name code-cov --vault-name ${{ secrets.NIC_KEYVAULT_NAME }} --query value -o tsv)
           echo "::add-mask::$CODECOV_TOKEN"
           echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> $GITHUB_OUTPUT
-        if: ${{ inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true') }}
+        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
 
       - name: Setup Golang Environment
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
+        if: ${{ needs.checks.outputs.docs_only != 'true' && needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
 
       - name: Setup netrc
         run: |
@@ -292,7 +292,7 @@ jobs:
               password ${{ secrets.ARTIFACTORY_TOKEN }}
           EOF
           chmod 600 $HOME/.netrc
-        if: ${{ inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true') }}
+        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
 
       - name: Generate secrets for tests
         run: |
@@ -301,14 +301,14 @@ jobs:
 
       - name: Run Tests
         run: make cover
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
+        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false && needs.checks.outputs.docs_only != 'true' }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: ./coverage.txt
           token: ${{ steps.secrets.outputs.CODECOV_TOKEN }} # required
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
+        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false && needs.checks.outputs.docs_only != 'true' }}
 
       - name: Cleanup netrc
         run: rm -f $HOME/.netrc
@@ -327,10 +327,28 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Azure login
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_VAULT_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_VAULT_SUBSCRIPTION_ID }}
+        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
+
+      - name: Setup secrets
+        id: secrets
+        run: |
+          echo "Setting secrets for job"
+          CODECOV_TOKEN=$(az keyvault secret show --name code-cov --vault-name ${{ secrets.NIC_KEYVAULT_NAME }} --query value -o tsv)
+          echo "::add-mask::$CODECOV_TOKEN"
+          echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> $GITHUB_OUTPUT
+        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
+
       - name: Setup Golang Environment
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+        if: ${{ needs.checks.outputs.docs_only != 'true' && needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
 
       - name: Setup netrc
         run: |
@@ -340,7 +358,12 @@ jobs:
               password ${{ secrets.ARTIFACTORY_TOKEN }}
           EOF
           chmod 600 $HOME/.netrc
-        if: ${{ needs.checks.outputs.forked_workflow != 'true' }}
+        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
+
+      - name: Generate secrets for tests
+        run: |
+          make secrets
+        if: ${{ needs.checks.outputs.docs_only != 'true' }}
 
       - name: Run Static Check
         uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
@@ -366,11 +389,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup Golang Environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version-file: go.mod
-
       - name: Setup netrc
         run: |
           cat <<EOF > $HOME/.netrc
@@ -380,6 +398,11 @@ jobs:
           EOF
           chmod 600 $HOME/.netrc
         if: ${{ needs.checks.outputs.forked_workflow != 'true' }}
+
+      - name: Setup Golang Environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
 
       - name: Run govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,9 +353,47 @@ jobs:
         run: rm -f $HOME/.netrc
         if: ${{ always() }}
 
+  govulncheck:
+    name: Vulnerability Check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    needs: checks
+    if: ${{ needs.checks.outputs.docs_only != 'true' }}
+    env:
+      GOPROXY: ${{ needs.checks.outputs.go_proxy }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Golang Environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Setup netrc
+        run: |
+          cat <<EOF > $HOME/.netrc
+          machine azr.artifactory.f5net.com
+              login ${{ secrets.ARTIFACTORY_USER }}
+              password ${{ secrets.ARTIFACTORY_TOKEN }}
+          EOF
+          chmod 600 $HOME/.netrc
+        if: ${{ needs.checks.outputs.forked_workflow != 'true' }}
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          repo-checkout: false
+          cache: true
+
+      - name: Cleanup netrc
+        run: rm -f $HOME/.netrc
+        if: ${{ always() }}
+
   build-artifacts:
     name: Build Artifacts
-    needs: [checks, unit-tests, staticcheck, verify-codegen]
+    needs: [checks, unit-tests, staticcheck, govulncheck, verify-codegen]
     uses: ./.github/workflows/build-artifacts.yml
     with:
       force: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.binary_cache_hit != 'true' }}
@@ -853,7 +891,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     name: Final CI Results
-    needs: [tag-stable, build-artifacts, smoke-tests-oss, smoke-tests-plus, smoke-tests-nap, package-tests, helm-tests, staticcheck]
+    needs: [tag-stable, build-artifacts, smoke-tests-oss, smoke-tests-plus, smoke-tests-nap, package-tests, helm-tests, staticcheck, govulncheck]
     steps:
       - run: |
           tagResult="${{ needs.tag-stable.result }}"
@@ -864,6 +902,7 @@ jobs:
           smokeNAPResult="${{ needs.smoke-tests-nap.result }}"
           buildArtifactsResult="${{ needs.build-artifacts.result }}"
           staticcheckResult="${{ needs.staticcheck.result }}"
+          govulncheckResult="${{ needs.govulncheck.result }}"
           if [[ $tagResult != "success" && $tagResult != "skipped" ]]; then
             exit 1
           fi
@@ -886,6 +925,9 @@ jobs:
             exit 1
           fi
           if [[ $staticcheckResult != "success" && $staticcheckResult != "skipped" ]]; then
+            exit 1
+          fi
+          if [[ $govulncheckResult != "success" && $govulncheckResult != "skipped" ]]; then
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
         with:
           version: 'v3.18.6'
         if: >-
-          inputs.force == 'true' ||
+          inputs.force ||
           needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'
 
@@ -268,7 +268,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_VAULT_SUBSCRIPTION_ID }}
         if: >-
-          inputs.force == 'true' ||
+          inputs.force ||
           needs.checks.outputs.forked_workflow == 'false' &&
           (needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false')
@@ -281,7 +281,7 @@ jobs:
           echo "::add-mask::$CODECOV_TOKEN"
           echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> $GITHUB_OUTPUT
         if: >-
-          inputs.force == 'true' ||
+          inputs.force ||
           needs.checks.outputs.forked_workflow == 'false' &&
           (needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false')
@@ -291,7 +291,7 @@ jobs:
         with:
           go-version-file: go.mod
         if: >-
-          inputs.force == 'true' ||
+          inputs.force ||
           needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'
 
@@ -299,7 +299,7 @@ jobs:
         run: |
           make secrets
         if: >-
-          inputs.force == 'true' ||
+          inputs.force ||
           needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'
 
@@ -316,7 +316,7 @@ jobs:
           files: ./coverage.txt
           token: ${{ steps.secrets.outputs.CODECOV_TOKEN }} # required
         if: >-
-          inputs.force == 'true' ||
+          inputs.force ||
           (needs.checks.outputs.forked_workflow == 'false' &&
           (needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'))
@@ -328,7 +328,7 @@ jobs:
       contents: read
     needs: checks
     if: >-
-      inputs.force == 'true' ||
+      inputs.force ||
       needs.checks.outputs.run_tests == 'true' &&
       needs.checks.outputs.binary_cache_hit == 'false'
     env:
@@ -360,7 +360,7 @@ jobs:
       contents: read
     needs: checks
     if: >-
-      inputs.force == 'true' ||
+      inputs.force ||
       needs.checks.outputs.run_tests == 'true' &&
       needs.checks.outputs.binary_cache_hit == 'false'
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
           echo 'image_matrix_plus: ${{ steps.vars.outputs.image_matrix_plus }}'
           echo 'image_matrix_nap: ${{ steps.vars.outputs.image_matrix_nap }}'
           echo 'docker_build: ${{ steps.docker_build.outputs.docker_build }}'
-          echo run_tests: ${{ steps.run_tests.outputs.run_tests }}
+          echo 'run_tests: ${{ steps.run_tests.outputs.run_tests }}'
 
   verify-codegen:
     name: Verify generated code
@@ -204,7 +204,9 @@ jobs:
     permissions:
       contents: read
     needs: checks
-    if: ${{ needs.checks.outputs.run_tests == 'false' }}
+    if: >-
+      needs.checks.outputs.run_tests == 'true' &&
+      needs.checks.outputs.binary_cache_hit == 'false'
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -215,32 +217,26 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
 
       - name: Check if go.mod and go.sum are up to date
         run: go mod tidy && git diff --exit-code -- go.mod go.sum
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
 
       - name: Check if CRDs changed
         run: make update-crds && git diff --name-only --exit-code config/crd/bases
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
 
       - name: Check if Codegen changed
         run: |
           cd ../.. && mkdir -p github.com/nginx && mv kubernetes-ingress/kubernetes-ingress github.com/nginx/ && cd github.com/nginx/kubernetes-ingress
           make update-codegen && git diff --name-only --exit-code pkg/**
           cd ../../.. && mv github.com/nginx/kubernetes-ingress kubernetes-ingress/kubernetes-ingress
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
 
       - name: Install gofumpt
         run: go install mvdan.cc/gofumpt@v0.8.0
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
 
       - name: Check if telemetry schema changed
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin
           make telemetry-schema && git diff --name-only --exit-code internal/telemetry
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
 
   unit-tests:
     name: Unit Tests
@@ -324,7 +320,9 @@ jobs:
     permissions:
       contents: read
     needs: checks
-    if: ${{ needs.checks.outputs.run_tests != 'true' }}
+    if: >-
+      needs.checks.outputs.run_tests == 'true' &&
+      needs.checks.outputs.binary_cache_hit == 'false'
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -335,12 +333,10 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-        if: ${{ needs.checks.outputs.binary_cache_hit == 'false' }}
 
       - name: Generate secrets for tests
         run: |
           make secrets
-        if: ${{ needs.checks.outputs.binary_cache_hit == 'false' }}
 
       - name: Run Static Check
         uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
@@ -348,7 +344,6 @@ jobs:
           version: "2026.1" # renovate: datasource=github-releases depName=dominikh/go-tools
           install-go: false
           use-cache: true
-        if: ${{ needs.checks.outputs.binary_cache_hit == 'false' }}
 
   govulncheck:
     name: Vulnerability Check
@@ -356,7 +351,9 @@ jobs:
     permissions:
       contents: read
     needs: checks
-    if: ${{ needs.checks.outputs.run_tests != 'true' }}
+    if: >-
+      needs.checks.outputs.run_tests == 'true' &&
+      needs.checks.outputs.binary_cache_hit == 'false'
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -367,18 +364,16 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-        if: ${{ needs.checks.outputs.binary_cache_hit == 'false' }}
 
       - name: Run govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
           repo-checkout: false
           cache: true
-        if: ${{ needs.checks.outputs.binary_cache_hit == 'false' }}
 
   build-artifacts:
     name: Build Artifacts
-    needs: [checks, unit-tests, staticcheck, govulncheck, verify-codegen]
+    needs: [checks, unit-tests]
     uses: ./.github/workflows/build-artifacts.yml
     with:
       force: ${{ needs.checks.outputs.docker_build == 'true' }}
@@ -394,7 +389,7 @@ jobs:
       ic-version: ${{ needs.checks.outputs.ic_version }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       runner: ubuntu-24.04
-      write-to-cache: ${{ inputs.force != true }}
+      write-to-cache: true
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,7 @@ jobs:
     if: ${{ inputs.force || (needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false') || (needs.checks.outputs.forked_workflow == 'false' && needs.checks.outputs.stable_image_exists != 'true' && needs.checks.outputs.docs_only == 'false') }}
 
   package-tests:
-    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
     name: Package Tests
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -522,7 +522,7 @@ jobs:
         if: ${{ ( needs.checks.outputs.forked_workflow == 'false' || needs.checks.outputs.docs_only == 'false' ) && github.event.pull_request }}
 
   helm-tests:
-    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
     name: Helm Tests ${{ matrix.base-os }}
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -708,7 +708,7 @@ jobs:
         if: always()
 
   setup-matrix:
-    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
     name: Setup Matrix for Smoke Tests
     runs-on: ubuntu-24.04
     needs: [build-artifacts, checks]
@@ -790,7 +790,7 @@ jobs:
         if: ${{ steps.check-image.outcome == 'failure' && needs.checks.outputs.docs_only == 'false' }}
 
   smoke-tests-oss:
-    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -818,7 +818,7 @@ jobs:
       force: ${{ inputs.run_tests != false }}
 
   smoke-tests-plus:
-    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -846,7 +846,7 @@ jobs:
       force: ${{ inputs.run_tests != false }}
 
   smoke-tests-nap:
-    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -942,4 +942,4 @@ jobs:
       pull-requests: write # for scout report
     uses: ./.github/workflows/image-promotion.yml
     secrets: inherit
-    if: ${{ inputs.force }}
+    if: ${{ inputs.force && (github.ref_name == 'main' || startsWith(github.ref_name, 'release-')) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,16 +66,7 @@ jobs:
       - name: Filter only docs changes
         id: docs
         run: |
-          files=$(git diff --name-only HEAD^ | egrep -v "^examples/" | egrep -v "^README.md")
-          docs_files=$(git diff --name-only HEAD^)
-          if [ -z "$files" ]; then
-            echo "docs_only=true" >> $GITHUB_OUTPUT
-          else
-            echo "docs_only=false" >> $GITHUB_OUTPUT
-          fi
-
-          echo $files
-          echo $docs_files
+          ./.github/scripts/variables.sh docs_only >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         shell: bash --noprofile --norc -o pipefail {0}
 
@@ -268,6 +259,7 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: 'v3.18.6'
+        if: ${{ needs.checks.outputs.docs_only != 'true' }}
 
       - name: Azure login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
@@ -290,7 +282,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && (inputs.run_tests && inputs.run_tests || true) }}
+        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
 
       - name: Setup netrc
         run: |
@@ -305,24 +297,25 @@ jobs:
       - name: Generate secrets for tests
         run: |
           make secrets
+        if: ${{ needs.checks.outputs.docs_only != 'true' }}
 
       - name: Run Tests
         run: make cover
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && (inputs.run_tests && inputs.run_tests || true) }}
+        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: ./coverage.txt
           token: ${{ steps.secrets.outputs.CODECOV_TOKEN }} # required
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && (inputs.run_tests && inputs.run_tests || true) }}
+        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
 
       - name: Run static check
         uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
           version: "v0.7.0"
           install-go: false
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && (inputs.run_tests && inputs.run_tests || true) }}
+        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
 
       - name: Cleanup netrc
         run: rm -f $HOME/.netrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
         with:
           version: 'v3.18.6'
         if: >-
-          needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'
 
       - name: Azure login
@@ -266,9 +266,9 @@ jobs:
           tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_VAULT_SUBSCRIPTION_ID }}
         if: >-
-          (needs.checks.outputs.forked_workflow == 'false' &&
-          (needs.checks.outputs.run_tests == 'true' ||
-          needs.checks.outputs.binary_cache_hit == 'false'))
+          needs.checks.outputs.forked_workflow == 'false' &&
+          (needs.checks.outputs.run_tests == 'true' &&
+          needs.checks.outputs.binary_cache_hit == 'false')
 
       - name: Setup secrets
         id: secrets
@@ -278,30 +278,30 @@ jobs:
           echo "::add-mask::$CODECOV_TOKEN"
           echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> $GITHUB_OUTPUT
         if: >-
-          (needs.checks.outputs.forked_workflow == 'false' &&
-          (needs.checks.outputs.run_tests == 'true' ||
-          needs.checks.outputs.binary_cache_hit == 'false'))
+          needs.checks.outputs.forked_workflow == 'false' &&
+          (needs.checks.outputs.run_tests == 'true' &&
+          needs.checks.outputs.binary_cache_hit == 'false')
 
       - name: Setup Golang Environment
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
         if: >-
-          needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'
 
       - name: Generate secrets for tests
         run: |
           make secrets
         if: >-
-          needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'
 
       - name: Run Tests
         run: make cover
         if: >-
           inputs.force ||
-          needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'
 
       - name: Upload coverage to Codecov
@@ -311,7 +311,7 @@ jobs:
           token: ${{ steps.secrets.outputs.CODECOV_TOKEN }} # required
         if: >-
           (needs.checks.outputs.forked_workflow == 'false' &&
-          (needs.checks.outputs.run_tests == 'true' ||
+          (needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.binary_cache_hit == 'false'))
 
   staticcheck:
@@ -377,7 +377,7 @@ jobs:
     uses: ./.github/workflows/build-artifacts.yml
     with:
       force: ${{ needs.checks.outputs.docker_build == 'true' }}
-      branch: ${{ (github.head_ref && needs.checks.outputs.forked_workflow != 'true') && github.head_ref || github.ref }}
+      branch: ${{ (github.head_ref && needs.checks.outputs.forked_workflow == 'false') && github.head_ref || github.ref }}
       tag: ${{ needs.checks.outputs.build_tag }}
       docker-md5: ${{ needs.checks.outputs.docker_md5 }}
       go-md5: ${{ needs.checks.outputs.go_code_md5 }}
@@ -387,7 +387,7 @@ jobs:
       image-matrix-plus: ${{ needs.checks.outputs.image_matrix_plus }}
       image-matrix-nap: ${{ needs.checks.outputs.image_matrix_nap }}
       ic-version: ${{ needs.checks.outputs.ic_version }}
-      authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
+      authenticated: ${{ needs.checks.outputs.forked_workflow == 'false' }}
       runner: ubuntu-24.04
       write-to-cache: true
     permissions:
@@ -413,12 +413,12 @@ jobs:
     if: >-
       needs.checks.outputs.forked_workflow == 'false' &&
       (needs.checks.outputs.run_tests == 'true' ||
-      needs.checks.outputs.binary_cache_hit == 'false')
+      needs.checks.outputs.docker_build == 'true')
 
   package-tests:
     if: >-
       needs.checks.outputs.run_tests == 'true' ||
-      needs.checks.outputs.binary_cache_hit == 'false'
+      needs.checks.outputs.docker_build == 'true'
     name: Package Tests
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -500,7 +500,7 @@ jobs:
   helm-tests:
     if: >-
       needs.checks.outputs.run_tests == 'true' ||
-      needs.checks.outputs.binary_cache_hit == 'false'
+      needs.checks.outputs.docker_build == 'true'
     name: Helm Tests ${{ matrix.base-os }}
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -686,7 +686,9 @@ jobs:
         if: always()
 
   setup-matrix:
-    if: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.run_tests == 'true' }}
+    if: >-
+      needs.checks.outputs.run_tests == 'true' ||
+      needs.checks.outputs.docker_build == 'true'
     name: Setup Matrix for Smoke Tests
     runs-on: ubuntu-24.04
     needs: [build-artifacts, checks]
@@ -768,7 +770,9 @@ jobs:
         if: ${{ steps.check-image.outcome == 'failure' }}
 
   smoke-tests-oss:
-    if: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.run_tests == 'true' }}
+    if: >-
+      needs.checks.outputs.run_tests == 'true' ||
+      needs.checks.outputs.docker_build == 'true'
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -796,7 +800,9 @@ jobs:
       force: ${{ needs.checks.outputs.run_tests == 'true' }}
 
   smoke-tests-plus:
-    if: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.run_tests == 'true' }}
+    if: >-
+      needs.checks.outputs.run_tests == 'true' ||
+      needs.checks.outputs.docker_build == 'true'
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -824,7 +830,9 @@ jobs:
       force: ${{ needs.checks.outputs.run_tests == 'true' }}
 
   smoke-tests-nap:
-    if: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.run_tests == 'true' }}
+    if: >-
+      needs.checks.outputs.run_tests == 'true' ||
+      needs.checks.outputs.docker_build == 'true'
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,7 @@ jobs:
     if: ${{ inputs.force || (needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false') || (needs.checks.outputs.forked_workflow == 'false' && needs.checks.outputs.stable_image_exists != 'true' && needs.checks.outputs.docs_only == 'false') }}
 
   package-tests:
-    if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.run_tests && inputs.run_tests || true) }}
+    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
     name: Package Tests
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -522,7 +522,7 @@ jobs:
         if: ${{ ( needs.checks.outputs.forked_workflow == 'false' || needs.checks.outputs.docs_only == 'false' ) && github.event.pull_request }}
 
   helm-tests:
-    if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.run_tests && inputs.run_tests || true) }}
+    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
     name: Helm Tests ${{ matrix.base-os }}
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -708,7 +708,7 @@ jobs:
         if: always()
 
   setup-matrix:
-    if: ${{ inputs.force || (inputs.run_tests && inputs.run_tests || true) || needs.checks.outputs.docs_only != 'true' }}
+    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
     name: Setup Matrix for Smoke Tests
     runs-on: ubuntu-24.04
     needs: [build-artifacts, checks]
@@ -790,7 +790,7 @@ jobs:
         if: ${{ steps.check-image.outcome == 'failure' && needs.checks.outputs.docs_only == 'false' }}
 
   smoke-tests-oss:
-    if: ${{ inputs.force || (inputs.run_tests && inputs.run_tests || true) || needs.checks.outputs.docs_only != 'true' }}
+    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -815,10 +815,10 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
-      force: ${{ inputs.run_tests && inputs.run_tests || true }}
+      force: ${{ inputs.run_tests != false }}
 
   smoke-tests-plus:
-    if: ${{ inputs.force || (inputs.run_tests && inputs.run_tests || true) || needs.checks.outputs.docs_only != 'true' }}
+    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -843,10 +843,10 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
-      force: ${{ inputs.run_tests && inputs.run_tests || true }}
+      force: ${{ inputs.run_tests != false }}
 
   smoke-tests-nap:
-    if: ${{ inputs.force || (inputs.run_tests && inputs.run_tests || true) || needs.checks.outputs.docs_only != 'true' }}
+    if: ${{ needs.checks.outputs.docs_only != 'true' && inputs.run_tests != false }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -871,7 +871,7 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
-      force: ${{ inputs.run_tests && inputs.run_tests || true }}
+      force: ${{ inputs.run_tests != false }}
 
   tag-stable:
     name: Tag tested image as stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,12 +310,44 @@ jobs:
           token: ${{ steps.secrets.outputs.CODECOV_TOKEN }} # required
         if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
 
-      - name: Run static check
+      - name: Cleanup netrc
+        run: rm -f $HOME/.netrc
+        if: ${{ always() }}
+
+  staticcheck:
+    name: Static Check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    needs: checks
+    if: ${{ needs.checks.outputs.docs_only != 'true' }}
+    env:
+      GOPROXY: ${{ needs.checks.outputs.go_proxy }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Golang Environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Setup netrc
+        run: |
+          cat <<EOF > $HOME/.netrc
+          machine azr.artifactory.f5net.com
+              login ${{ secrets.ARTIFACTORY_USER }}
+              password ${{ secrets.ARTIFACTORY_TOKEN }}
+          EOF
+          chmod 600 $HOME/.netrc
+        if: ${{ needs.checks.outputs.forked_workflow != 'true' }}
+
+      - name: Run Static Check
         uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
-          version: "v0.7.0"
+          version: "v0.7.0" # renovate: datasource=github-releases depName=dominikh/go-tools
           install-go: false
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
+          use-cache: true
 
       - name: Cleanup netrc
         run: rm -f $HOME/.netrc
@@ -323,7 +355,7 @@ jobs:
 
   build-artifacts:
     name: Build Artifacts
-    needs: [checks, unit-tests, verify-codegen]
+    needs: [checks, unit-tests, staticcheck, verify-codegen]
     uses: ./.github/workflows/build-artifacts.yml
     with:
       force: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.binary_cache_hit != 'true' }}
@@ -821,7 +853,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     name: Final CI Results
-    needs: [tag-stable, build-artifacts, smoke-tests-oss, smoke-tests-plus, smoke-tests-nap, package-tests, helm-tests]
+    needs: [tag-stable, build-artifacts, smoke-tests-oss, smoke-tests-plus, smoke-tests-nap, package-tests, helm-tests, staticcheck]
     steps:
       - run: |
           tagResult="${{ needs.tag-stable.result }}"
@@ -831,6 +863,7 @@ jobs:
           smokePlusResult="${{ needs.smoke-tests-plus.result }}"
           smokeNAPResult="${{ needs.smoke-tests-nap.result }}"
           buildArtifactsResult="${{ needs.build-artifacts.result }}"
+          staticcheckResult="${{ needs.staticcheck.result }}"
           if [[ $tagResult != "success" && $tagResult != "skipped" ]]; then
             exit 1
           fi
@@ -850,6 +883,9 @@ jobs:
             exit 1
           fi
           if [[ $packageResult != "success" && $packageResult != "skipped" ]]; then
+            exit 1
+          fi
+          if [[ $staticcheckResult != "success" && $staticcheckResult != "skipped" ]]; then
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,15 +87,7 @@ jobs:
       - name: Configure pipeline Variables
         id: vars
         run: |
-          kindest_latest=$(curl -s "https://hub.docker.com/v2/repositories/kindest/node/tags" \
-            | jq -r '.results[].name' \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-            | sort -rV \
-            | grep -v v1.32.1 \
-            | head -n 1 \
-            | sed 's/^.\{1\}//' \
-            | tr -d '\n')
-          echo "k8s_latest=$kindest_latest" >> $GITHUB_OUTPUT
+          ./.github/scripts/variables.sh k8s_latest_version >> $GITHUB_OUTPUT
           echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
           source .github/data/version.txt
           echo "ic_version=${IC_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       image_matrix_plus: ${{ steps.vars.outputs.image_matrix_plus }}
       image_matrix_nap: ${{ steps.vars.outputs.image_matrix_nap }}
       docker_build: ${{ steps.docker_build.outputs.docker_build }}
-      run_tests: ${{ inputs.run_tests != 'false' }}
+      run_tests: ${{ steps.run_tests.outputs.run_tests }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -95,7 +95,6 @@ jobs:
           echo "image_matrix_oss=$(cat .github/data/matrix-images-oss.json | jq -c)" >> $GITHUB_OUTPUT
           echo "image_matrix_plus=$(cat .github/data/matrix-images-plus.json | jq -c)" >> $GITHUB_OUTPUT
           echo "image_matrix_nap=$(cat .github/data/matrix-images-nap.json | jq -c)" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
 
       - name: Fetch Cached Binary Artifacts
         id: binary-cache
@@ -164,7 +163,19 @@ jobs:
             docker_build="true"
           fi
           echo "docker_build=${docker_build}" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+
+      - name: Check if tests should be run
+        id: run_tests
+        run: |
+          run_tests="true"
+          if [ "${{ inputs.run_tests }}" = "false" ]; then
+            run_tests="false"
+          elif [ "${{ steps.docs.outputs.docs_only }}" = "false" ]; then
+            run_tests="false"
+          elif [ "${{ steps.vars.outputs.forked_workflow }}" = "false" ] && [ "${{ steps.binary-cache.outputs.cache-hit }}" = "true" ] && [ "${{ steps.vars.outputs.stable_image_exists }}" = "true" ]; then
+            run_tests="false"
+          fi
+          echo "run_tests=${run_tests}" >> $GITHUB_OUTPUT
 
       - name: Output variables
         run: |
@@ -185,7 +196,7 @@ jobs:
           echo 'image_matrix_plus: ${{ steps.vars.outputs.image_matrix_plus }}'
           echo 'image_matrix_nap: ${{ steps.vars.outputs.image_matrix_nap }}'
           echo 'docker_build: ${{ steps.docker_build.outputs.docker_build }}'
-          echo run_tests: ${{ inputs.run_tests != 'false' }}
+          echo run_tests: ${{ steps.run_tests.outputs.run_tests }}
 
   verify-codegen:
     name: Verify generated code
@@ -193,7 +204,7 @@ jobs:
     permissions:
       contents: read
     needs: checks
-    if: ${{ needs.checks.outputs.docs_only != 'true' }}
+    if: ${{ needs.checks.outputs.run_tests == 'false' }}
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -248,7 +259,9 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: 'v3.18.6'
-        if: ${{ needs.checks.outputs.docs_only != 'true' }}
+        if: >-
+          needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.binary_cache_hit == 'false'
 
       - name: Azure login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
@@ -257,10 +270,9 @@ jobs:
           tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_VAULT_SUBSCRIPTION_ID }}
         if: >-
-          needs.checks.outputs.docs_only != 'true' &&
-          (inputs.force ||
-          (needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.forked_workflow != 'true'))
+          (needs.checks.outputs.forked_workflow == 'false' &&
+          (needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.binary_cache_hit == 'false'))
 
       - name: Setup secrets
         id: secrets
@@ -270,34 +282,31 @@ jobs:
           echo "::add-mask::$CODECOV_TOKEN"
           echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> $GITHUB_OUTPUT
         if: >-
-          needs.checks.outputs.docs_only != 'true' &&
-          (inputs.force ||
-          (needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.forked_workflow != 'true'))
+          (needs.checks.outputs.forked_workflow == 'false' &&
+          (needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.binary_cache_hit == 'false'))
 
       - name: Setup Golang Environment
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
         if: >-
-          needs.checks.outputs.docs_only != 'true' &&
-          needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.run_tests == 'true'
+          needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.binary_cache_hit == 'false'
 
       - name: Generate secrets for tests
         run: |
           make secrets
         if: >-
-          needs.checks.outputs.docs_only != 'true' &&
-          needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.run_tests == 'true'
+          needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.binary_cache_hit == 'false'
 
       - name: Run Tests
         run: make cover
         if: >-
-          needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.run_tests == 'true' &&
-          needs.checks.outputs.docs_only != 'true'
+          inputs.force ||
+          needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.binary_cache_hit == 'false'
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -305,9 +314,9 @@ jobs:
           files: ./coverage.txt
           token: ${{ steps.secrets.outputs.CODECOV_TOKEN }} # required
         if: >-
-          needs.checks.outputs.binary_cache_hit != 'true' &&
-          needs.checks.outputs.run_tests == 'true' &&
-          needs.checks.outputs.docs_only != 'true'
+          (needs.checks.outputs.forked_workflow == 'false' &&
+          (needs.checks.outputs.run_tests == 'true' ||
+          needs.checks.outputs.binary_cache_hit == 'false'))
 
   staticcheck:
     name: Static Check
@@ -315,7 +324,7 @@ jobs:
     permissions:
       contents: read
     needs: checks
-    if: ${{ needs.checks.outputs.docs_only != 'true' }}
+    if: ${{ needs.checks.outputs.run_tests != 'true' }}
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -326,12 +335,12 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-        if: inputs.force || needs.checks.outputs.binary_cache_hit != 'true'
+        if: ${{ needs.checks.outputs.binary_cache_hit == 'false' }}
 
       - name: Generate secrets for tests
         run: |
           make secrets
-        if: inputs.force || needs.checks.outputs.binary_cache_hit != 'true'
+        if: ${{ needs.checks.outputs.binary_cache_hit == 'false' }}
 
       - name: Run Static Check
         uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
@@ -339,7 +348,7 @@ jobs:
           version: "2026.1" # renovate: datasource=github-releases depName=dominikh/go-tools
           install-go: false
           use-cache: true
-        if: inputs.force || needs.checks.outputs.binary_cache_hit != 'true'
+        if: ${{ needs.checks.outputs.binary_cache_hit == 'false' }}
 
   govulncheck:
     name: Vulnerability Check
@@ -347,7 +356,7 @@ jobs:
     permissions:
       contents: read
     needs: checks
-    if: ${{ needs.checks.outputs.docs_only != 'true' }}
+    if: ${{ needs.checks.outputs.run_tests != 'true' }}
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -358,21 +367,21 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-        if: inputs.force || needs.checks.outputs.binary_cache_hit != 'true'
+        if: ${{ needs.checks.outputs.binary_cache_hit == 'false' }}
 
       - name: Run govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
           repo-checkout: false
           cache: true
-        if: inputs.force || needs.checks.outputs.binary_cache_hit != 'true'
+        if: ${{ needs.checks.outputs.binary_cache_hit == 'false' }}
 
   build-artifacts:
     name: Build Artifacts
     needs: [checks, unit-tests, staticcheck, govulncheck, verify-codegen]
     uses: ./.github/workflows/build-artifacts.yml
     with:
-      force: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.binary_cache_hit != 'true' }}
+      force: ${{ needs.checks.outputs.docker_build == 'true' }}
       branch: ${{ (github.head_ref && needs.checks.outputs.forked_workflow != 'true') && github.head_ref || github.ref }}
       tag: ${{ needs.checks.outputs.build_tag }}
       docker-md5: ${{ needs.checks.outputs.docker_md5 }}
@@ -407,14 +416,14 @@ jobs:
       dry_run: false
     secrets: inherit
     if: >-
-      inputs.force ||
-      (needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false') ||
-      (needs.checks.outputs.forked_workflow == 'false' &&
-      needs.checks.outputs.stable_image_exists != 'true' &&
-      needs.checks.outputs.docs_only == 'false')
+      needs.checks.outputs.forked_workflow == 'false' &&
+      (needs.checks.outputs.run_tests == 'true' ||
+      needs.checks.outputs.binary_cache_hit == 'false')
 
   package-tests:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
+    if: >-
+      needs.checks.outputs.run_tests == 'true' ||
+      needs.checks.outputs.binary_cache_hit == 'false'
     name: Package Tests
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -494,7 +503,9 @@ jobs:
         if: ${{ ( needs.checks.outputs.forked_workflow == 'false' || needs.checks.outputs.docs_only == 'false' ) && github.event.pull_request }}
 
   helm-tests:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
+    if: >-
+      needs.checks.outputs.run_tests == 'true' ||
+      needs.checks.outputs.binary_cache_hit == 'false'
     name: Helm Tests ${{ matrix.base-os }}
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -564,7 +575,7 @@ jobs:
           token_format: access_token
           workload_identity_provider: ${{ steps.secrets.outputs.GCR_WORKLOAD_ID }}
           service_account: ${{ steps.secrets.outputs.GCR_SERVICE_ACCOUNT }}
-        if: ${{ needs.checks.outputs.forked_workflow == 'false' || needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
 
       - name: Login to GCR
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -572,7 +583,7 @@ jobs:
           registry: gcr.io
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
-        if: ${{ needs.checks.outputs.forked_workflow == 'false' || needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
 
       - name: Check if stable image exists
         id: stable_exists
@@ -580,23 +591,23 @@ jobs:
           if docker pull ${{ matrix.image }}:${{ needs.checks.outputs.stable_tag }}; then
             echo "exists=true" >> $GITHUB_OUTPUT
           fi
-        if: ${{ needs.checks.outputs.forked_workflow == 'false' || needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
 
       - name: Pull build image
         run: |
           docker pull ${{ matrix.image }}:${{ needs.checks.outputs.build_tag }}
-        if: ${{ ( needs.checks.outputs.forked_workflow == 'false' || needs.checks.outputs.docs_only == 'false' ) && steps.stable_exists.outputs.exists != 'true' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'false' && steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Fetch Cached Artifacts
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ needs.checks.outputs.go_code_md5 }}
-        if: ${{ needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'true' }}
 
       - name: Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-        if: ${{ needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'true' }}
 
       - name: Build Docker Image ${{ matrix.base-os }}
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -614,7 +625,7 @@ jobs:
           secret-files: |
             ${{ matrix.type == 'plus' && 'nginx-repo.crt=nginx-repo.crt' || '' }}
             ${{ matrix.type == 'plus' && 'nginx-repo.key=nginx-repo.key' || '' }}
-        if: ${{ needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'true' }}
 
       - name: Deploy Kubernetes
         id: k8s
@@ -625,11 +636,11 @@ jobs:
             docker exec -i ${{ github.run_id }}-control-plane \
               ctr --namespace=k8s.io images import -
           echo "DEBUG: Kind setup complete!"
-        if: ${{ steps.stable_exists.outputs.exists != 'true' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Create Plus Secret
         run: kubectl create secret generic license-token --from-literal=license.jwt="${{ steps.secrets.outputs.PLUS_JWT }}" --type="nginx.com/license"
-        if: ${{ matrix.type == 'plus' && steps.stable_exists.outputs.exists != 'true' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ matrix.type == 'plus' && steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Install Chart
         run: >
@@ -643,12 +654,12 @@ jobs:
           --set controller.telemetryReporting.enable=false
           --wait
         working-directory: ${{ github.workspace }}/charts/nginx-ingress
-        if: ${{ steps.stable_exists.outputs.exists != 'true' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Expose Test Ingresses
         run: |
           kubectl port-forward service/${{ matrix.type }}-nginx-ingress-controller 8080:80 8443:443 &
-        if: ${{ steps.stable_exists.outputs.exists != 'true' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Test HTTP
         run: |
@@ -660,7 +671,7 @@ jobs:
             fi
             printf '.'; counter=$(($counter+1)); sleep 5;
           done
-        if: ${{ steps.stable_exists.outputs.exists != 'true' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Test HTTPS
         run: |
@@ -672,7 +683,7 @@ jobs:
             fi
             printf '.'; counter=$(($counter+1)); sleep 5;
           done
-        if: ${{ steps.stable_exists.outputs.exists != 'true' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Clean up secrets
         run: |
@@ -680,7 +691,7 @@ jobs:
         if: always()
 
   setup-matrix:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.run_tests == 'true' }}
     name: Setup Matrix for Smoke Tests
     runs-on: ubuntu-24.04
     needs: [build-artifacts, checks]
@@ -710,7 +721,7 @@ jobs:
           client-id: ${{ secrets.AZURE_VAULT_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_VAULT_SUBSCRIPTION_ID }}
-        if: ${{ needs.checks.outputs.forked_workflow == 'false' || needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
 
       - name: Setup secrets
         id: secrets
@@ -722,7 +733,7 @@ jobs:
           GCR_SERVICE_ACCOUNT=$(az keyvault secret show --name kic-pipeline-gcr-sa --vault-name ${{ secrets.NIC_KEYVAULT_NAME }} --query value -o tsv)
           echo "::add-mask::$GCR_SERVICE_ACCOUNT"
           echo "GCR_SERVICE_ACCOUNT=$GCR_SERVICE_ACCOUNT" >> $GITHUB_OUTPUT
-        if: ${{ needs.checks.outputs.forked_workflow == 'false' || needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -731,7 +742,7 @@ jobs:
           token_format: access_token
           workload_identity_provider: ${{ steps.secrets.outputs.GCR_WORKLOAD_ID }}
           service_account: ${{ steps.secrets.outputs.GCR_SERVICE_ACCOUNT }}
-        if: ${{ needs.checks.outputs.forked_workflow == 'false' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
 
       - name: Login to GCR
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -739,7 +750,7 @@ jobs:
           registry: gcr.io
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
-        if: ${{ needs.checks.outputs.forked_workflow == 'false' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
 
       - name: Check if test image exists
         id: check-image
@@ -747,7 +758,7 @@ jobs:
           docker pull gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/test-runner:${{ hashFiles('./tests/requirements.txt', './tests/Dockerfile') || 'latest' }}
         shell: bash
         continue-on-error: true
-        if: ${{ needs.checks.outputs.forked_workflow == 'false' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
 
       - name: Build Test-Runner Container
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -759,10 +770,10 @@ jobs:
           pull: true
           push: ${{ needs.checks.outputs.forked_workflow == 'false' }}
           load: false
-        if: ${{ steps.check-image.outcome == 'failure' && needs.checks.outputs.docs_only == 'false' }}
+        if: ${{ steps.check-image.outcome == 'failure' }}
 
   smoke-tests-oss:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.run_tests == 'true' }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -785,12 +796,12 @@ jobs:
       go-md5: ${{ needs.checks.outputs.go_code_md5 }}
       build-tag: ${{ needs.checks.outputs.build_tag }}
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
-      authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
+      authenticated: ${{ needs.checks.outputs.forked_workflow == 'false' }}
       k8s-version: ${{ matrix.k8s }}
       force: ${{ needs.checks.outputs.run_tests == 'true' }}
 
   smoke-tests-plus:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.run_tests == 'true' }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -813,12 +824,12 @@ jobs:
       go-md5: ${{ needs.checks.outputs.go_code_md5 }}
       build-tag: ${{ needs.checks.outputs.build_tag }}
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
-      authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
+      authenticated: ${{ needs.checks.outputs.forked_workflow == 'false' }}
       k8s-version: ${{ matrix.k8s }}
       force: ${{ needs.checks.outputs.run_tests == 'true' }}
 
   smoke-tests-nap:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' || needs.checks.outputs.run_tests == 'true' }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -841,7 +852,7 @@ jobs:
       go-md5: ${{ needs.checks.outputs.go_code_md5 }}
       build-tag: ${{ needs.checks.outputs.build_tag }}
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
-      authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
+      authenticated: ${{ needs.checks.outputs.forked_workflow == 'false' }}
       k8s-version: ${{ matrix.k8s }}
       force: ${{ needs.checks.outputs.run_tests == 'true' }}
 
@@ -858,11 +869,8 @@ jobs:
       dry_run: false
     secrets: inherit
     if: >-
-      inputs.force ||
-      (needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false') ||
       (needs.checks.outputs.forked_workflow == 'false' &&
-      needs.checks.outputs.stable_image_exists != 'true' &&
-      needs.checks.outputs.docs_only == 'false')
+      needs.checks.outputs.stable_image_exists != 'true')
 
   final-results:
     if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       contents: read
     needs: checks
     if: >-
-      inputs.force == 'true' ||
+      inputs.force ||
       needs.checks.outputs.run_tests == 'true' &&
       needs.checks.outputs.binary_cache_hit == 'false'
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,10 @@ jobs:
               password ${{ secrets.ARTIFACTORY_TOKEN }}
           EOF
           chmod 600 $HOME/.netrc
-        if: ${{ inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true') }}
+        if: >-
+          inputs.force ||
+          (needs.checks.outputs.binary_cache_hit != 'true' &&
+          needs.checks.outputs.forked_workflow != 'true')
 
       - name: Check if go.mod and go.sum are up to date
         run: go mod tidy && git diff --exit-code -- go.mod go.sum
@@ -267,7 +270,11 @@ jobs:
           client-id: ${{ secrets.AZURE_VAULT_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_VAULT_SUBSCRIPTION_ID }}
-        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
+        if: >-
+          needs.checks.outputs.docs_only != 'true' &&
+          (inputs.force ||
+          (needs.checks.outputs.binary_cache_hit != 'true' &&
+          needs.checks.outputs.forked_workflow != 'true'))
 
       - name: Setup secrets
         id: secrets
@@ -276,13 +283,20 @@ jobs:
           CODECOV_TOKEN=$(az keyvault secret show --name code-cov --vault-name ${{ secrets.NIC_KEYVAULT_NAME }} --query value -o tsv)
           echo "::add-mask::$CODECOV_TOKEN"
           echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> $GITHUB_OUTPUT
-        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
+        if: >-
+          needs.checks.outputs.docs_only != 'true' &&
+          (inputs.force ||
+          (needs.checks.outputs.binary_cache_hit != 'true' &&
+          needs.checks.outputs.forked_workflow != 'true'))
 
       - name: Setup Golang Environment
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-        if: ${{ needs.checks.outputs.docs_only != 'true' && needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
+        if: >-
+          needs.checks.outputs.docs_only != 'true' &&
+          needs.checks.outputs.binary_cache_hit != 'true' &&
+          inputs.run_tests != false
 
       - name: Setup netrc
         run: |
@@ -292,7 +306,11 @@ jobs:
               password ${{ secrets.ARTIFACTORY_TOKEN }}
           EOF
           chmod 600 $HOME/.netrc
-        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
+        if: >-
+          needs.checks.outputs.docs_only != 'true' &&
+          (inputs.force ||
+          (needs.checks.outputs.binary_cache_hit != 'true' &&
+          needs.checks.outputs.forked_workflow != 'true'))
 
       - name: Generate secrets for tests
         run: |
@@ -301,14 +319,20 @@ jobs:
 
       - name: Run Tests
         run: make cover
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false && needs.checks.outputs.docs_only != 'true' }}
+        if: >-
+          needs.checks.outputs.binary_cache_hit != 'true' &&
+          inputs.run_tests != false &&
+          needs.checks.outputs.docs_only != 'true'
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: ./coverage.txt
           token: ${{ steps.secrets.outputs.CODECOV_TOKEN }} # required
-        if: ${{ needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false && needs.checks.outputs.docs_only != 'true' }}
+        if: >-
+          needs.checks.outputs.binary_cache_hit != 'true' &&
+          inputs.run_tests != false &&
+          needs.checks.outputs.docs_only != 'true'
 
       - name: Cleanup netrc
         run: rm -f $HOME/.netrc
@@ -333,7 +357,11 @@ jobs:
           client-id: ${{ secrets.AZURE_VAULT_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_VAULT_SUBSCRIPTION_ID }}
-        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
+        if: >-
+          needs.checks.outputs.docs_only != 'true' &&
+          (inputs.force ||
+          (needs.checks.outputs.binary_cache_hit != 'true' &&
+          needs.checks.outputs.forked_workflow != 'true'))
 
       - name: Setup secrets
         id: secrets
@@ -342,13 +370,20 @@ jobs:
           CODECOV_TOKEN=$(az keyvault secret show --name code-cov --vault-name ${{ secrets.NIC_KEYVAULT_NAME }} --query value -o tsv)
           echo "::add-mask::$CODECOV_TOKEN"
           echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> $GITHUB_OUTPUT
-        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
+        if: >-
+          needs.checks.outputs.docs_only != 'true' &&
+          (inputs.force ||
+          (needs.checks.outputs.binary_cache_hit != 'true' &&
+          needs.checks.outputs.forked_workflow != 'true'))
 
       - name: Setup Golang Environment
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-        if: ${{ needs.checks.outputs.docs_only != 'true' && needs.checks.outputs.binary_cache_hit != 'true' && inputs.run_tests != false }}
+        if: >-
+          needs.checks.outputs.docs_only != 'true' &&
+          needs.checks.outputs.binary_cache_hit != 'true' &&
+          inputs.run_tests != false
 
       - name: Setup netrc
         run: |
@@ -358,7 +393,11 @@ jobs:
               password ${{ secrets.ARTIFACTORY_TOKEN }}
           EOF
           chmod 600 $HOME/.netrc
-        if: ${{ needs.checks.outputs.docs_only != 'true' && (inputs.force || (needs.checks.outputs.binary_cache_hit != 'true' && needs.checks.outputs.forked_workflow != 'true')) }}
+        if: >-
+          needs.checks.outputs.docs_only != 'true' &&
+          (inputs.force ||
+          (needs.checks.outputs.binary_cache_hit != 'true' &&
+          needs.checks.outputs.forked_workflow != 'true'))
 
       - name: Generate secrets for tests
         run: |
@@ -462,7 +501,12 @@ jobs:
       target_tag: ${{ needs.checks.outputs.additional_tag }}
       dry_run: false
     secrets: inherit
-    if: ${{ inputs.force || (needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false') || (needs.checks.outputs.forked_workflow == 'false' && needs.checks.outputs.stable_image_exists != 'true' && needs.checks.outputs.docs_only == 'false') }}
+    if: >-
+      inputs.force ||
+      (needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false') ||
+      (needs.checks.outputs.forked_workflow == 'false' &&
+      needs.checks.outputs.stable_image_exists != 'true' &&
+      needs.checks.outputs.docs_only == 'false')
 
   package-tests:
     if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
@@ -908,7 +952,12 @@ jobs:
       target_tag: ${{ needs.checks.outputs.stable_tag }}
       dry_run: false
     secrets: inherit
-    if: ${{ inputs.force || (needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false') || (needs.checks.outputs.forked_workflow == 'false' && needs.checks.outputs.stable_image_exists != 'true' && needs.checks.outputs.docs_only == 'false') }}
+    if: >-
+      inputs.force ||
+      (needs.checks.outputs.forked_workflow == 'true' && needs.checks.outputs.docs_only == 'false') ||
+      (needs.checks.outputs.forked_workflow == 'false' &&
+      needs.checks.outputs.stable_image_exists != 'true' &&
+      needs.checks.outputs.docs_only == 'false')
 
   final-results:
     if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,9 +170,9 @@ jobs:
           run_tests="true"
           if [ "${{ inputs.run_tests }}" = "false" ]; then
             run_tests="false"
-          elif [ "${{ steps.docs.outputs.docs_only }}" = "false" ]; then
+          elif [ "${{ steps.docs.outputs.docs_only }}" = "true" ]; then
             run_tests="false"
-          elif [ "${{ steps.vars.outputs.forked_workflow }}" = "false" ] && [ "${{ steps.binary-cache.outputs.cache-hit }}" = "true" ] && [ "${{ steps.vars.outputs.stable_image_exists }}" = "true" ]; then
+          elif [ "${{ steps.binary-cache.outputs.cache-hit }}" = "true" ] && [ "${{ steps.vars.outputs.stable_image_exists }}" = "true" ]; then
             run_tests="false"
           fi
           echo "run_tests=${run_tests}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       image_matrix_plus: ${{ steps.vars.outputs.image_matrix_plus }}
       image_matrix_nap: ${{ steps.vars.outputs.image_matrix_nap }}
       docker_build: ${{ steps.docker_build.outputs.docker_build }}
-      run_tests: ${{ inputs.run_tests != false }}
+      run_tests: ${{ inputs.run_tests != 'false' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -160,7 +160,7 @@ jobs:
             docker_build="true"
           elif [ "${{ steps.vars.outputs.forked_workflow }}" = "true" ] && [ "${{ steps.docs.outputs.docs_only }}" = "false" ]; then
             docker_build="true"
-          elif [ "${{ steps.vars.outputs.forked_workflow }}" = "false" ] && [ "${{ steps.docs.outputs.docs_only }}" = "false" ] && [ "${{ steps.stable_exists.outputs.exists }}" = "false" ]; then
+          elif [ "${{ steps.vars.outputs.forked_workflow }}" = "false" ] && [ "${{ steps.docs.outputs.docs_only }}" = "false" ] && [ "${{ steps.binary-cache.outputs.cache-hit }}" = "false" ]; then
             docker_build="true"
           fi
           echo "docker_build=${docker_build}" >> $GITHUB_OUTPUT
@@ -185,7 +185,7 @@ jobs:
           echo 'image_matrix_plus: ${{ steps.vars.outputs.image_matrix_plus }}'
           echo 'image_matrix_nap: ${{ steps.vars.outputs.image_matrix_nap }}'
           echo 'docker_build: ${{ steps.docker_build.outputs.docker_build }}'
-          echo run_tests: ${{ inputs.run_tests != false }}
+          echo run_tests: ${{ inputs.run_tests != 'false' }}
 
   verify-codegen:
     name: Verify generated code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       image_matrix_plus: ${{ steps.vars.outputs.image_matrix_plus }}
       image_matrix_nap: ${{ steps.vars.outputs.image_matrix_nap }}
       docker_build: ${{ steps.docker_build.outputs.docker_build }}
+      run_tests: ${{ inputs.run_tests != false }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -184,6 +185,7 @@ jobs:
           echo 'image_matrix_plus: ${{ steps.vars.outputs.image_matrix_plus }}'
           echo 'image_matrix_nap: ${{ steps.vars.outputs.image_matrix_nap }}'
           echo 'docker_build: ${{ steps.docker_build.outputs.docker_build }}'
+          echo run_tests: ${{ inputs.run_tests != false }}
 
   verify-codegen:
     name: Verify generated code
@@ -280,7 +282,7 @@ jobs:
         if: >-
           needs.checks.outputs.docs_only != 'true' &&
           needs.checks.outputs.binary_cache_hit != 'true' &&
-          inputs.run_tests != false
+          needs.checks.outputs.run_tests == 'true'
 
       - name: Generate secrets for tests
         run: |
@@ -288,13 +290,13 @@ jobs:
         if: >-
           needs.checks.outputs.docs_only != 'true' &&
           needs.checks.outputs.binary_cache_hit != 'true' &&
-          inputs.run_tests != false
+          needs.checks.outputs.run_tests == 'true'
 
       - name: Run Tests
         run: make cover
         if: >-
           needs.checks.outputs.binary_cache_hit != 'true' &&
-          inputs.run_tests != false &&
+          needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.docs_only != 'true'
 
       - name: Upload coverage to Codecov
@@ -304,7 +306,7 @@ jobs:
           token: ${{ steps.secrets.outputs.CODECOV_TOKEN }} # required
         if: >-
           needs.checks.outputs.binary_cache_hit != 'true' &&
-          inputs.run_tests != false &&
+          needs.checks.outputs.run_tests == 'true' &&
           needs.checks.outputs.docs_only != 'true'
 
   staticcheck:
@@ -392,15 +394,6 @@ jobs:
       pull-requests: write # for scout report
     secrets: inherit
 
-  #  To pass the build in "Build Binaries" check
-  build-binaries:
-    name: Build Binaries
-    runs-on: ubuntu-24.04
-    needs: [build-artifacts]
-    steps:
-      - name: Report build binaries status
-        run: echo "Build binaries completed successfully via build-artifacts job"
-
   tag-target:
     name: Tag untested image with PR number
     needs: [checks, build-artifacts]
@@ -421,7 +414,7 @@ jobs:
       needs.checks.outputs.docs_only == 'false')
 
   package-tests:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
     name: Package Tests
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -501,7 +494,7 @@ jobs:
         if: ${{ ( needs.checks.outputs.forked_workflow == 'false' || needs.checks.outputs.docs_only == 'false' ) && github.event.pull_request }}
 
   helm-tests:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
     name: Helm Tests ${{ matrix.base-os }}
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -687,7 +680,7 @@ jobs:
         if: always()
 
   setup-matrix:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
     name: Setup Matrix for Smoke Tests
     runs-on: ubuntu-24.04
     needs: [build-artifacts, checks]
@@ -769,7 +762,7 @@ jobs:
         if: ${{ steps.check-image.outcome == 'failure' && needs.checks.outputs.docs_only == 'false' }}
 
   smoke-tests-oss:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -794,10 +787,10 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
-      force: ${{ inputs.run_tests != false }}
+      force: ${{ needs.checks.outputs.run_tests == 'true' }}
 
   smoke-tests-plus:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -822,10 +815,10 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
-      force: ${{ inputs.run_tests != false }}
+      force: ${{ needs.checks.outputs.run_tests == 'true' }}
 
   smoke-tests-nap:
-    if: ${{ needs.checks.outputs.docker_build == 'true' && inputs.run_tests != false }}
+    if: ${{ needs.checks.outputs.docker_build == 'true' && needs.checks.outputs.run_tests == 'true' }}
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -850,7 +843,7 @@ jobs:
       stable-tag: ${{ needs.checks.outputs.stable_tag }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       k8s-version: ${{ matrix.k8s }}
-      force: ${{ inputs.run_tests != false }}
+      force: ${{ needs.checks.outputs.run_tests == 'true' }}
 
   tag-stable:
     name: Tag tested image as stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,7 @@ jobs:
       ic-version: ${{ needs.checks.outputs.ic_version }}
       authenticated: ${{ needs.checks.outputs.forked_workflow != 'true' }}
       runner: ubuntu-24.04
-      write-to-cache: false
+      write-to-cache: ${{ inputs.force != true }}
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
       - name: Run Static Check
         uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
-          version: "v0.7.0" # renovate: datasource=github-releases depName=dominikh/go-tools
+          version: "2026.1" # renovate: datasource=github-releases depName=dominikh/go-tools
           install-go: false
           use-cache: true
 

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -24,10 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Modify readme for DockerHub
-        run: |
-          sed -i '3,4d' README.md
-
       - name: Azure login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -189,6 +189,7 @@ jobs:
       docker-md5: ${{ needs.checks.outputs.docker_md5 }}
       runner: "ubuntu-24.04-amd64"
       write-to-cache: true
+      read-from-cache: false
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -43,15 +43,7 @@ jobs:
       - name: Output Variables
         id: vars
         run: |
-          kindest_latest=$(curl -s "https://hub.docker.com/v2/repositories/kindest/node/tags" \
-            | jq -r '.results[].name' \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-            | sort -rV \
-            | grep -v v1.32.1 \
-            | head -n 1 \
-            | sed 's/^.\{1\}//' \
-            | tr -d '\n')
-          echo "k8s_latest=$kindest_latest" >> $GITHUB_OUTPUT
+          ./.github/scripts/variables.sh k8s_latest_version >> $GITHUB_OUTPUT
           kindest_versions=$(curl -s "https://hub.docker.com/v2/repositories/kindest/node/tags/?page_size=50" \
             | jq -r '.results[].name' \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
       docker-md5: ${{ needs.variables.outputs.docker_md5 }}
       runner: "ubuntu-24.04-amd64"
       write-to-cache: true
+      read-from-cache: false
     secrets: inherit
     permissions:
       contents: read


### PR DESCRIPTION
This pull request introduces several improvements to the CI/CD workflows, focusing on better handling of documentation-only changes, improved caching controls for Docker builds, and refactoring for maintainability. The main highlights include skipping unnecessary jobs for docs-only PRs, centralizing and simplifying version and docs checks, and adding more granular cache controls to workflows.

**Key improvements:**

*Docs-only change detection and workflow optimization:*
- Centralized the logic for detecting docs-only changes in `variables.sh`, and updated the `ci.yml` workflow to use this, ensuring that jobs like tests and builds are skipped when only documentation is modified. This reduces unnecessary CI resource usage and speeds up docs PRs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL69-R69) [[2]](diffhunk://#diff-ee584368102d8c79edffeed7d08f036b755a28f90261f0eb9870dce1f3916ac5R64-R77) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR194)
- Updated conditional logic throughout `ci.yml` to consistently skip jobs when `docs_only` is true, including test, build, and deployment jobs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR194) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR249-R261) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL295-R370) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL357-R386) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL387-R424) [[6]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL470-R504) [[7]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL656-R690) [[8]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL738-R772) [[9]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL763-R800) [[10]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL791-R828)

*Caching and build improvements:*
- Added a `read-from-cache` input to all relevant build workflows (`build-artifacts.yml`, `build-oss.yml`, `build-plus.yml`), allowing finer control over Docker layer caching and improving build performance. [[1]](diffhunk://#diff-b42f740b4418aaeb96e2db7ca7816039f8cfb34d8e1e4a4b7519d540b34a2a08R50-R53) [[2]](diffhunk://#diff-f892d9cdbe9f4a9dcc4db830d4d374e40e2c3bc4aa6a41145b5779b53fc1d4c2R41-R45) [[3]](diffhunk://#diff-6dc3f95d2feea751f4d59ec09be73e2c5679faa5aa3f27ff1cff30d7502c2850R47-R51)
- Updated Docker build steps to use the new `read-from-cache` input, making cache usage explicit and configurable. [[1]](diffhunk://#diff-f892d9cdbe9f4a9dcc4db830d4d374e40e2c3bc4aa6a41145b5779b53fc1d4c2L217-R222) [[2]](diffhunk://#diff-6dc3f95d2feea751f4d59ec09be73e2c5679faa5aa3f27ff1cff30d7502c2850L245-R250)
- Passed the `read-from-cache` input through to reusable workflows for consistency. [[1]](diffhunk://#diff-b42f740b4418aaeb96e2db7ca7816039f8cfb34d8e1e4a4b7519d540b34a2a08R220) [[2]](diffhunk://#diff-b42f740b4418aaeb96e2db7ca7816039f8cfb34d8e1e4a4b7519d540b34a2a08R249) [[3]](diffhunk://#diff-b42f740b4418aaeb96e2db7ca7816039f8cfb34d8e1e4a4b7519d540b34a2a08R277)

*Version and variable management:*
- Moved the logic for determining the latest Kubernetes version (`K8S_LATEST_VERSION`) into `variables.sh` for consistency and maintainability, and updated the workflow to use this script instead of inline shell logic. [[1]](diffhunk://#diff-ee584368102d8c79edffeed7d08f036b755a28f90261f0eb9870dce1f3916ac5R15-R17) [[2]](diffhunk://#diff-ee584368102d8c79edffeed7d08f036b755a28f90261f0eb9870dce1f3916ac5R64-R77) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL90-R81)

*Refactoring and cleanup:*
- Removed redundant and duplicated `netrc` setup and cleanup steps, streamlining the workflow and reducing potential security risks. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL223-L232) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL258-L261) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR249-R261) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL295-R370)
- Updated conditional logic for test and build jobs to use clearer and more maintainable expressions, reducing confusion and potential errors. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL357-R386) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL387-R424) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL470-R504) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL656-R690) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL738-R772) [[6]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL763-R800) [[7]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL791-R828)

*Static analysis and security:*
- Split out static analysis (`staticcheck`) and vulnerability scanning (`govulncheck`) into dedicated jobs, ensuring these checks are always run unless the PR is docs-only. Updated to the latest versions of these tools.

These changes make the CI/CD pipeline more efficient, easier to maintain, and better at handling documentation-only pull requests.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
