### PR TITLE
Enhance health check handling in TCP load balancing tests

### DIFF
--- a/tests/suite/test_transport_server_tcp_load_balance.py
+++ b/tests/suite/test_transport_server_tcp_load_balance.py
@@ -535,7 +535,7 @@ class TestTransportServerTcpLoadBalance:
             patch_src,
             transport_server_setup.namespace,
         )
-        # 4s includes 3s timeout for a health check to fail in case of a connection timeout to a backend pod
+        # Wait for NGINX to reload with the new config
         wait_before_test(4)
 
         result_conf = get_ts_nginx_template_conf(
@@ -554,6 +554,11 @@ class TestTransportServerTcpLoadBalance:
         assert 'send "health"' in result_conf
         assert 'expect  "unmatched"' in result_conf
 
+        # Wait for health checks to run and mark backends as unhealthy.
+        # The health check interval is 5s, so we need to wait at least one full cycle
+        # after the config has been confirmed applied above.
+        wait_before_test(6)
+
         # Step 2 - confirm load balancing doesn't work
 
         port = transport_server_setup.public_endpoint.tcp_server_port
@@ -564,11 +569,16 @@ class TestTransportServerTcpLoadBalance:
         client.sendall(b"connect")
 
         try:
-            client.recv(4096)  # must return ConnectionResetError
+            data = client.recv(4096)
             client.close()
-            pytest.fail("We expected an error here, but didn't get it. Exiting...")
+            # When all upstreams are unhealthy NGINX Plus closes the connection;
+            # depending on timing it may send RST (ConnectionResetError) or FIN
+            # (empty recv). Both indicate the connection was rejected.
+            if data:
+                pytest.fail("We expected a rejected connection here, but got data back. Exiting...")
+            print("Connection was closed by NGINX (all upstreams unhealthy)")
         except ConnectionResetError as ex:
-            # expected error
+            # expected error: NGINX sent RST
             print(f"There was an expected exception {str(ex)}")
 
         # Step 3 - restore


### PR DESCRIPTION
This pull request updates the `test_tcp_failing_healthcheck_with_match` test in `tests/suite/test_transport_server_tcp_load_balance.py` to improve reliability and clarity. The main changes ensure that NGINX has time to reload and that health checks have time to mark backends as unhealthy before assertions are made. The test logic for handling connection rejections has also been refined to account for both possible outcomes (RST or FIN).

**Test reliability and clarity improvements:**

* Added a wait after applying configuration changes to ensure NGINX reloads before proceeding with health checks.
* Added an additional wait to allow the health check interval to elapse, ensuring backends are marked unhealthy before testing connection behavior.

**Test logic improvements:**

* Updated the assertion logic to handle both possible connection rejection signals from NGINX (either an empty response or a `ConnectionResetError`), making the test more robust.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
