### PR TITLE
Tighten path validation

### DIFF
--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -952,9 +952,10 @@ func validateRewriteTargetAnnotation(context *annotationValidationContext) field
 		allErrs = append(allErrs, field.Invalid(context.fieldPath, target, "NGINX configuration syntax characters (;{}) and []|<>,^`~ not allowed in rewrite target"))
 	}
 
-	// Prevent control characters and line breaks that could break NGINX config
+	// Prevent ASCII control characters (< 32) and DEL (127) that could break NGINX config.
+	// Whitespace is already rejected by ValidatePath above.
 	if strings.IndexFunc(target, func(r rune) bool {
-		return r <= 32 || r == 127 // ASCII control characters; 127 is DEL, 32 is space
+		return r < 32 || r == 127
 	}) != -1 {
 		allErrs = append(allErrs, field.Invalid(context.fieldPath, target, "control characters not allowed in rewrite target"))
 	}

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/dlclark/regexp2"
 	"github.com/nginx/kubernetes-ingress/internal/configs"
-	ap_validation "github.com/nginx/kubernetes-ingress/pkg/apis/configuration/validation"
+	common_validation "github.com/nginx/kubernetes-ingress/pkg/apis/configuration/validation"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -460,32 +460,20 @@ func validateAppRootAnnotation(context *annotationValidationContext) field.Error
 
 	path := context.value
 
-	// App root must start with /
-	if !strings.HasPrefix(path, "/") {
-		allErrs = append(allErrs, field.Invalid(context.fieldPath, path, "must start with '/'"))
-		return allErrs
-	}
-
 	// App root cannot be just "/"
 	if path == "/" {
 		allErrs = append(allErrs, field.Invalid(context.fieldPath, path, "cannot be '/'"))
-		return allErrs
 	}
 
