### PR TITLE
Update CI workflow to use '!=' for binary cache hit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
             docker_build="true"
           elif [ "${{ steps.vars.outputs.forked_workflow }}" = "true" ] && [ "${{ steps.docs.outputs.docs_only }}" = "false" ]; then
             docker_build="true"
-          elif [ "${{ steps.vars.outputs.forked_workflow }}" = "false" ] && [ "${{ steps.docs.outputs.docs_only }}" = "false" ] && [ "${{ steps.binary-cache.outputs.cache-hit }}" = "false" ]; then
+          elif [ "${{ steps.vars.outputs.forked_workflow }}" = "false" ] && [ "${{ steps.docs.outputs.docs_only }}" = "false" ] && [ "${{ steps.binary-cache.outputs.cache-hit }}" != "true" ]; then
             docker_build="true"
           fi
           echo "docker_build=${docker_build}" >> $GITHUB_OUTPUT
@@ -207,7 +207,7 @@ jobs:
     if: >-
       inputs.force ||
       needs.checks.outputs.run_tests == 'true' &&
-      needs.checks.outputs.binary_cache_hit == 'false'
+      needs.checks.outputs.binary_cache_hit != 'true'
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -259,7 +259,7 @@ jobs:
         if: >-
           inputs.force ||
           needs.checks.outputs.run_tests == 'true' &&
-          needs.checks.outputs.binary_cache_hit == 'false'
+          needs.checks.outputs.binary_cache_hit != 'true'
 
       - name: Azure login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
@@ -271,7 +271,7 @@ jobs:
           inputs.force ||
           needs.checks.outputs.forked_workflow == 'false' &&
           (needs.checks.outputs.run_tests == 'true' &&
-          needs.checks.outputs.binary_cache_hit == 'false')
+          needs.checks.outputs.binary_cache_hit != 'true')
 
       - name: Setup secrets
         id: secrets
@@ -284,7 +284,7 @@ jobs:
           inputs.force ||
           needs.checks.outputs.forked_workflow == 'false' &&
           (needs.checks.outputs.run_tests == 'true' &&
-          needs.checks.outputs.binary_cache_hit == 'false')
+          needs.checks.outputs.binary_cache_hit != 'true')
 
       - name: Setup Golang Environment
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -293,7 +293,7 @@ jobs:
         if: >-
           inputs.force ||
           needs.checks.outputs.run_tests == 'true' &&
-          needs.checks.outputs.binary_cache_hit == 'false'
+          needs.checks.outputs.binary_cache_hit != 'true'
 
       - name: Generate secrets for tests
         run: |
@@ -301,14 +301,14 @@ jobs:
         if: >-
           inputs.force ||
           needs.checks.outputs.run_tests == 'true' &&
-          needs.checks.outputs.binary_cache_hit == 'false'
+          needs.checks.outputs.binary_cache_hit != 'true'
 
       - name: Run Tests
         run: make cover
         if: >-
           inputs.force ||
           needs.checks.outputs.run_tests == 'true' &&
-          needs.checks.outputs.binary_cache_hit == 'false'
+          needs.checks.outputs.binary_cache_hit != 'true'
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -319,7 +319,7 @@ jobs:
           inputs.force ||
           (needs.checks.outputs.forked_workflow == 'false' &&
           (needs.checks.outputs.run_tests == 'true' &&
-          needs.checks.outputs.binary_cache_hit == 'false'))
+          needs.checks.outputs.binary_cache_hit != 'true'))
 
   staticcheck:
     name: Static Check
@@ -330,7 +330,7 @@ jobs:
     if: >-
       inputs.force ||
       needs.checks.outputs.run_tests == 'true' &&
-      needs.checks.outputs.binary_cache_hit == 'false'
+      needs.checks.outputs.binary_cache_hit != 'true'
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -362,7 +362,7 @@ jobs:
     if: >-
       inputs.force ||
       needs.checks.outputs.run_tests == 'true' &&
-      needs.checks.outputs.binary_cache_hit == 'false'
+      needs.checks.outputs.binary_cache_hit != 'true'
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:


### PR DESCRIPTION
This pull request updates the conditional checks in the `.github/workflows/ci.yml` file to improve the handling of the `binary_cache_hit` output throughout the CI workflow. The main change is to ensure that conditions check for `binary_cache_hit` not being `"true"` rather than being exactly `"false"`, which makes the logic more robust if the value is unset or set to another non-true value.

Key workflow logic improvements:

* Updated all relevant conditional checks to use `needs.checks.outputs.binary_cache_hit != 'true'` instead of `== 'false'` to more accurately determine when to run builds, tests, and related steps. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL162-R162) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL210-R210) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL262-R262) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL274-R274) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL287-R287) [[6]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL296-R311) [[7]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL322-R322) [[8]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL333-R333) [[9]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL365-R365)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
