### PR TITLE
Add fastcgi-services annotation for FastCGI backends

### DIFF
--- a/examples/ingress-resources/fastcgi-services/README.md
+++ b/examples/ingress-resources/fastcgi-services/README.md
@@ -1,0 +1,133 @@
+# FastCGI support
+
+To route traffic to a FastCGI backend (such as PHP-FPM) with NGINX Ingress Controller, add the
+**nginx.org/fastcgi-services** annotation to your Ingress resource definition. This eliminates the need for a sidecar
+NGINX container in your application pods.
+
+## Syntax
+
+The `nginx.org/fastcgi-services` specifies which services are FastCGI services. The annotation syntax is as follows:
+
+```yaml
+nginx.org/fastcgi-services: "service1[,service2,...]"
+```
+
+## Example 1: PHP-FPM application
+
+In the following example we route traffic to a PHP-FPM backend that speaks FastCGI on port 9000:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: php-ingress
+  annotations:
+    nginx.org/fastcgi-services: "php-svc"
+    nginx.org/server-snippets: |
+      root /var/www/html;
+    nginx.org/location-snippets: |
+      fastcgi_index index.php;
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: php.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: php-svc
+            port:
+              number: 9000
+```
+
+*php-svc* is a Kubernetes Service pointing to PHP-FPM pods. NGINX will use `fastcgi_pass` instead of `proxy_pass` for
+this service.
+
+The `server-snippets` annotation sets `root` to the directory containing your PHP files inside the PHP-FPM container.
+This is required so that `SCRIPT_FILENAME` (which defaults to `$document_root$fastcgi_script_name`) resolves to the
+correct file path. The `location-snippets` annotation sets `fastcgi_index` for directory requests.
+
+> **Note**: The snippet annotations require `-enable-snippets` on the Ingress Controller.
+
+## Example 2: Symfony application with custom SCRIPT_FILENAME
+
+Symfony routes all requests through `public/index.php`. Use `nginx.org/server-snippets` to set the document root and
+`nginx.org/location-snippets` to override the default `SCRIPT_FILENAME` and set `fastcgi_index`:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: symfony-ingress
+  annotations:
+    nginx.org/fastcgi-services: "symfony-svc"
+    nginx.org/server-snippets: |
+      root /app/public;
+    nginx.org/location-snippets: |
+      fastcgi_index index.php;
+      fastcgi_param SCRIPT_FILENAME /app/public/index.php;
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: symfony.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: symfony-svc
+            port:
+              number: 9000
+```
+
+> **Note**: The `location-snippets` annotation requires `-enable-snippets` on the Ingress Controller.
+
+## Example 3: Mixed FastCGI and HTTP backends
+
+You can mix FastCGI and HTTP backends on the same Ingress. Only the services listed in `nginx.org/fastcgi-services` use
+`fastcgi_pass`; all others continue to use `proxy_pass`:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mixed-ingress
+  annotations:
+    nginx.org/fastcgi-services: "php-svc"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: app.example.com
+    http:
+      paths:
+      - path: /api
+        pathType: Prefix
+        backend:
+          service:
+            name: php-svc
+            port:
+              number: 9000
+      - path: /static
+        pathType: Prefix
+        backend:
+          service:
+            name: static-svc
+            port:
+              number: 80
+```
+
+## Migration from community ingress-nginx
+
+Users migrating from the community `kubernetes/ingress-nginx` controller should note the following annotation mapping:
+
+| Community (kubernetes/ingress-nginx) | NginxInc (nginx/kubernetes-ingress) |
+|--------------------------------------|-------------------------------------|
+| `nginx.ingress.kubernetes.io/backend-protocol: "FCGI"` | `nginx.org/fastcgi-services: "svc-name"` |
+| `nginx.ingress.kubernetes.io/fastcgi-index` | Use `nginx.org/location-snippets` with `fastcgi_index` directive |
+| `nginx.ingress.kubernetes.io/fastcgi-params-configmap` | Use `nginx.org/location-snippets` with `fastcgi_param` directives |
+
+The key difference is that the NginxInc annotation uses per-service granularity (matching `nginx.org/grpc-services`),
+while the community annotation applies to all paths in the Ingress.

--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -93,6 +93,7 @@ var masterDenylist = map[string]bool{
 	"nginx.org/rewrites":                      true,
 	"nginx.org/ssl-services":                  true,
 	"nginx.org/grpc-services":                 true,
+	"nginx.org/fastcgi-services":              true,
 	"nginx.org/websocket-services":            true,
 	StickyCookieServicesAnnotation:            true,
 	StickyCookieServicesAnnotationPlus:        true,
@@ -715,6 +716,13 @@ func getSSLServices(ingEx *IngressEx) map[string]bool {
 
 func getGrpcServices(ingEx *IngressEx) map[string]bool {
 	if value, exists := ingEx.Ingress.Annotations["nginx.org/grpc-services"]; exists {
+		return ParseServiceList(value)
+	}
+	return nil
+}
+
+func getFastCGIServices(ingEx *IngressEx) map[string]bool {
+	if value, exists := ingEx.Ingress.Annotations["nginx.org/fastcgi-services"]; exists {
 		return ParseServiceList(value)
 	}
 	return nil

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -250,6 +250,7 @@ func generateNginxCfg(ncp NginxCfgParams) (version1.IngressNginxConfig, Warnings
 	rewriteTarget, rewriteTargetWarnings := getRewriteTarget(ncp.BaseCfgParams.Context, ncp.ingEx)
 	sslServices := getSSLServices(ncp.ingEx)
 	grpcServices := getGrpcServices(ncp.ingEx)
+	fcgiServices := getFastCGIServices(ncp.ingEx)
 
 	upstreams := make(map[string]version1.Upstream)
 	healthChecks := make(map[string]version1.HealthCheck)
@@ -487,7 +488,7 @@ func generateNginxCfg(ncp NginxCfgParams) (version1.IngressNginxConfig, Warnings
 			ssl := isSSLEnabled(sslServices[path.Backend.Service.Name], cfgParams, ncp.staticParams)
 			proxySSLName := generateProxySSLName(path.Backend.Service.Name, ncp.ingEx.Ingress.Namespace)
 			loc := createLocation(pathOrDefault(path.Path), upstreams[upsName], &cfgParams, wsServices[path.Backend.Service.Name], rewrites[path.Backend.Service.Name],
-				ssl, grpcServices[path.Backend.Service.Name], proxySSLName, path.PathType, path.Backend.Service.Name, rewriteTarget)
+				ssl, grpcServices[path.Backend.Service.Name], fcgiServices[path.Backend.Service.Name], proxySSLName, path.PathType, path.Backend.Service.Name, rewriteTarget)
 			if ncp.isMinion && policyCfg.EgressMTLS != nil {
 				// Minion egress mTLS is rendered per location to match VirtualServer route policy behavior.
 				loc.EgressMTLS = policyCfg.EgressMTLS
@@ -578,7 +579,7 @@ func generateNginxCfg(ncp NginxCfgParams) (version1.IngressNginxConfig, Warnings
 			ssl := isSSLEnabled(sslServices[ncp.ingEx.Ingress.Spec.DefaultBackend.Service.Name], cfgParams, ncp.staticParams)
 			proxySSLName := generateProxySSLName(ncp.ingEx.Ingress.Spec.DefaultBackend.Service.Name, ncp.ingEx.Ingress.Namespace)
 			loc := createLocation(pathOrDefault("/"), upstreams[upsName], &cfgParams, wsServices[ncp.ingEx.Ingress.Spec.DefaultBackend.Service.Name], rewrites[ncp.ingEx.Ingress.Spec.DefaultBackend.Service.Name],
-				ssl, grpcServices[ncp.ingEx.Ingress.Spec.DefaultBackend.Service.Name], proxySSLName, new(networking.PathTypePrefix), ncp.ingEx.Ingress.Spec.DefaultBackend.Service.Name, rewriteTarget)
+				ssl, grpcServices[ncp.ingEx.Ingress.Spec.DefaultBackend.Service.Name], fcgiServices[ncp.ingEx.Ingress.Spec.DefaultBackend.Service.Name], proxySSLName, new(networking.PathTypePrefix), ncp.ingEx.Ingress.Spec.DefaultBackend.Service.Name, rewriteTarget)
 			if ncp.isMinion && policyCfg.EgressMTLS != nil {
 				// Keep default-backend locations aligned with other minion locations for egress mTLS overrides.
 				loc.EgressMTLS = policyCfg.EgressMTLS
@@ -759,7 +760,7 @@ func generateIngressPath(path string, pathType *networking.PathType) string {
 	return path
 }
 
-func createLocation(path string, upstream version1.Upstream, cfg *ConfigParams, websocket bool, rewrite string, ssl bool, grpc bool, proxySSLName string, pathType *networking.PathType, serviceName string, rewriteTarget string) version1.Location {
+func createLocation(path string, upstream version1.Upstream, cfg *ConfigParams, websocket bool, rewrite string, ssl bool, grpc bool, fcgi bool, proxySSLName string, pathType *networking.PathType, serviceName string, rewriteTarget string) version1.Location {
 	loc := version1.Location{
 		Path:                     generateIngressPath(path, pathType),
 		Upstream:                 upstream,
@@ -775,6 +776,7 @@ func createLocation(path string, upstream version1.Upstream, cfg *ConfigParams, 
 		RewriteTarget:            rewriteTarget,
 		SSL:                      ssl,
 		GRPC:                     grpc,
+		FCGI:                     fcgi,
 		ProxyBuffering:           cfg.ProxyBuffering,
 		ProxyBuffers:             cfg.ProxyBuffers,
 		ProxyBufferSize:          cfg.ProxyBufferSize,

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -101,6 +101,47 @@ func TestGenerateNginxCfgForJWT(t *testing.T) {
 	}
 }
 
+func TestGenerateNginxCfgForFastCGI(t *testing.T) {
+	t.Parallel()
+	cafeIngressEx := createCafeIngressEx()
+	cafeIngressEx.Ingress.Annotations["nginx.org/fastcgi-services"] = "coffee-svc"
+
+	isPlus := false
+	configParams := NewDefaultConfigParams(context.Background(), isPlus)
+
+	result, warnings := generateNginxCfg(NginxCfgParams{
+		staticParams:         &StaticConfigParams{},
+		ingEx:                &cafeIngressEx,
+		apResources:          nil,
+		dosResource:          nil,
+		isMinion:             false,
+		isPlus:               false,
+		BaseCfgParams:        configParams,
+		isResolverConfigured: false,
+		isWildcardEnabled:    false,
+	})
+
+	coffeeFCGI := false
+	teaFCGI := false
+	for _, loc := range result.Servers[0].Locations {
+		if loc.Path == "/coffee" {
+			coffeeFCGI = loc.FCGI
+		}
+		if loc.Path == "/tea" {
+			teaFCGI = loc.FCGI
+		}
+	}
+	if !coffeeFCGI {
+		t.Error("generateNginxCfg: coffee-svc location should have FCGI=true")
+	}
+	if teaFCGI {
+		t.Error("generateNginxCfg: tea-svc location should have FCGI=false")
+	}
+	if len(warnings) != 0 {
+		t.Errorf("generateNginxCfg returned warnings: %v", warnings)
+	}
+}
+
 func TestGenerateNginxCfgForBasicAuth(t *testing.T) {
 	t.Parallel()
 	cafeIngressEx := createCafeIngressEx()

--- a/internal/configs/version1/__snapshots__/template_test.snap
+++ b/internal/configs/version1/__snapshots__/template_test.snap
@@ -1266,6 +1266,51 @@ server {
 
 ---
 
+[TestExecuteTemplate_ForIngressForNGINXPlusWithFastCGI - 1]
+# configuration for default/fcgi-ingress
+upstream test {
+    zone test 256k;
+    server 127.0.0.1:8181 max_fails=0 fail_timeout=1s max_conns=0 slow_start=5s;
+}
+
+
+server {
+
+    server_tokens "off";
+
+    server_name fcgi.example.com;
+
+    status_zone ;
+    set $resource_type "ingress";
+    set $resource_name "fcgi-ingress";
+    set $resource_namespace "default";
+    set $service "-";
+
+    
+
+    
+    location / {
+        set $service "";
+        status_zone "";
+
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+        fastcgi_param HTTP_X_FORWARDED_HOST $host;
+        fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+        fastcgi_connect_timeout 60s;
+        fastcgi_read_timeout 60s;
+        fastcgi_send_timeout 60s;
+        client_max_body_size 1m;
+        fastcgi_pass test;
+        
+    }
+    
+}
+
+---
+
 [TestExecuteTemplate_ForIngressForNGINXPlusWithHTTP2Off - 1]
 # configuration for default/cafe-ingress
 upstream test {
@@ -2600,6 +2645,46 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_buffering off;
         proxy_pass http://test;
+        
+    }
+    
+}
+
+---
+
+[TestExecuteTemplate_ForIngressForNGINXWithFastCGI - 1]
+# configuration for default/fcgi-ingress
+upstream test {
+    zone test 256k;
+    server 127.0.0.1:8181 max_fails=0 fail_timeout=1s max_conns=0;
+}
+
+
+
+server {
+
+    server_tokens off;
+
+    server_name fcgi.example.com;
+
+    set $resource_type "ingress";
+    set $resource_name "fcgi-ingress";
+    set $resource_namespace "default";
+    set $service "-";
+    location / {
+        set $service "";
+
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+        fastcgi_param HTTP_X_FORWARDED_HOST $host;
+        fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+        fastcgi_connect_timeout 60s;
+        fastcgi_read_timeout 60s;
+        fastcgi_send_timeout 60s;
+        client_max_body_size 1m;
+        fastcgi_pass test;
         
     }
     

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -192,6 +192,7 @@ type Location struct {
 	RewriteTarget        string
 	SSL                  bool
 	GRPC                 bool
+	FCGI                 bool
 	ProxyBuffering       bool
 	ProxyBuffers         string
 	ProxyBufferSize      string

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -322,7 +322,41 @@ server {
 		{{$proxyOrGRPC}}_ssl_server_name {{ if .ServerName }}on{{else}}off{{end}};
 		{{$proxyOrGRPC}}_ssl_name {{ .SSLName }};
 		{{- end}}
-		{{- if $location.GRPC}}
+		{{- if $location.FCGI}}
+
+		{{- with $jwt := $location.JWTAuth}}
+		auth_jwt_key_file {{$jwt.Key}};
+		auth_jwt "{{.Realm}}"{{if $jwt.Token}} token={{$jwt.Token}}{{end}};
+		{{- end}}
+
+		{{- with $location.BasicAuth }}
+		auth_basic {{ printf "%q" .Realm }};
+		auth_basic_user_file {{ .Secret }};
+		{{- end }}
+
+		include fastcgi_params;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+		fastcgi_param HTTP_X_FORWARDED_HOST $host;
+		fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
+		fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+		fastcgi_connect_timeout {{$location.ProxyConnectTimeout}};
+		fastcgi_read_timeout {{$location.ProxyReadTimeout}};
+		fastcgi_send_timeout {{$location.ProxySendTimeout}};
+		client_max_body_size {{$location.ClientMaxBodySize}};
+		{{- if $location.ClientBodyBufferSize }}
+		client_body_buffer_size {{$location.ClientBodyBufferSize}};
+		{{- end}}
+		{{- if $location.ProxyBufferSize}}
+		fastcgi_buffer_size {{$location.ProxyBufferSize}};
+		{{- end}}
+		{{- if $location.ProxyBuffers}}
+		fastcgi_buffers {{$location.ProxyBuffers}};
+		{{- end}}
+		{{- range $value := $location.LocationSnippets}}
+		{{$value}}{{end}}
+		fastcgi_pass {{$location.Upstream.Name}};
+		{{- else if $location.GRPC}}
 		{{- if not $server.GRPCOnly}}
 		error_page 400 @grpcerror400;
 		error_page 401 @grpcerror401;

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -221,7 +221,36 @@ server {
 		{{$proxyOrGRPC}}_ssl_server_name {{ if .ServerName }}on{{else}}off{{end}};
 		{{$proxyOrGRPC}}_ssl_name {{ .SSLName }};
 		{{- end}}
-		{{- if $location.GRPC}}
+		{{- if $location.FCGI}}
+
+		{{- with $location.BasicAuth }}
+		auth_basic {{ printf "%q" .Realm }};
+		auth_basic_user_file {{ .Secret }};
+		{{- end }}
+
+		include fastcgi_params;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+		fastcgi_param HTTP_X_FORWARDED_HOST $host;
+		fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
+		fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+		fastcgi_connect_timeout {{$location.ProxyConnectTimeout}};
+		fastcgi_read_timeout {{$location.ProxyReadTimeout}};
+		fastcgi_send_timeout {{$location.ProxySendTimeout}};
+		client_max_body_size {{$location.ClientMaxBodySize}};
+		{{- if $location.ClientBodyBufferSize }}
+		client_body_buffer_size {{$location.ClientBodyBufferSize}};
+		{{- end}}
+		{{- if $location.ProxyBufferSize}}
+		fastcgi_buffer_size {{$location.ProxyBufferSize}};
+		{{- end}}
+		{{- if $location.ProxyBuffers}}
+		fastcgi_buffers {{$location.ProxyBuffers}};
+		{{- end}}
+		{{- range $value := $location.LocationSnippets}}
+		{{$value}}{{- end}}
+		fastcgi_pass {{$location.Upstream.Name}};
+		{{- else if $location.GRPC}}
 		{{- if not $server.GRPCOnly}}
 		error_page 400 @grpcerror400;
 		error_page 401 @grpcerror401;

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -5723,3 +5723,107 @@ func newIngressConfigWithEgressMTLS(grpc bool) IngressNginxConfig {
 		Upstreams: []Upstream{upstream},
 	}
 }
+
+func TestExecuteTemplate_ForIngressForNGINXWithFastCGI(t *testing.T) {
+	t.Parallel()
+
+	tmpl := newNGINXIngressTmpl(t)
+	buf := &bytes.Buffer{}
+
+	cfg := IngressNginxConfig{
+		Servers: []Server{
+			{
+				Name:         "fcgi.example.com",
+				ServerTokens: "off",
+				Locations: []Location{
+					{
+						Path:                "/",
+						Upstream:            testUpstream,
+						ProxyConnectTimeout: "60s",
+						ProxyReadTimeout:    "60s",
+						ProxySendTimeout:    "60s",
+						ClientMaxBodySize:   "1m",
+						FCGI:                true,
+					},
+				},
+			},
+		},
+		Upstreams: []Upstream{testUpstream},
+		Ingress: Ingress{
+			Name:      "fcgi-ingress",
+			Namespace: "default",
+		},
+	}
+
+	err := tmpl.Execute(buf, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bufString := buf.String()
+
+	if !strings.Contains(bufString, "fastcgi_pass") {
+		t.Error("want fastcgi_pass in generated config")
+	}
+	if !strings.Contains(bufString, "include fastcgi_params;") {
+		t.Error("want include fastcgi_params in generated config")
+	}
+	if strings.Contains(bufString, "proxy_pass") {
+		t.Error("want no proxy_pass in FastCGI location")
+	}
+
+	snaps.MatchSnapshot(t, bufString)
+	t.Log(bufString)
+}
+
+func TestExecuteTemplate_ForIngressForNGINXPlusWithFastCGI(t *testing.T) {
+	t.Parallel()
+
+	tmpl := newNGINXPlusIngressTmpl(t)
+	buf := &bytes.Buffer{}
+
+	cfg := IngressNginxConfig{
+		Servers: []Server{
+			{
+				Name:         "fcgi.example.com",
+				ServerTokens: "off",
+				Locations: []Location{
+					{
+						Path:                "/",
+						Upstream:            testUpstream,
+						ProxyConnectTimeout: "60s",
+						ProxyReadTimeout:    "60s",
+						ProxySendTimeout:    "60s",
+						ClientMaxBodySize:   "1m",
+						FCGI:                true,
+					},
+				},
+			},
+		},
+		Upstreams: []Upstream{testUpstream},
+		Ingress: Ingress{
+			Name:      "fcgi-ingress",
+			Namespace: "default",
+		},
+	}
+
+	err := tmpl.Execute(buf, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bufString := buf.String()
+
+	if !strings.Contains(bufString, "fastcgi_pass") {
+		t.Error("want fastcgi_pass in generated config")
+	}
+	if !strings.Contains(bufString, "include fastcgi_params;") {
+		t.Error("want include fastcgi_params in generated config")
+	}
+	if strings.Contains(bufString, "proxy_pass") {
+		t.Error("want no proxy_pass in FastCGI location")
+	}
+
+	snaps.MatchSnapshot(t, bufString)
+	t.Log(bufString)
+}

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -66,6 +66,7 @@ const (
 	websocketServicesAnnotation           = "nginx.org/websocket-services"
 	sslServicesAnnotation                 = "nginx.org/ssl-services"
 	grpcServicesAnnotation                = "nginx.org/grpc-services"
+	fastcgiServicesAnnotation             = "nginx.org/fastcgi-services"
 	rewritesAnnotation                    = "nginx.org/rewrites"
 	rewriteTargetAnnotation               = "nginx.org/rewrite-target"
 	stickyCookieServicesAnnotation        = configs.StickyCookieServicesAnnotation
@@ -350,6 +351,10 @@ var (
 			validateServiceListAnnotation,
 		},
 		grpcServicesAnnotation: {
+			validateRequiredAnnotation,
+			validateServiceListAnnotation,
+		},
+		fastcgiServicesAnnotation: {
 			validateRequiredAnnotation,
 			validateServiceListAnnotation,
 		},


### PR DESCRIPTION
### Proposed changes

Add nginx.org/fastcgi-services annotation that enables fastcgi_pass for backend services speaking the FastCGI protocol (e.g. PHP-FPM). This eliminates the need for sidecar NGINX containers when routing to FastCGI-only backends.

The annotation accepts a comma-separated list of service names, mirroring the existing nginx.org/grpc-services pattern. Services listed use fastcgi_pass with include fastcgi_params, default SCRIPT_FILENAME, and fastcgi_index index.php.

Fixes #8184
Fixes #458


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