-	// Prevent protocol-relative URLs (//)
-	if strings.HasPrefix(path, "//") {
-		return field.ErrorList{field.Invalid(context.fieldPath, path, "protocol-relative URLs not allowed")}
-	}
-
-	// Prevent path traversal patterns
-	if strings.Contains(path, "../") || strings.Contains(path, "..\\") {
-		return field.ErrorList{field.Invalid(context.fieldPath, path, "path traversal patterns not allowed")}
+	// Prevent protocol-relative URLs (//) & path traversal patterns.
+	// Also enforces that the path starts with /, so no separate check is needed.
+	if pathErrs := common_validation.ValidatePath(path, context.fieldPath); pathErrs != nil {
+		allErrs = append(allErrs, pathErrs...)
 	}
 
 	// Prevents invalid config characters
 	if !validateRFC1738Path(path) {
 		allErrs = append(allErrs, field.Invalid(context.fieldPath, path, "path must not contain the following characters: whitespace, '{', '}', ';', '$', '|', '^', '<', '>', '\\', '\"', '#', '[', ']'"))
-		return allErrs
 	}
 
 	// Prevent tilde character
@@ -496,7 +484,6 @@ func validateAppRootAnnotation(context *annotationValidationContext) field.Error
 	// Ensure path doesn't end with /
 	if strings.HasSuffix(path, "/") {
 		allErrs = append(allErrs, field.Invalid(context.fieldPath, path, "path should not end with '/'"))
-		return allErrs
 	}
 
 	return allErrs
@@ -860,7 +847,7 @@ func validateOffsetAnnotation(context *annotationValidationContext) field.ErrorL
 }
 
 func validateSizeAnnotation(context *annotationValidationContext) field.ErrorList {
-	return ap_validation.ValidateSize(context.value, context.fieldPath)
+	return common_validation.ValidateSize(context.value, context.fieldPath)
 }
 
 func validateProxyBuffersAnnotation(context *annotationValidationContext) field.ErrorList {
@@ -947,39 +934,32 @@ func validateRewriteListAnnotation(context *annotationValidationContext) field.E
 func validateRewriteTargetAnnotation(context *annotationValidationContext) field.ErrorList {
 	target := context.value
 
+	allErrs := field.ErrorList{}
+
 	// Prevent absolute URLs (http://, https://)
 	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
-		return field.ErrorList{field.Invalid(context.fieldPath, target, "absolute URLs not allowed in rewrite target")}
+		allErrs = append(allErrs, field.Invalid(context.fieldPath, target, "absolute URLs not allowed in rewrite target"))
 	}
 
-	// Prevent protocol-relative URLs (//)
-	if strings.HasPrefix(target, "//") {
-		return field.ErrorList{field.Invalid(context.fieldPath, target, "protocol-relative URLs not allowed in rewrite target")}
-	}
-
-	// Prevent path traversal patterns
-	if strings.Contains(target, "../") || strings.Contains(target, "..\\") {
-		return field.ErrorList{field.Invalid(context.fieldPath, target, "path traversal patterns not allowed in rewrite target")}
-	}
-
-	// Must start with / (relative path)
-	if !strings.HasPrefix(target, "/") {
-		return field.ErrorList{field.Invalid(context.fieldPath, target, "rewrite target must start with /")}
+	// Prevent protocol-relative URLs (//) & path traversal patterns.
+	// Also enforces that the path starts with /, so no separate check is needed.
+	if pathErrs := common_validation.ValidatePath(target, context.fieldPath); pathErrs != nil {
+		allErrs = append(allErrs, pathErrs...)
 	}
 
 	// Prevent NGINX configuration injection characters
 	if strings.ContainsAny(target, ";{}[]|<>,^`~") {
-		return field.ErrorList{field.Invalid(context.fieldPath, target, "NGINX configuration syntax characters (;{}) and []|<>,^`~ not allowed in rewrite target")}
+		allErrs = append(allErrs, field.Invalid(context.fieldPath, target, "NGINX configuration syntax characters (;{}) and []|<>,^`~ not allowed in rewrite target"))
 	}
 
 	// Prevent control characters and line breaks that could break NGINX config
-	for _, char := range target {
-		if char <= 32 || char == 127 { // ASCII control characters; 127 is DEL, 32 is space
-			return field.ErrorList{field.Invalid(context.fieldPath, target, "control characters not allowed in rewrite target")}
-		}
+	if strings.IndexFunc(target, func(r rune) bool {
+		return r <= 32 || r == 127 // ASCII control characters; 127 is DEL, 32 is space
+	}) != -1 {
+		allErrs = append(allErrs, field.Invalid(context.fieldPath, target, "control characters not allowed in rewrite target"))
 	}
 
-	return nil
+	return allErrs
 }
 
 func validateAppProtectSecurityLogAnnotation(context *annotationValidationContext) field.ErrorList {
@@ -998,7 +978,7 @@ func validateAppProtectSecurityLogDestAnnotation(context *annotationValidationCo
 	allErrs := field.ErrorList{}
 	logDsts := strings.Split(context.value, ",")
 	for _, logDst := range logDsts {
-		err := ap_validation.ValidateAppProtectLogDestination(logDst)
+		err := common_validation.ValidateAppProtectLogDestination(logDst)
 		if err != nil {
 			errorMsg := fmt.Sprintf("Error Validating App Protect Log Destination Config: %v", err)
 			allErrs = append(allErrs, field.Invalid(context.fieldPath, context.value, errorMsg))
@@ -1124,6 +1104,16 @@ func validatePath(path string, pathType *networking.PathType, fieldPath *field.P
 
 	if path == "" {
 		return field.ErrorList{field.Required(fieldPath, "path is required for Exact and Prefix PathTypes")}
+	}
+
+	// Prevent protocol-relative URLs
+	if strings.HasPrefix(path, "//") {
+		return field.ErrorList{field.Invalid(fieldPath, path, "protocol-relative URIs not allowed, must not start with '//'")}
+	}
+
+	// Prevent path traversal patterns
+	if strings.Contains(path, "../") || strings.Contains(path, "..\\") {
+		return field.ErrorList{field.Invalid(fieldPath, path, "path traversal patterns not allowed, must not contain '../' or '..\\'")}
 	}
 
 	if !pathRegexp.MatchString(path) {

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -1111,9 +1111,15 @@ func validatePath(path string, pathType *networking.PathType, fieldPath *field.P
 		return field.ErrorList{field.Invalid(fieldPath, path, "protocol-relative URIs not allowed, must not start with '//'")}
 	}
 
-	// Prevent path traversal patterns
-	if strings.Contains(path, "../") || strings.Contains(path, "..\\") {
-		return field.ErrorList{field.Invalid(fieldPath, path, "path traversal patterns not allowed, must not contain '../' or '..\\'")}
+	// Reject any path segment equal to ".." to prevent directory traversal,
+	// including trailing forms like "/.." and "/a/.." (no trailing slash required).
+	// Splitting on both "/" and "\\" also catches Windows-style segments.
+	for _, segment := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if segment == ".." {
+			return field.ErrorList{field.Invalid(fieldPath, path, "path traversal not allowed, path must not contain '..' segments")}
+		}
 	}
 
 	if !pathRegexp.MatchString(path) {

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -3988,7 +3988,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
-				`annotations.nginx.org/rewrite-target: Invalid value: "/api/../admin/users": path traversal patterns not allowed, must not contain '../' or '..\'`,
+				`annotations.nginx.org/rewrite-target: Invalid value: "/api/../admin/users": path traversal not allowed, path must not contain '..' segments`,
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, path traversal with ../",
 		},
@@ -4002,7 +4002,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
-				`annotations.nginx.org/rewrite-target: Invalid value: "/api/..\\admin/users": path traversal patterns not allowed, must not contain '../' or '..\'`,
+				`annotations.nginx.org/rewrite-target: Invalid value: "/api/..\\admin/users": path traversal not allowed, path must not contain '..' segments`,
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, path traversal with ..\\ (Windows style)",
 		},
@@ -5170,6 +5170,8 @@ func TestValidatePath(t *testing.T) {
 		"//evil.com/payload",
 		"/api/../etc/passwd",
 		`/api/..\admin`,
+		"/api/..",
+		"/a/b/..",
 	}
 
 	for _, path := range invalidPaths {

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -4018,7 +4018,6 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			expectedErrors: []string{
 				"annotations.nginx.org/rewrite-target: Invalid value: \"/foo/$1; } path / { my/location/test/ }\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 				`annotations.nginx.org/rewrite-target: Invalid value: "/foo/$1; } path / { my/location/test/ }": NGINX configuration syntax characters (;{}) and []|<>,^` + "`" + `~ not allowed in rewrite target`,
-				`annotations.nginx.org/rewrite-target: Invalid value: "/foo/$1; } path / { my/location/test/ }": control characters not allowed in rewrite target`,
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, NGINX configuration syntax characters (;{}) not allowed in rewrite target",
 		},
@@ -4063,7 +4062,6 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			expectedErrors: []string{
 				"annotations.nginx.org/rewrite-target: Invalid value: \"/api/v1`; proxy_pass http://evil.com; #\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 				"annotations.nginx.org/rewrite-target: Invalid value: \"/api/v1`; proxy_pass http://evil.com; #\": NGINX configuration syntax characters (;{}) and []|<>,^`~ not allowed in rewrite target",
-				"annotations.nginx.org/rewrite-target: Invalid value: \"/api/v1`; proxy_pass http://evil.com; #\": control characters not allowed in rewrite target",
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, backtick and semicolon injection",
 		},

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -3945,6 +3945,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
 				`annotations.nginx.org/rewrite-target: Invalid value: "http://example.com/path": absolute URLs not allowed in rewrite target`,
+				"annotations.nginx.org/rewrite-target: Invalid value: \"http://example.com/path\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, absolute HTTP URL",
 		},
@@ -3959,6 +3960,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
 				`annotations.nginx.org/rewrite-target: Invalid value: "https://example.com/path": absolute URLs not allowed in rewrite target`,
+				"annotations.nginx.org/rewrite-target: Invalid value: \"https://example.com/path\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, absolute HTTPS URL",
 		},
@@ -3972,7 +3974,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
-				`annotations.nginx.org/rewrite-target: Invalid value: "//example.com/path": protocol-relative URLs not allowed in rewrite target`,
+				`annotations.nginx.org/rewrite-target: Invalid value: "//example.com/path": protocol-relative URIs not allowed, must not start with '//'`,
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, protocol-relative URL",
 		},
@@ -3986,7 +3988,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
-				`annotations.nginx.org/rewrite-target: Invalid value: "/api/../admin/users": path traversal patterns not allowed in rewrite target`,
+				`annotations.nginx.org/rewrite-target: Invalid value: "/api/../admin/users": path traversal patterns not allowed, must not contain '../' or '..\'`,
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, path traversal with ../",
 		},
@@ -4000,7 +4002,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
-				`annotations.nginx.org/rewrite-target: Invalid value: "/api/..\\admin/users": path traversal patterns not allowed in rewrite target`,
+				`annotations.nginx.org/rewrite-target: Invalid value: "/api/..\\admin/users": path traversal patterns not allowed, must not contain '../' or '..\'`,
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, path traversal with ..\\ (Windows style)",
 		},
@@ -4014,7 +4016,9 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
+				"annotations.nginx.org/rewrite-target: Invalid value: \"/foo/$1; } path / { my/location/test/ }\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 				`annotations.nginx.org/rewrite-target: Invalid value: "/foo/$1; } path / { my/location/test/ }": NGINX configuration syntax characters (;{}) and []|<>,^` + "`" + `~ not allowed in rewrite target`,
+				`annotations.nginx.org/rewrite-target: Invalid value: "/foo/$1; } path / { my/location/test/ }": control characters not allowed in rewrite target`,
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, NGINX configuration syntax characters (;{}) not allowed in rewrite target",
 		},
@@ -4028,6 +4032,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
+				"annotations.nginx.org/rewrite-target: Invalid value: \"/api\\npath\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 				`annotations.nginx.org/rewrite-target: Invalid value: "/api\npath": control characters not allowed in rewrite target`,
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, control characters not allowed in rewrite target",
@@ -4042,7 +4047,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
-				`annotations.nginx.org/rewrite-target: Invalid value: "api/users": rewrite target must start with /`,
+				"annotations.nginx.org/rewrite-target: Invalid value: \"api/users\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, does not start with slash",
 		},
@@ -4056,7 +4061,9 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
+				"annotations.nginx.org/rewrite-target: Invalid value: \"/api/v1`; proxy_pass http://evil.com; #\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 				"annotations.nginx.org/rewrite-target: Invalid value: \"/api/v1`; proxy_pass http://evil.com; #\": NGINX configuration syntax characters (;{}) and []|<>,^`~ not allowed in rewrite target",
+				"annotations.nginx.org/rewrite-target: Invalid value: \"/api/v1`; proxy_pass http://evil.com; #\": control characters not allowed in rewrite target",
 			},
 			msg: "invalid nginx.org/rewrite-target annotation, backtick and semicolon injection",
 		},
