### PR TITLE
VSR guard during startup

### DIFF
--- a/internal/k8s/configuration.go
+++ b/internal/k8s/configuration.go
@@ -678,6 +678,19 @@ func (c *Configuration) AddOrUpdateVirtualServerRoute(vsr *conf_v1.VirtualServer
 		}
 	}
 
+	if !c.startupComplete {
+        var problems []ConfigurationProblem
+        if validationError != nil {
+            problems = append(problems, ConfigurationProblem{
+                Object:  vsr,
+                IsError: true,
+                Reason:  nl.EventReasonRejected,
+                Message: fmt.Sprintf("VirtualServerRoute %s was rejected with error: %s", getResourceKey(&vsr.ObjectMeta), validationError.Error()),
+            })
+        }
+        return nil, problems
+    }
+	
 	changes, problems := c.rebuildHosts()
 
 	if validationError != nil {

--- a/internal/k8s/configuration.go
+++ b/internal/k8s/configuration.go
@@ -386,6 +386,11 @@ type Configuration struct {
 	virtualServerRoutes map[string]*conf_v1.VirtualServerRoute
 	transportServers    map[string]*conf_v1.TransportServer
 
+	// minionsByHost indexes minion Ingresses by their host for O(1) lookup.
+	// Outer key: host string, inner key: ingress resource key (namespace/name).
+	// Maintained by AddOrUpdateIngress/DeleteIngress; consumed by buildMinionConfigs.
+	minionsByHost map[string]map[string]bool
+
 	globalConfiguration *conf_v1.GlobalConfiguration
 
 	hostProblems     map[string]ConfigurationProblem
@@ -414,6 +419,12 @@ type Configuration struct {
 	isIPV6Disabled               bool
 	isDirectiveAutoadjustEnabled bool
 
+	// startupComplete indicates whether the initial informer cache sync and
+	// queue drain have finished. When false, rebuildHosts() is skipped in
+	// AddOrUpdate*/Delete* methods to avoid O(N) full rebuilds during startup.
+	// CompleteStartup() flips this to true and performs a single rebuild.
+	startupComplete bool
+
 	lock sync.RWMutex
 }
 
@@ -441,6 +452,7 @@ func NewConfiguration(
 		virtualServers:               make(map[string]*conf_v1.VirtualServer),
 		virtualServerRoutes:          make(map[string]*conf_v1.VirtualServerRoute),
 		transportServers:             make(map[string]*conf_v1.TransportServer),
+		minionsByHost:                make(map[string]map[string]bool),
 		hostProblems:                 make(map[string]ConfigurationProblem),
 		hasCorrectIngressClass:       hasCorrectIngressClass,
 		virtualServerValidator:       virtualServerValidator,
@@ -475,13 +487,29 @@ func (c *Configuration) AddOrUpdateIngress(ing *networking.Ingress) ([]ResourceC
 
 	if !c.hasCorrectIngressClass(ing) {
 		delete(c.ingresses, key)
+		c.updateMinionIndex(key, nil)
 	} else {
 		validationError = validateIngress(ing, c.isPlus, c.appProtectEnabled, c.appProtectDosEnabled, c.internalRoutesEnabled, c.snippetsEnabled, c.isDirectiveAutoadjustEnabled).ToAggregate()
 		if validationError != nil {
 			delete(c.ingresses, key)
+			c.updateMinionIndex(key, nil)
 		} else {
 			c.ingresses[key] = ing
+			c.updateMinionIndex(key, ing)
 		}
+	}
+
+	if !c.startupComplete {
+		var problems []ConfigurationProblem
+		if validationError != nil {
+			problems = append(problems, ConfigurationProblem{
+				Object:  ing,
+				IsError: true,
+				Reason:  nl.EventReasonRejected,
+				Message: validationError.Error(),
+			})
+		}
+		return nil, problems
 	}
 
 	changes, problems := c.rebuildHosts()
@@ -527,6 +555,11 @@ func (c *Configuration) DeleteIngress(key string) ([]ResourceChange, []Configura
 	}
 
 	delete(c.ingresses, key)
+	c.removeMinionFromIndex(key)
+
+	if !c.startupComplete {
+		return nil, nil
+	}
 
 	return c.rebuildHosts()
 }
@@ -553,6 +586,19 @@ func (c *Configuration) AddOrUpdateVirtualServer(vs *conf_v1.VirtualServer) ([]R
 				c.virtualServers[key] = vs
 			}
 		}
+	}
+
+	if !c.startupComplete {
+		var problems []ConfigurationProblem
+		if validationError != nil {
+			problems = append(problems, ConfigurationProblem{
+				Object:  vs,
+				IsError: true,
+				Reason:  nl.EventReasonRejected,
+				Message: fmt.Sprintf("VirtualServer %s was rejected with error: %s", getResourceKey(&vs.ObjectMeta), validationError.Error()),
+			})
+		}
+		return nil, problems
 	}
 
 	changes, problems := c.rebuildHosts()
@@ -598,6 +644,10 @@ func (c *Configuration) DeleteVirtualServer(key string) ([]ResourceChange, []Con
 	}
 
 	delete(c.virtualServers, key)
+
+	if !c.startupComplete {
+		return nil, nil
+	}
 
 	return c.rebuildHosts()
 }
@@ -655,6 +705,10 @@ func (c *Configuration) DeleteVirtualServerRoute(key string) ([]ResourceChange, 
 
 	delete(c.virtualServerRoutes, key)
 
+	if !c.startupComplete {
+		return nil, nil
+	}
+
 	return c.rebuildHosts()
 }
 
@@ -676,9 +730,11 @@ func (c *Configuration) AddOrUpdateGlobalConfiguration(gc *conf_v1.GlobalConfigu
 	changes = append(changes, listenerChanges...)
 	problems = append(problems, listenerProblems...)
 
-	hostChanges, hostProblems := c.rebuildHosts()
-	changes = append(changes, hostChanges...)
-	problems = append(problems, hostProblems...)
+	if c.startupComplete {
+		hostChanges, hostProblems := c.rebuildHosts()
+		changes = append(changes, hostChanges...)
+		problems = append(problems, hostProblems...)
+	}
 
 	return changes, problems, validationErr
 }
