### PR TITLE
Fix container package check by replacing auto_remove with remove flag

### DIFF
--- a/tests/scripts/check_container_packages.py
+++ b/tests/scripts/check_container_packages.py
@@ -79,7 +79,7 @@ with open(f"{script_dir}/../data/modules/data.json") as file:
                         command,
                         entrypoint="",
                         platform=platform,
-                        auto_remove=True,
+                        remove=True,
                         detach=False,
                     )
                 except (docker.errors.ContainerError, docker.errors.NotFound) as e:
@@ -89,7 +89,7 @@ with open(f"{script_dir}/../data/modules/data.json") as file:
                         command,
                         entrypoint="",
                         platform=platform,
-                        auto_remove=True,
+                        remove=True,
                         detach=False,
                     )
                 result = re.search(regex, output.decode("utf-8").strip())


### PR DESCRIPTION
This pull request makes a minor update to the Docker container run command in the `tests/scripts/check_container_packages.py` script. The change replaces the deprecated `auto_remove=True` parameter with the updated `remove=True` parameter for better compatibility with recent versions of the Docker Python SDK.

- Updated Docker container run parameter from `auto_remove=True` to `remove=True` in two places to follow the latest Docker SDK conventions. [[1]](diffhunk://#diff-a80a88b4c0833fa086a8d7b03194c8a76c1c47eb01ce76438e1c0bbaf809112aL82-R82) [[2]](diffhunk://#diff-a80a88b4c0833fa086a8d7b03194c8a76c1c47eb01ce76438e1c0bbaf809112aL92-R92)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