@@ -4108,7 +4115,8 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
-				`annotations.nginx.org/app-root: Invalid value: "coffee": must start with '/'`,
+				"annotations.nginx.org/app-root: Invalid value: \"coffee\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
+				`annotations.nginx.org/app-root: Invalid value: "coffee": path must not contain the following characters: whitespace, '{', '}', ';', '$', '|', '^', '<', '>', '\', '"', '#', '[', ']'`,
 			},
 			msg: "invalid nginx.org/app-root annotation, does not start with slash",
 		},
@@ -4123,6 +4131,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
 				`annotations.nginx.org/app-root: Invalid value: "/": cannot be '/'`,
+				`annotations.nginx.org/app-root: Invalid value: "/": path should not end with '/'`,
 			},
 			msg: "invalid nginx.org/app-root annotation, cannot be root path",
 		},
@@ -4178,6 +4187,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
+				"annotations.nginx.org/app-root: Invalid value: \"/coffee{test}\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 				`annotations.nginx.org/app-root: Invalid value: "/coffee{test}": path must not contain the following characters: whitespace, '{', '}', ';', '$', '|', '^', '<', '>', '\', '"', '#', '[', ']'`,
 			},
 			msg: "invalid app-root - contains curly braces",
@@ -4192,6 +4202,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
+				"annotations.nginx.org/app-root: Invalid value: \"/tea;chai\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 				`annotations.nginx.org/app-root: Invalid value: "/tea;chai": path must not contain the following characters: whitespace, '{', '}', ';', '$', '|', '^', '<', '>', '\', '"', '#', '[', ']'`,
 			},
 			msg: "invalid app-root - contains semicolon",