@@ -697,9 +753,11 @@ func (c *Configuration) DeleteGlobalConfiguration() ([]ResourceChange, []Configu
 	changes = append(changes, listenerChanges...)
 	problems = append(problems, listenerProblems...)
 
-	hostChanges, hostProblems := c.rebuildHosts()
-	changes = append(changes, hostChanges...)
-	problems = append(problems, hostProblems...)
+	if c.startupComplete {
+		hostChanges, hostProblems := c.rebuildHosts()
+		changes = append(changes, hostChanges...)
+		problems = append(problems, hostProblems...)
+	}
 
 	return changes, problems
 }
@@ -733,7 +791,7 @@ func (c *Configuration) AddOrUpdateTransportServer(ts *conf_v1.TransportServer) 
 
 	changes, problems := c.rebuildListenerHosts()
 
-	if c.isTLSPassthroughEnabled {
+	if c.isTLSPassthroughEnabled && c.startupComplete {
 		hostChanges, hostProblems := c.rebuildHosts()
 
 		changes = append(changes, hostChanges...)
@@ -784,7 +842,7 @@ func (c *Configuration) DeleteTransportServer(key string) ([]ResourceChange, []C
 
 	changes, problems := c.rebuildListenerHosts()
 
-	if c.isTLSPassthroughEnabled {
+	if c.isTLSPassthroughEnabled && c.startupComplete {
 		hostChanges, hostProblems := c.rebuildHosts()
 
 		changes = append(changes, hostChanges...)
@@ -792,6 +850,49 @@ func (c *Configuration) DeleteTransportServer(key string) ([]ResourceChange, []C
 	}
 
 	return changes, problems
+}
+
+// updateMinionIndex adds or removes an ingress from the minionsByHost index.
+// Must be called with the lock held.
+func (c *Configuration) updateMinionIndex(key string, ing *networking.Ingress) {
+	// Remove old entry for this key from any host it was previously under.
+	c.removeMinionFromIndex(key)
+
+	// If the ingress is a valid minion, add it to the index under its host.
+	if ing != nil && isMinion(ing) && len(ing.Spec.Rules) > 0 {
+		host := ing.Spec.Rules[0].Host
+		if c.minionsByHost[host] == nil {
+			c.minionsByHost[host] = make(map[string]bool)
+		}
+		c.minionsByHost[host][key] = true
+	}
+}
+
+// removeMinionFromIndex removes a key from the minionsByHost index.
+// Must be called with the lock held.
+func (c *Configuration) removeMinionFromIndex(key string) {
+	for host, keys := range c.minionsByHost {
+		if keys[key] {
+			delete(keys, key)
+			if len(keys) == 0 {
+				delete(c.minionsByHost, host)
+			}
+			return
+		}
+	}
+}
+
+// CompleteStartup marks startup as complete and performs a single rebuildHosts()
+// to compute the definitive host→resource mapping and all ConfigurationProblems
+// (host conflicts, orphaned minions, orphaned VSRs). This must be called exactly
+// once after the initial informer cache sync and queue drain, before
+// updateAllConfigs() generates and writes NGINX config files.
+func (c *Configuration) CompleteStartup() ([]ResourceChange, []ConfigurationProblem) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.startupComplete = true
+	return c.rebuildHosts()
 }
 
 func (c *Configuration) rebuildListenerHosts() ([]ResourceChange, []ConfigurationProblem) {
@@ -1308,17 +1409,21 @@ func (c *Configuration) isListenerInCorrectBlock(listenerName string, expectedSs
 }
 
 func (c *Configuration) addProblemsForOrphanMinions(problems map[string]ConfigurationProblem) {
-	for _, key := range getSortedIngressKeys(c.ingresses) {
-		ing := c.ingresses[key]
+	// Iterate only over indexed minions instead of all ingresses.
+	for host, minionKeys := range c.minionsByHost {
+		r, exists := c.hosts[host]
+		ingressConf, ok := r.(*IngressConfiguration)
+		hasMaster := exists && ok && ingressConf.IsMaster
 
-		if !isMinion(ing) {
+		if hasMaster {
 			continue
 		}
 
-		r, exists := c.hosts[ing.Spec.Rules[0].Host]
-		ingressConf, ok := r.(*IngressConfiguration)
-
-		if !exists || !ok || !ingressConf.IsMaster {
+		for key := range minionKeys {
+			ing, ingExists := c.ingresses[key]
+			if !ingExists {
+				continue
+			}
 			p := ConfigurationProblem{
 				Object:  ing,
 				IsError: false,
@@ -1683,14 +1788,17 @@ func (c *Configuration) buildMinionConfigs(masterHost string) ([]*MinionConfigur
 	childWarnings := make(map[string][]string)
 	paths := make(map[string]*MinionConfiguration)
 
-	for _, minionKey := range getSortedIngressKeys(c.ingresses) {
-		ingress := c.ingresses[minionKey]
+	// Use the minionsByHost index for O(1) host lookup instead of scanning all ingresses.
+	minionKeys := c.minionsByHost[masterHost]
+	sortedKeys := make([]string, 0, len(minionKeys))
+	for k := range minionKeys {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
 
-		if !isMinion(ingress) {
-			continue
-		}
-
-		if masterHost != ingress.Spec.Rules[0].Host {
+	for _, minionKey := range sortedKeys {
+		ingress, exists := c.ingresses[minionKey]
+		if !exists {
 			continue
 		}
 

--- a/internal/k8s/configuration.go
+++ b/internal/k8s/configuration.go
@@ -690,7 +690,7 @@ func (c *Configuration) AddOrUpdateVirtualServerRoute(vsr *conf_v1.VirtualServer
         }
         return nil, problems
     }
-	
+
 	changes, problems := c.rebuildHosts()
 
 	if validationError != nil {

--- a/internal/k8s/configuration_test.go
+++ b/internal/k8s/configuration_test.go
@@ -3879,6 +3879,51 @@ func TestAddVirtualServerDuringStartup_ReturnsNoChanges(t *testing.T) {
 	}
 }
 
+func TestAddVirtualServerRouteDuringStartup_ReturnsNoChanges(t *testing.T) {
+    t.Parallel()
+    configuration := createTestConfigurationDuringStartup()
+
+    vsr := createTestVirtualServerRoute("virtualserverroute", "default", "foo.example.com", "/path")
+
+    changes, problems := configuration.AddOrUpdateVirtualServerRoute(vsr)
+
+    if len(changes) != 0 {
+        t.Errorf("AddOrUpdateVirtualServerRoute() during startup returned %d changes, expected 0", len(changes))
+    }
+    if len(problems) != 0 {
+        t.Errorf("AddOrUpdateVirtualServerRoute() during startup returned %d problems, expected 0", len(problems))
+    }
+
+    // VSR must be stored in the map for CompleteStartup() to process
+    key := getResourceKey(&vsr.ObjectMeta)
+    if _, exists := configuration.virtualServerRoutes[key]; !exists {
+        t.Error("VSR was not stored in configuration.virtualServerRoutes during startup")
+    }
+}
+
+func TestAddInvalidVirtualServerRouteDuringStartup_ReportsValidationProblem(t *testing.T) {
+    t.Parallel()
+    configuration := createTestConfigurationDuringStartup()
+
+    // Create an invalid VSR with empty host
+    vsr := createTestVirtualServerRoute("virtualserverroute", "default", "", "/path")
+
+    changes, problems := configuration.AddOrUpdateVirtualServerRoute(vsr)
+
+    if len(changes) != 0 {
+        t.Errorf("AddOrUpdateVirtualServerRoute() during startup returned %d changes, expected 0", len(changes))
+    }
+    if len(problems) != 1 {
+        t.Fatalf("AddOrUpdateVirtualServerRoute() during startup returned %d problems, expected 1", len(problems))
+    }
+    if !problems[0].IsError {
+        t.Errorf("expected problem to be an error")
+    }
+    if problems[0].Reason != nl.EventReasonRejected {
+        t.Errorf("expected problem reason %q, got %q", nl.EventReasonRejected, problems[0].Reason)
+    }
+}
+
 func TestDeleteIngressDuringStartup_ReturnsNoChanges(t *testing.T) {
 	t.Parallel()
 	configuration := createTestConfigurationDuringStartup()

--- a/internal/k8s/configuration_test.go
+++ b/internal/k8s/configuration_test.go
@@ -17,6 +17,14 @@ import (
 )
 
 func createTestConfiguration() *Configuration {
+	c := createTestConfigurationDuringStartup()
+	c.CompleteStartup()
+	return c
+}
+
+// createTestConfigurationDuringStartup creates a Configuration in pre-startup
+// state (startupComplete=false), matching the state during initial queue drain.
+func createTestConfigurationDuringStartup() *Configuration {
 	lbc := LoadBalancerController{
 		ingressClass: "nginx",
 		Logger:       nl.LoggerFromContext(context.Background()),
@@ -3813,6 +3821,295 @@ func addOrUpdateVirtualServer(t *testing.T, c *Configuration, virtualServer *con
 	if !cmp.Equal(expectedProblems, problems) {
 		t.Fatalf("AddOrUpdateVirtualServer() returned unexpected result (-want +got):\n%s",
 			cmp.Diff(noProblems, problems))
+	}
+}
+
+func TestAddIngressDuringStartup_ReturnsNoChanges(t *testing.T) {
+	t.Parallel()
+	configuration := createTestConfigurationDuringStartup()
+
+	ing := createTestIngress("ingress", "foo.example.com")
+
+	changes, problems := configuration.AddOrUpdateIngress(ing)
+
+	if len(changes) != 0 {
+		t.Errorf("AddOrUpdateIngress() during startup returned %d changes, expected 0", len(changes))
+	}
+	if len(problems) != 0 {
+		t.Errorf("AddOrUpdateIngress() during startup returned %d problems, expected 0", len(problems))
+	}
+}
+
+func TestAddInvalidIngressDuringStartup_ReportsValidationProblem(t *testing.T) {
+	t.Parallel()
+	configuration := createTestConfigurationDuringStartup()
+
+	// Create an invalid ingress with duplicate hosts
+	ing := createTestIngress("ingress", "foo.example.com", "foo.example.com")
+
+	changes, problems := configuration.AddOrUpdateIngress(ing)
+
+	if len(changes) != 0 {
+		t.Errorf("AddOrUpdateIngress() during startup returned %d changes, expected 0", len(changes))
+	}
+	if len(problems) != 1 {
+		t.Fatalf("AddOrUpdateIngress() during startup returned %d problems, expected 1", len(problems))
+	}
+	if !problems[0].IsError {
+		t.Errorf("expected problem to be an error")
+	}
+	if problems[0].Reason != nl.EventReasonRejected {
+		t.Errorf("expected problem reason %q, got %q", nl.EventReasonRejected, problems[0].Reason)
+	}
+}
+
+func TestAddVirtualServerDuringStartup_ReturnsNoChanges(t *testing.T) {
+	t.Parallel()
+	configuration := createTestConfigurationDuringStartup()
+
+	vs := createTestVirtualServer("virtualserver", "foo.example.com")
+
+	changes, problems := configuration.AddOrUpdateVirtualServer(vs)
+
+	if len(changes) != 0 {
+		t.Errorf("AddOrUpdateVirtualServer() during startup returned %d changes, expected 0", len(changes))
+	}
+	if len(problems) != 0 {
+		t.Errorf("AddOrUpdateVirtualServer() during startup returned %d problems, expected 0", len(problems))
+	}
+}
+
+func TestDeleteIngressDuringStartup_ReturnsNoChanges(t *testing.T) {
+	t.Parallel()
+	configuration := createTestConfigurationDuringStartup()
+
+	// First complete startup so we can add an ingress normally
+	// Then we'll test delete during a fresh startup scenario
+	// Actually: add during startup (no rebuild), then delete during startup
+	ing := createTestIngress("ingress", "foo.example.com")
+	configuration.AddOrUpdateIngress(ing)
+
+	changes, problems := configuration.DeleteIngress("default/ingress")
+
+	if len(changes) != 0 {
+		t.Errorf("DeleteIngress() during startup returned %d changes, expected 0", len(changes))
+	}
+	if len(problems) != 0 {
+		t.Errorf("DeleteIngress() during startup returned %d problems, expected 0", len(problems))
+	}
+}
+
+func TestCompleteStartup_RebuildsHostsOnce(t *testing.T) {
+	t.Parallel()
+	configuration := createTestConfigurationDuringStartup()
+
+	// Add multiple resources during startup — no rebuilds happen
+	ing1 := createTestIngress("ingress-1", "foo.example.com")
+	ing2 := createTestIngress("ingress-2", "bar.example.com")
+	vs := createTestVirtualServer("virtualserver", "baz.example.com")
+
+	changes, _ := configuration.AddOrUpdateIngress(ing1)
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes during startup, got %d", len(changes))
+	}
+
+	changes, _ = configuration.AddOrUpdateIngress(ing2)
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes during startup, got %d", len(changes))
+	}
+
+	changes, _ = configuration.AddOrUpdateVirtualServer(vs)
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes during startup, got %d", len(changes))
+	}
+
+	// CompleteStartup should return all resources as AddOrUpdate changes
+	changes, problems := configuration.CompleteStartup()
+
+	if len(changes) != 3 {
+		t.Errorf("CompleteStartup() returned %d changes, expected 3", len(changes))
+	}
+	for _, c := range changes {
+		if c.Op != AddOrUpdate {
+			t.Errorf("expected AddOrUpdate operation, got %v", c.Op)
+		}
+	}
+	if len(problems) != 0 {
+		t.Errorf("CompleteStartup() returned %d problems, expected 0", len(problems))
+	}
+}
+
+func TestCompleteStartup_ReportsHostConflicts(t *testing.T) {
+	t.Parallel()
+	configuration := createTestConfigurationDuringStartup()
+
+	// Add two resources competing for the same host during startup
+	ing := createTestIngress("ingress", "foo.example.com")
+	vs := createTestVirtualServer("virtualserver", "foo.example.com")
+
+	configuration.AddOrUpdateIngress(ing)
+	configuration.AddOrUpdateVirtualServer(vs)
+
+	// CompleteStartup should detect the host conflict
+	changes, problems := configuration.CompleteStartup()
+
+	// One resource wins the host, the loser gets a ConfigurationProblem (warning, not error)
+	if len(problems) != 1 {
+		t.Fatalf("CompleteStartup() returned %d problems, expected 1 (host conflict)", len(problems))
+	}
+	if problems[0].IsError {
+		t.Errorf("expected host conflict problem to be a warning (IsError=false)")
+	}
+
+	// The winner should get an AddOrUpdate change
+	addOrUpdateCount := 0
+	for _, c := range changes {
+		if c.Op == AddOrUpdate {
+			addOrUpdateCount++
+		}
+	}
+	if addOrUpdateCount < 1 {
+		t.Errorf("expected at least 1 AddOrUpdate change, got %d", addOrUpdateCount)
+	}
+}
+
+func TestCompleteStartup_OrphanedMinions(t *testing.T) {
+	t.Parallel()
+	configuration := createTestConfigurationDuringStartup()
+
+	// Add a minion without its master during startup
+	minion := createTestIngressMinion("minion", "foo.example.com", "/path")
+
+	configuration.AddOrUpdateIngress(minion)
+
+	// CompleteStartup should detect the orphaned minion
+	changes, problems := configuration.CompleteStartup()
+
+	if len(problems) != 1 {
+		t.Fatalf("CompleteStartup() returned %d problems, expected 1 (orphaned minion)", len(problems))
+	}
+	if problems[0].Reason != nl.EventReasonNoIngressMasterFound {
+		t.Errorf("expected problem reason %q, got %q", nl.EventReasonNoIngressMasterFound, problems[0].Reason)
+	}
+
+	// Orphaned minion should produce no AddOrUpdate changes
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes for orphaned minion, got %d", len(changes))
+	}
+}
+
+func TestAfterCompleteStartup_NormalBehaviorResumes(t *testing.T) {
+	t.Parallel()
+	configuration := createTestConfigurationDuringStartup()
+
+	// Complete startup with no resources
+	configuration.CompleteStartup()
+
+	// Now add a resource — should get normal changes back
+	ing := createTestIngress("ingress", "foo.example.com")
+
+	expectedChanges := []ResourceChange{
+		{
+			Op: AddOrUpdate,
+			Resource: &IngressConfiguration{
+				Ingress: ing,
+				ValidHosts: map[string]bool{
+					"foo.example.com": true,
+				},
+				ChildWarnings: map[string][]string{},
+			},
+		},
+	}
+
+	changes, problems := configuration.AddOrUpdateIngress(ing)
+	if diff := cmp.Diff(expectedChanges, changes); diff != "" {
+		t.Errorf("AddOrUpdateIngress() after CompleteStartup() returned unexpected result (-want +got):\n%s", diff)
+	}
+	if len(problems) != 0 {
+		t.Errorf("AddOrUpdateIngress() after CompleteStartup() returned %d problems, expected 0", len(problems))
+	}
+}
+
+func TestCompleteStartup_MergeableIngresses(t *testing.T) {
+	t.Parallel()
+	configuration := createTestConfigurationDuringStartup()
+
+	// Add master and minions during startup
+	master := createTestIngressMaster("master", "foo.example.com")
+	minion1 := createTestIngressMinion("minion-1", "foo.example.com", "/path-1")
+	minion2 := createTestIngressMinion("minion-2", "foo.example.com", "/path-2")
+
+	configuration.AddOrUpdateIngress(master)
+	configuration.AddOrUpdateIngress(minion1)
+	configuration.AddOrUpdateIngress(minion2)
+
+	// CompleteStartup should produce a single AddOrUpdate for the master with both minions
+	changes, problems := configuration.CompleteStartup()
+
+	if len(changes) != 1 {
+		t.Fatalf("CompleteStartup() returned %d changes, expected 1", len(changes))
+	}
+	if changes[0].Op != AddOrUpdate {
+		t.Fatalf("expected AddOrUpdate operation, got %v", changes[0].Op)
+	}
+
+	ingConfig, ok := changes[0].Resource.(*IngressConfiguration)
+	if !ok {
+		t.Fatalf("expected *IngressConfiguration, got %T", changes[0].Resource)
+	}
+	if !ingConfig.IsMaster {
+		t.Errorf("expected IsMaster to be true")
+	}
+	if len(ingConfig.Minions) != 2 {
+		t.Errorf("expected 2 minions, got %d", len(ingConfig.Minions))
+	}
+	if len(problems) != 0 {
+		t.Errorf("CompleteStartup() returned %d problems, expected 0", len(problems))
+	}
+}
+
+func TestMinionsByHostIndex_TracksMinions(t *testing.T) {
+	t.Parallel()
+	configuration := createTestConfigurationDuringStartup()
+
+	// Add master and minions
+	master := createTestIngressMaster("master", "foo.example.com")
+	minion1 := createTestIngressMinion("minion-1", "foo.example.com", "/path-1")
+	minion2 := createTestIngressMinion("minion-2", "foo.example.com", "/path-2")
+
+	configuration.AddOrUpdateIngress(master)
+	configuration.AddOrUpdateIngress(minion1)
+	configuration.AddOrUpdateIngress(minion2)
+
+	// Verify the index tracks minions by host
+	hostMinions := configuration.minionsByHost["foo.example.com"]
+	if len(hostMinions) != 2 {
+		t.Fatalf("expected 2 minions indexed for foo.example.com, got %d", len(hostMinions))
+	}
+	if !hostMinions["default/minion-1"] {
+		t.Error("expected default/minion-1 in minionsByHost index")
+	}
+	if !hostMinions["default/minion-2"] {
+		t.Error("expected default/minion-2 in minionsByHost index")
+	}
+
+	// Master should not be in the index
+	for host, keys := range configuration.minionsByHost {
+		for key := range keys {
+			if key == "default/master" {
+				t.Errorf("master should not be in minionsByHost index, found under host %s", host)
+			}
+		}
+	}
+
+	// Delete a minion and verify it's removed from the index
+	configuration.DeleteIngress("default/minion-1")
+	hostMinions = configuration.minionsByHost["foo.example.com"]
+	if len(hostMinions) != 1 {
+		t.Fatalf("expected 1 minion indexed after delete, got %d", len(hostMinions))
+	}
+	if hostMinions["default/minion-1"] {
+		t.Error("default/minion-1 should have been removed from index")
 	}
 }
 

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -118,6 +118,49 @@ type controllerMetadata struct {
 
 // LoadBalancerController watches Kubernetes API and
 // reconfigures NGINX via NginxController when needed
+
+// Startup performance optimization
+// During the initial queue drain (!isNginxReady), status API calls for each
+// resource are deferred into pending slices instead of being made inline.
+// This avoids O(N) serial API calls that would block readiness
+// for minutes at scale (e.g., 1250 resources × 200ms = ~250s). After NGINX
+// is reloaded and the pod is marked ready, flushPendingStatusesAsync()
+// dispatches all deferred updates in parallel (10 workers) in a background
+// goroutine, so status metadata propagates without blocking traffic serving.
+
+// pendingVSStatus captures deferred VirtualServer status update parameters.
+type pendingVSStatus struct {
+	vs      *conf_v1.VirtualServer
+	state   string
+	reason  string
+	message string
+}
+
+// pendingVSRStatus captures deferred VirtualServerRoute status update parameters.
+type pendingVSRStatus struct {
+	vsr          *conf_v1.VirtualServerRoute
+	state        string
+	reason       string
+	message      string
+	referencedBy []*conf_v1.VirtualServer
+}
+
+// pendingTSStatus captures deferred TransportServer status update parameters.
+type pendingTSStatus struct {
+	ts      *conf_v1.TransportServer
+	state   string
+	reason  string
+	message string
+}
+
+// pendingPolicyStatus captures deferred Policy status update parameters.
+type pendingPolicyStatus struct {
+	pol     *conf_v1.Policy
+	state   string
+	reason  string
+	message string
+}
+
 type LoadBalancerController struct {
 	client                        kubernetes.Interface
 	confClient                    k8s_nginx.Interface
@@ -189,6 +232,16 @@ type LoadBalancerController struct {
 	mgmtConfigMapName             string
 	ShuttingDown                  bool
 	endpointSliceWarnings         map[string]bool // see updateEndpointSliceWarningState
+
+	// Startup status deferral: pending slices accumulate status updates
+	// during the initial queue drain (!isNginxReady). They are snapshotted
+	// and flushed asynchronously by flushPendingStatusesAsync() once the
+	// pod is ready. See the startup block in syncQueue processing.
+	pendingStatusIngresses []networking.Ingress
+	pendingStatusVSes      []pendingVSStatus
+	pendingStatusVSRs      []pendingVSRStatus
+	pendingStatusTSes      []pendingTSStatus
+	pendingStatusPolicies  []pendingPolicyStatus
 }
 
 var keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
@@ -1132,11 +1185,45 @@ func (lbc *LoadBalancerController) sync(task task) {
 	}
 
 	if !lbc.isNginxReady && lbc.syncQueue.Len() == 0 {
+		// Startup sequence: the queue is fully drained and all resources are
+		// in the in-memory model. We now perform the expensive one-time
+		// operations that were deferred during the queue drain to avoid O(N²)
+		// host rebuilds and per-resource status API calls.
+		//
+		// Step 1: CompleteStartup() performs a single rebuildHosts() that
+		// computes the definitive host→resource mapping and detects host
+		// conflicts, orphaned minions, and orphaned VSRs. processProblems()
+		// sets status to Invalid/Warning for those problematic resources.
+		_, problems := lbc.configuration.CompleteStartup()
+		lbc.processProblems(problems)
+
+		// Step 2: Generate all NGINX config files from the accumulated
+		// in-memory state and perform a single NGINX reload.
 		lbc.configurator.EnableReloads()
 		lbc.updateAllConfigs()
 
+		// Step 2b: Sync Prometheus gauges now that the configurator maps
+		// (cnf.ingresses, cnf.virtualServers, cnf.transportServers) have been
+		// populated by updateAllConfigs(). Without this, the gauges stay at 0
+		// until the first post-startup watch event triggers a per-resource
+		// metric update in syncIngress(), syncVirtualServer(), or syncTransportServer().
+		lbc.updateIngressMetrics()
+		lbc.updateVirtualServerMetrics()
+		lbc.updateTransportServerMetrics()
+
+		// Step 3: Mark ready BEFORE flushing status updates. The pod can
+		// serve traffic as soon as NGINX is reloaded — status metadata
+		// (Ingress IP, CR state) is not required for traffic serving.
+		// This decouples readiness from status API calls, which can take
+		// minutes at scale for leader pod
 		lbc.isNginxReady = true
 		nl.Debug(lbc.Logger, "NGINX is ready")
+
+		// Step 4: Flush deferred status updates in a background goroutine
+		// using a parallel worker pool (10 concurrent API calls). Snapshot
+		// the pending slices and nil the fields so the main goroutine can
+		// safely append new statuses for resources arriving after startup.
+		lbc.flushPendingStatusesAsync()
 	}
 
 	if lbc.batchSyncEnabled && lbc.syncQueue.Len() == 0 {
@@ -1586,6 +1673,13 @@ func (lbc *LoadBalancerController) updateMergeableIngressStatusAndEvents(ingConf
 			ings = append(ings, *fm.Ingress)
 		}
 
+		// Defer status updates during startup to avoid serial API calls
+		// that block readiness. See flushPendingStatusesAsync().
+		if !lbc.isNginxReady {
+			lbc.pendingStatusIngresses = append(lbc.pendingStatusIngresses, ings...)
+			return
+		}
+
 		err := lbc.statusUpdater.BulkUpdateIngressStatus(ings)
 		if err != nil {
 			nl.Errorf(lbc.Logger, "error updating ing status: %v", err)
@@ -1620,6 +1714,13 @@ func (lbc *LoadBalancerController) updateRegularIngressStatusAndEvents(ingConfig
 	lbc.recorder.Eventf(ingConfig.Ingress, eventType, eventTitle, msg)
 
 	if lbc.reportStatusEnabled() {
+		// Defer status updates during startup to avoid serial API calls
+		// that block readiness. See flushPendingStatusesAsync().
+		if !lbc.isNginxReady {
+			lbc.pendingStatusIngresses = append(lbc.pendingStatusIngresses, *ingConfig.Ingress)
+			return
+		}
+
 		err := lbc.statusUpdater.UpdateIngressStatus(*ingConfig.Ingress)
 		if err != nil {
 			nl.Errorf(lbc.Logger, "error updating ingress status: %v", err)
@@ -1658,9 +1759,17 @@ func (lbc *LoadBalancerController) updateVirtualServerStatusAndEvents(vsConfig *
 	lbc.recorder.Eventf(vsConfig.VirtualServer, eventType, eventTitle, msg)
 
 	if lbc.reportCustomResourceStatusEnabled() {
-		err := lbc.statusUpdater.UpdateVirtualServerStatus(vsConfig.VirtualServer, state, eventTitle, msg)
-		if err != nil {
-			nl.Errorf(lbc.Logger, "Error when updating the status for VirtualServer %v/%v: %v", vsConfig.VirtualServer.Namespace, vsConfig.VirtualServer.Name, err)
+		// Defer VS status updates during startup to avoid serial API calls
+		// that block readiness. See flushPendingStatusesAsync().
+		if !lbc.isNginxReady {
+			lbc.pendingStatusVSes = append(lbc.pendingStatusVSes, pendingVSStatus{
+				vs: vsConfig.VirtualServer, state: state, reason: eventTitle, message: msg,
+			})
+		} else {
+			err := lbc.statusUpdater.UpdateVirtualServerStatus(vsConfig.VirtualServer, state, eventTitle, msg)
+			if err != nil {
+				nl.Errorf(lbc.Logger, "Error when updating the status for VirtualServer %v/%v: %v", vsConfig.VirtualServer.Namespace, vsConfig.VirtualServer.Name, err)
+			}
 		}
 	}
 
@@ -1689,9 +1798,16 @@ func (lbc *LoadBalancerController) updateVirtualServerStatusAndEvents(vsConfig *
 
 		if lbc.reportCustomResourceStatusEnabled() {
 			vss := []*conf_v1.VirtualServer{vsConfig.VirtualServer}
-			err := lbc.statusUpdater.UpdateVirtualServerRouteStatusWithReferencedBy(vsr, vsrState, vsrEventTitle, msg, vss)
-			if err != nil {
-				nl.Errorf(lbc.Logger, "Error when updating the status for VirtualServerRoute %v/%v: %v", vsr.Namespace, vsr.Name, err)
+			// Defer VSR status updates during startup. See flushPendingStatusesAsync().
+			if !lbc.isNginxReady {
+				lbc.pendingStatusVSRs = append(lbc.pendingStatusVSRs, pendingVSRStatus{
+					vsr: vsr, state: vsrState, reason: vsrEventTitle, message: msg, referencedBy: vss,
+				})
+			} else {
+				err := lbc.statusUpdater.UpdateVirtualServerRouteStatusWithReferencedBy(vsr, vsrState, vsrEventTitle, msg, vss)
+				if err != nil {
+					nl.Errorf(lbc.Logger, "Error when updating the status for VirtualServerRoute %v/%v: %v", vsr.Namespace, vsr.Name, err)
+				}
 			}
 		}
 	}
@@ -1800,6 +1916,132 @@ func (lbc *LoadBalancerController) reportCustomResourceStatusEnabled() bool {
 	}
 
 	return true
+}
+
+// flushPendingStatuses writes all status updates that were deferred during startup.
+// statusFlushWorkers is the number of parallel goroutines used to flush
+// deferred status updates after startup. 10 workers occupy at most 10
+// concurrency seats under K8s API Priority and Fairness (APF). NIC's service-account
+// requests land in the "workload-low" priority level, which gets a proportional share
+// of those seats. 10 concurrent status writes is well within that budget and
+// will be queued (not rejected) by APF's fair-queuing if the level is busy.
+//
+// Each status update function in status.go has retry-on-conflict logic
+// (fetch fresh copy from API + retry) to handle 409 Conflict errors from
+// stale resourceVersion gracefully.
+//
+// Leader safety: flushPendingStatusesAsync() captures reportStatusEnabled()
+// and reportCustomResourceStatusEnabled() at snapshot time — both check
+// leaderElector.IsLeader(). Non-leader pods skip all status writes.
+const statusFlushWorkers = 10
+
+// flushPendingStatusesAsync snapshots all pending status slices, nils the
+// fields on the controller (so the main goroutine can safely reuse them for
+// post-startup resources), and flushes the snapshots in a background
+// goroutine with a bounded parallel worker pool.
+//
+// This is called immediately after isNginxReady is set to true so that the
+// pod is marked Ready (can serve traffic) while status metadata propagates
+// asynchronously.
+func (lbc *LoadBalancerController) flushPendingStatusesAsync() {
+	// Snapshot and nil: after this point the main goroutine owns the nil
+	// slices and the background goroutine owns the snapshots exclusively.
+	ings := lbc.pendingStatusIngresses
+	lbc.pendingStatusIngresses = nil
+	vses := lbc.pendingStatusVSes
+	lbc.pendingStatusVSes = nil
+	vsrs := lbc.pendingStatusVSRs
+	lbc.pendingStatusVSRs = nil
+	tses := lbc.pendingStatusTSes
+	lbc.pendingStatusTSes = nil
+	pols := lbc.pendingStatusPolicies
+	lbc.pendingStatusPolicies = nil
+
+	reportIngress := lbc.reportStatusEnabled()
+	reportCR := lbc.reportCustomResourceStatusEnabled()
+
+	go lbc.runStatusFlush(ings, vses, vsrs, tses, pols, reportIngress, reportCR)
+}
+
+// runStatusFlush dispatches all deferred status updates using a bounded parallel
+// worker pool. It is run in a dedicated goroutine by flushPendingStatusesAsync.
+func (lbc *LoadBalancerController) runStatusFlush(
+	ings []networking.Ingress,
+	vses []pendingVSStatus,
+	vsrs []pendingVSRStatus,
+	tses []pendingTSStatus,
+	pols []pendingPolicyStatus,
+	reportIngress bool,
+	reportCR bool,
+) {
+	var wg sync.WaitGroup
+	// Buffered channel acts as a counting semaphore to cap concurrency.
+	sem := make(chan struct{}, statusFlushWorkers)
+
+	// --- Ingress status (load-balancer IP) ---
+	if reportIngress && len(ings) > 0 {
+		nl.Debugf(lbc.Logger, "Flushing %d pending ingress status updates (%d workers)", len(ings), statusFlushWorkers)
+		for i := range ings {
+			ing := ings[i]
+			lbc.launchStatusWorker(sem, &wg, fmt.Sprintf("Ingress %v/%v", ing.Namespace, ing.Name), func() error {
+				return lbc.statusUpdater.UpdateIngressStatus(ing)
+			})
+		}
+	}
+
+	// --- Custom Resource statuses (VS, VSR, TS, Policy) ---
+	if reportCR {
+		for i := range vses {
+			p := vses[i]
+			lbc.launchStatusWorker(sem, &wg, fmt.Sprintf("VirtualServer %v/%v", p.vs.Namespace, p.vs.Name), func() error {
+				return lbc.statusUpdater.UpdateVirtualServerStatus(p.vs, p.state, p.reason, p.message)
+			})
+		}
+
+		for i := range vsrs {
+			p := vsrs[i]
+			lbc.launchStatusWorker(sem, &wg, fmt.Sprintf("VirtualServerRoute %v/%v", p.vsr.Namespace, p.vsr.Name), func() error {
+				return lbc.statusUpdater.UpdateVirtualServerRouteStatusWithReferencedBy(p.vsr, p.state, p.reason, p.message, p.referencedBy)
+			})
+		}
+
+		for i := range tses {
+			p := tses[i]
+			lbc.launchStatusWorker(sem, &wg, fmt.Sprintf("TransportServer %v/%v", p.ts.Namespace, p.ts.Name), func() error {
+				return lbc.statusUpdater.UpdateTransportServerStatus(p.ts, p.state, p.reason, p.message)
+			})
+		}
+
+		for i := range pols {
+			p := pols[i]
+			lbc.launchStatusWorker(sem, &wg, fmt.Sprintf("Policy %v/%v", p.pol.Namespace, p.pol.Name), func() error {
+				return lbc.statusUpdater.UpdatePolicyStatus(p.pol, p.state, p.reason, p.message)
+			})
+		}
+
+		if len(vses) > 0 || len(vsrs) > 0 || len(tses) > 0 || len(pols) > 0 {
+			nl.Debugf(lbc.Logger, "Flushing pending CR status updates (%d workers): VS=%d VSR=%d TS=%d Policy=%d",
+				statusFlushWorkers, len(vses), len(vsrs), len(tses), len(pols))
+		}
+	}
+
+	wg.Wait()
+	nl.Debugf(lbc.Logger, "Background status flush complete: Ingress=%d VS=%d VSR=%d TS=%d Policy=%d",
+		len(ings), len(vses), len(vsrs), len(tses), len(pols))
+}
+
+// launchStatusWorker acquires one semaphore slot, increments the WaitGroup,
+// and starts a goroutine that calls fn and logs any returned error.
+func (lbc *LoadBalancerController) launchStatusWorker(sem chan struct{}, wg *sync.WaitGroup, resource string, fn func() error) {
+	wg.Add(1)
+	sem <- struct{}{}
+	go func() {
+		defer wg.Done()
+		defer func() { <-sem }()
+		if err := fn(); err != nil {
+			nl.Errorf(lbc.Logger, "error flushing %s status: %v", resource, err)
+		}
+	}()
 }
 
 func (lbc *LoadBalancerController) syncSecret(task task) {

--- a/internal/k8s/policy.go
+++ b/internal/k8s/policy.go
@@ -78,9 +78,17 @@ func (lbc *LoadBalancerController) syncPolicy(task task) {
 			lbc.recorder.Eventf(pol, api_v1.EventTypeWarning, nl.EventReasonRejected, msg)
 
 			if lbc.reportCustomResourceStatusEnabled() {
-				err = lbc.statusUpdater.UpdatePolicyStatus(pol, conf_v1.StateInvalid, "Rejected", msg)
-				if err != nil {
-					nl.Debugf(lbc.Logger, "Failed to update policy %s status: %v", key, err)
+				// Defer policy status updates during startup to avoid serial
+				// API calls that block readiness. See flushPendingStatusesAsync().
+				if !lbc.isNginxReady {
+					lbc.pendingStatusPolicies = append(lbc.pendingStatusPolicies, pendingPolicyStatus{
+						pol: pol, state: conf_v1.StateInvalid, reason: "Rejected", message: msg,
+					})
+				} else {
+					err = lbc.statusUpdater.UpdatePolicyStatus(pol, conf_v1.StateInvalid, "Rejected", msg)
+					if err != nil {
+						nl.Debugf(lbc.Logger, "Failed to update policy %s status: %v", key, err)
+					}
 				}
 			}
 		} else {
@@ -88,9 +96,17 @@ func (lbc *LoadBalancerController) syncPolicy(task task) {
 			lbc.recorder.Eventf(pol, api_v1.EventTypeNormal, nl.EventReasonAddedOrUpdated, msg)
 
 			if lbc.reportCustomResourceStatusEnabled() {
-				err = lbc.statusUpdater.UpdatePolicyStatus(pol, conf_v1.StateValid, "AddedOrUpdated", msg)
-				if err != nil {
-					nl.Debugf(lbc.Logger, "Failed to update policy %s status: %v", key, err)
+				// Defer policy status updates during startup to avoid serial
+				// API calls that block readiness. See flushPendingStatusesAsync().
+				if !lbc.isNginxReady {
+					lbc.pendingStatusPolicies = append(lbc.pendingStatusPolicies, pendingPolicyStatus{
+						pol: pol, state: conf_v1.StateValid, reason: "AddedOrUpdated", message: msg,
+					})
+				} else {
+					err = lbc.statusUpdater.UpdatePolicyStatus(pol, conf_v1.StateValid, "AddedOrUpdated", msg)
+					if err != nil {
+						nl.Debugf(lbc.Logger, "Failed to update policy %s status: %v", key, err)
+					}
 				}
 			}
 		}

--- a/internal/k8s/transport_server.go
+++ b/internal/k8s/transport_server.go
@@ -156,9 +156,17 @@ func (lbc *LoadBalancerController) updateTransportServerStatusAndEvents(tsConfig
 	lbc.recorder.Eventf(tsConfig.TransportServer, eventType, eventTitle, msg)
 
 	if lbc.reportCustomResourceStatusEnabled() {
-		err := lbc.statusUpdater.UpdateTransportServerStatus(tsConfig.TransportServer, state, eventTitle, msg)
-		if err != nil {
-			nl.Errorf(lbc.Logger, "Error when updating the status for TransportServer %v/%v: %v", tsConfig.TransportServer.Namespace, tsConfig.TransportServer.Name, err)
+		// Defer TS status updates during startup to avoid serial API calls
+		// that block readiness. See flushPendingStatusesAsync().
+		if !lbc.isNginxReady {
+			lbc.pendingStatusTSes = append(lbc.pendingStatusTSes, pendingTSStatus{
+				ts: tsConfig.TransportServer, state: state, reason: eventTitle, message: msg,
+			})
+		} else {
+			err := lbc.statusUpdater.UpdateTransportServerStatus(tsConfig.TransportServer, state, eventTitle, msg)
+			if err != nil {
+				nl.Errorf(lbc.Logger, "Error when updating the status for TransportServer %v/%v: %v", tsConfig.TransportServer.Namespace, tsConfig.TransportServer.Name, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Proposed changes

Add guard logic for VirtualServerRoute during startup optimization to prevent expensive rebuilds.
 
During startup, adding VirtualServerRoutes triggers expensive rebuildHosts() operations even though the configuration isn't fully loaded yet. This causes performance issues when many VSRs are created during startup.
 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