@@ -4206,6 +4217,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
+				"annotations.nginx.org/app-root: Invalid value: \"/tea chai\": must start with / and must not include any whitespace character, `{`, `}` or `;` (e.g. '/',  or '/path',  or '/path/subpath-123', regex used for validation is '/[^\\s{};\\\\]*')",
 				`annotations.nginx.org/app-root: Invalid value: "/tea chai": path must not contain the following characters: whitespace, '{', '}', ';', '$', '|', '^', '<', '>', '\', '"', '#', '[', ']'`,
 			},
 			msg: "invalid app-root - contains whitespace",
@@ -5155,6 +5167,9 @@ func TestValidatePath(t *testing.T) {
 		`/var/run/secrets`,
 		"/{autoindex on; root /var/run/secrets;}location /tea",
 		"/{root}",
+		"//evil.com/payload",
+		"/api/../etc/passwd",
+		`/api/..\admin`,
 	}
 
 	for _, path := range invalidPaths {

--- a/pkg/apis/configuration/validation/common.go
+++ b/pkg/apis/configuration/validation/common.go
@@ -232,3 +232,34 @@ func isValidHeaderName(name string) bool {
 	validHeaderName := regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
 	return validHeaderName.MatchString(name)
 }
+
+const (
+	pathFmt    = `/[^\s{};\\]*`
+	pathErrMsg = "must start with / and must not include any whitespace character, `{`, `}` or `;`"
+)
+
+var pathRegexp = regexp.MustCompile("^" + pathFmt + "$")
+
+func validatePath(path string, fieldPath *field.Path) field.ErrorList {
+	if path == "" {
+		return field.ErrorList{field.Required(fieldPath, "")}
+	}
+	if strings.HasPrefix(path, "//") {
+		return field.ErrorList{field.Invalid(fieldPath, path, "protocol-relative URIs not allowed, must not start with '//'")}
+	}
+
+	if strings.Contains(path, "../") || strings.Contains(path, "..\\") {
+		return field.ErrorList{field.Invalid(fieldPath, path, "path traversal patterns not allowed, must not contain '../' or '..\\'")}
+	}
+
+	if !pathRegexp.MatchString(path) {
+		msg := validation.RegexError(pathErrMsg, pathFmt, "/", "/path", "/path/subpath-123")
+		return field.ErrorList{field.Invalid(fieldPath, path, msg)}
+	}
+	return nil
+}
+
+// ValidatePath is a wrapper for validatePath to be used in other packages
+func ValidatePath(path string, fieldPath *field.Path) field.ErrorList {
+	return validatePath(path, fieldPath)
+}

--- a/pkg/apis/configuration/validation/common.go
+++ b/pkg/apis/configuration/validation/common.go
@@ -248,8 +248,15 @@ func validatePath(path string, fieldPath *field.Path) field.ErrorList {
 		return field.ErrorList{field.Invalid(fieldPath, path, "protocol-relative URIs not allowed, must not start with '//'")}
 	}
 
-	if strings.Contains(path, "../") || strings.Contains(path, "..\\") {
-		return field.ErrorList{field.Invalid(fieldPath, path, "path traversal patterns not allowed, must not contain '../' or '..\\'")}
+	// Reject any path segment equal to ".." to prevent directory traversal,
+	// including trailing forms like "/.." and "/a/.." (no trailing slash required).
+	// Splitting on both "/" and "\\" also catches Windows-style segments.
+	for _, segment := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if segment == ".." {
+			return field.ErrorList{field.Invalid(fieldPath, path, "path traversal not allowed, path must not contain '..' segments")}
+		}
 	}
 
 	if !pathRegexp.MatchString(path) {

--- a/pkg/apis/configuration/validation/common_test.go
+++ b/pkg/apis/configuration/validation/common_test.go
@@ -399,7 +399,8 @@ func TestValidatePath(t *testing.T) {
 		`//path`,
 		`/path/../`,
 		`/../`,
-		`/path/../etc/passwd`,
+		`/path/../etc/passwd`, `/..`,
+		`/a/..`,
 	}
 
 	for _, path := range invalidPaths {

--- a/pkg/apis/configuration/validation/common_test.go
+++ b/pkg/apis/configuration/validation/common_test.go
@@ -371,3 +371,41 @@ func TestHeaderValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePath(t *testing.T) {
+	t.Parallel()
+	validPaths := []string{
+		"/",
+		"/path",
+		"/a-1/_A/",
+	}
+
+	for _, path := range validPaths {
+		allErrs := validatePath(path, field.NewPath("path"))
+		if len(allErrs) > 0 {
+			t.Errorf("validatePath(%q) returned errors %v for valid input", path, allErrs)
+		}
+	}
+
+	invalidPaths := []string{
+		"",
+		" /",
+		"/ ",
+		"/{",
+		"/}",
+		"/abc;",
+		`/path\`,
+		`/path\n`,
+		`//path`,
+		`/path/../`,
+		`/../`,
+		`/path/../etc/passwd`,
+	}
+
+	for _, path := range invalidPaths {
+		allErrs := validatePath(path, field.NewPath("path"))
+		if len(allErrs) == 0 {
+			t.Errorf("validatePath(%q) returned no errors for invalid input", path)
+		}
+	}
+}

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -1387,6 +1387,14 @@ func validatePath(path string, fieldPath *field.Path) field.ErrorList {
 	if path == "" {
 		return field.ErrorList{field.Required(fieldPath, "")}
 	}
+	if strings.HasPrefix(path, "//") {
+		return field.ErrorList{field.Invalid(fieldPath, path, "protocol-relative URIs not allowed, must not start with '//'")}
+	}
+
+	if strings.Contains(path, "../") || strings.Contains(path, "..\\") {
+		return field.ErrorList{field.Invalid(fieldPath, path, "path traversal patterns not allowed, must not contain '../' or '..\\'")}
+	}
+
 	if !pathRegexp.MatchString(path) {
 		msg := validation.RegexError(pathErrMsg, pathFmt, "/", "/path", "/path/subpath-123")
 		return field.ErrorList{field.Invalid(fieldPath, path, msg)}

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -1377,32 +1377,6 @@ func validateRegexPath(path string, fieldPath *field.Path) field.ErrorList {
 }
 
 const (
-	pathFmt    = `/[^\s{};\\]*`
-	pathErrMsg = "must start with / and must not include any whitespace character, `{`, `}` or `;`"
-)
-
-var pathRegexp = regexp.MustCompile("^" + pathFmt + "$")
-
-func validatePath(path string, fieldPath *field.Path) field.ErrorList {
-	if path == "" {
-		return field.ErrorList{field.Required(fieldPath, "")}
-	}
-	if strings.HasPrefix(path, "//") {
-		return field.ErrorList{field.Invalid(fieldPath, path, "protocol-relative URIs not allowed, must not start with '//'")}
-	}
-
-	if strings.Contains(path, "../") || strings.Contains(path, "..\\") {
-		return field.ErrorList{field.Invalid(fieldPath, path, "path traversal patterns not allowed, must not contain '../' or '..\\'")}
-	}
-
-	if !pathRegexp.MatchString(path) {
-		msg := validation.RegexError(pathErrMsg, pathFmt, "/", "/path", "/path/subpath-123")
-		return field.ErrorList{field.Invalid(fieldPath, path, msg)}
-	}
-	return nil
-}
-
-const (
 	grpcFmt    = `[^\s{};]*`
 	grpcErrMsg = "must not include any whitespace character, `{`, `}`, or `;`"
 )

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -1716,44 +1716,6 @@ func TestValidateRoutePath(t *testing.T) {
 	}
 }
 
-func TestValidatePath(t *testing.T) {
-	t.Parallel()
-	validPaths := []string{
-		"/",
-		"/path",
-		"/a-1/_A/",
-	}
-
-	for _, path := range validPaths {
-		allErrs := validatePath(path, field.NewPath("path"))
-		if len(allErrs) > 0 {
-			t.Errorf("validatePath(%q) returned errors %v for valid input", path, allErrs)
-		}
-	}
-
-	invalidPaths := []string{
-		"",
-		" /",
-		"/ ",
-		"/{",
-		"/}",
-		"/abc;",
-		`/path\`,
-		`/path\n`,
-		`//path`,
-		`/path/../`,
-		`/../`,
-		`/path/../etc/passwd`,
-	}
-
-	for _, path := range invalidPaths {
-		allErrs := validatePath(path, field.NewPath("path"))
-		if len(allErrs) == 0 {
-			t.Errorf("validatePath(%q) returned no errors for invalid input", path)
-		}
-	}
-}
-
 func TestValidateSplits(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -1740,6 +1740,10 @@ func TestValidatePath(t *testing.T) {
 		"/abc;",
 		`/path\`,
 		`/path\n`,
+		`//path`,
+		`/path/../`,
+		`/../`,
+		`/path/../etc/passwd`,
 	}
 
 	for _, path := range invalidPaths {


### PR DESCRIPTION
This pull request refactors and strengthens the validation logic for annotation paths (such as `app-root` and `rewrite-target`) in the NGINX Kubernetes Ingress Controller. It introduces a centralized, reusable path validation function to enforce stricter security and correctness, and updates related tests to reflect the new validation behavior.

**Key changes:**

### Validation Logic Refactoring & Centralization

- Introduced a new `ValidatePath` function in `pkg/apis/configuration/validation/common.go` that enforces:
  - Paths must start with `/`
  - No protocol-relative URLs (must not start with `//`)
  - No path traversal segments (`..`)
  - No whitespace, `{`, `}`, `;`, or `This pull request refactors and strengthens the validation logic for annotation paths (such as `app-root` and `rewrite-target`) in the NGINX Kubernetes Ingress Controller. It introduces a centralized, reusable path validation function to enforce stricter security and correctness, and updates related tests to reflect the new validation behavior.

**Key changes:**

### Validation Logic Refactoring & Centralization

- Introduced a new `ValidatePath` function in `pkg/apis/configuration/validation/common.go` that enforces:
  - Paths must start with `/`
  - No protocol-relative URLs (must not start with `//`)
  - No path traversal segments (`..`)
 characters (enforced by regex)
  - Centralizes path validation for reuse across the codebase

- Updated `internal/k8s/validation.go` to use the new `ValidatePath` function for validating `app-root` and `rewrite-target` annotations, replacing scattered inline checks with a single call to the shared logic [[1]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77L463-L488) [[2]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77R937-R962)

### Security & Correctness Improvements

- Hardened path validation to prevent protocol-relative URLs and directory traversal attacks by rejecting any path segment equal to `..` [[1]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77R1109-R1124) [[2]](diffhunk://#diff-7186073b2da683704962065b1c768d52093374bb8769a9bd14056ec62219994fR235-R272)
- Ensured all path validations consistently apply the same strict rules, reducing the risk of bypasses [[1]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77L463-L488) [[2]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77R937-R962)

### Code Clean-up

- Replaced direct imports and calls to `ap_validation` with the new `common_validation` alias for clarity and consistency [[1]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77L13-R13) [[2]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77L863-R850) [[3]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77L1001-R981)

### Test Suite Updates

- Updated and expanded test cases in `internal/k8s/validation_test.go` to reflect new error messages and stricter validation, including checks for protocol-relative URLs, path traversal, and invalid characters [[1]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R3948) [[2]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R3963) [[3]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689L3975-R3977) [[4]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689L3989-R3991) [[5]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689L4003-R4005) [[6]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R4019-R4021) [[7]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R4035) [[8]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689L4045-R4050) [[9]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R4064-R4066) [[10]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689L4111-R4119) [[11]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R4134) [[12]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R4190) [[13]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R4205) [[14]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R4220) [[15]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R5170-R5174)

---

**References:**  
[[1]](diffhunk://#diff-7186073b2da683704962065b1c768d52093374bb8769a9bd14056ec62219994fR235-R272) [[2]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77L463-L488) [[3]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77R937-R962) [[4]](diffhunk://#diff-488a2fd37cfe436027391a2407367fc7df6ba77ab6d140a8a25abc316bf60e77R1109-R1124) [[5]](diffhunk://#diff-894ff45069d85e7ff11d2abe2b08ac740ddfce19c41cef83c0c5f055cec76689R3948)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
