### PR TITLE
Remove unneeded error return from BalanceProxyValues

### DIFF
--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -428,18 +428,15 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 
 	// Only run balance validation if auto-adjust is enabled
 	if enableDirectiveAutoadjust {
-		balancedProxyBuffers, balancedProxyBufferSize, balancedProxyBusyBufferSize, modifications, err := validation.BalanceProxyValues(cfgParams.ProxyBuffers, cfgParams.ProxyBufferSize, cfgParams.ProxyBusyBuffersSize, enableDirectiveAutoadjust)
-		if err != nil {
-			nl.Errorf(l, "error reconciling proxy_buffers, proxy_buffer_size, and proxy_busy_buffers_size values: %s", err.Error())
-		} else {
-			cfgParams.ProxyBuffers = balancedProxyBuffers
-			cfgParams.ProxyBufferSize = balancedProxyBufferSize
-			cfgParams.ProxyBusyBuffersSize = balancedProxyBusyBufferSize
+		balancedProxyBuffers, balancedProxyBufferSize, balancedProxyBusyBufferSize, modifications := validation.BalanceProxyValues(cfgParams.ProxyBuffers, cfgParams.ProxyBufferSize, cfgParams.ProxyBusyBuffersSize, enableDirectiveAutoadjust)
 
-			if len(modifications) > 0 {
-				for _, modification := range modifications {
-					nl.Infof(l, "Changes made to proxy values: %s", modification)
-				}
+		cfgParams.ProxyBuffers = balancedProxyBuffers
+		cfgParams.ProxyBufferSize = balancedProxyBufferSize
+		cfgParams.ProxyBusyBuffersSize = balancedProxyBusyBufferSize
+
+		if len(modifications) > 0 {
+			for _, modification := range modifications {
+				nl.Infof(l, "Changes made to proxy values: %s", modification)
 			}
 		}
 	}

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -393,18 +393,15 @@ func ParseConfigMap(ctx context.Context, cfgm *v1.ConfigMap, nginxPlus bool, has
 
 	// Only run balance validation if auto-adjust is enabled
 	if enableDirectiveAutoadjust {
-		balancedProxyBuffers, balancedProxyBufferSize, balancedProxyBusyBufferSize, modifications, err := validation.BalanceProxyValues(cfgParams.ProxyBuffers, cfgParams.ProxyBufferSize, cfgParams.ProxyBusyBuffersSize, enableDirectiveAutoadjust)
-		if err != nil {
-			nl.Errorf(l, "error reconciling proxy_buffers, proxy_buffer_size, and proxy_busy_buffers_size values: %s", err.Error())
-		} else {
-			cfgParams.ProxyBuffers = balancedProxyBuffers
-			cfgParams.ProxyBufferSize = balancedProxyBufferSize
-			cfgParams.ProxyBusyBuffersSize = balancedProxyBusyBufferSize
+		balancedProxyBuffers, balancedProxyBufferSize, balancedProxyBusyBufferSize, modifications := validation.BalanceProxyValues(cfgParams.ProxyBuffers, cfgParams.ProxyBufferSize, cfgParams.ProxyBusyBuffersSize, enableDirectiveAutoadjust)
 
-			if len(modifications) > 0 {
-				for _, modification := range modifications {
-					nl.Infof(l, "Changes made to proxy values: %s", modification)
-				}
+		cfgParams.ProxyBuffers = balancedProxyBuffers
+		cfgParams.ProxyBufferSize = balancedProxyBufferSize
+		cfgParams.ProxyBusyBuffersSize = balancedProxyBusyBufferSize
+
+		if len(modifications) > 0 {
+			for _, modification := range modifications {
+				nl.Infof(l, "Changes made to proxy values: %s", modification)
 			}
 		}
 	}

--- a/internal/k8s/configuration.go
+++ b/internal/k8s/configuration.go
@@ -546,12 +546,8 @@ func (c *Configuration) AddOrUpdateVirtualServer(vs *conf_v1.VirtualServer) ([]R
 		if validationError != nil {
 			delete(c.virtualServers, key)
 		} else {
-			if err := c.balanceUpstreamProxies(vs.Spec.Upstreams); err != nil {
-				validationError = fmt.Errorf("balancing proxy buffer sizes: %w", err)
-				delete(c.virtualServers, key)
-			} else {
-				c.virtualServers[key] = vs
-			}
+			c.balanceUpstreamProxies(vs.Spec.Upstreams)
+			c.virtualServers[key] = vs
 		}
 	}
 
@@ -618,13 +614,8 @@ func (c *Configuration) AddOrUpdateVirtualServerRoute(vsr *conf_v1.VirtualServer
 			delete(c.virtualServerRoutes, key)
 		} else {
 			// Balance proxy buffer sizes for all upstreams before storing
-			if err := c.balanceUpstreamProxies(vsr.Spec.Upstreams); err != nil {
-				// Create a proper validation error for proxy buffer balancing failures
-				validationError = fmt.Errorf("balancing proxy buffer sizes: %w", err)
-				delete(c.virtualServers, key)
-			} else {
-				c.virtualServerRoutes[key] = vsr
-			}
+			c.balanceUpstreamProxies(vsr.Spec.Upstreams)
+			c.virtualServerRoutes[key] = vsr
 		}
 	}
 
@@ -2099,12 +2090,8 @@ func detectChangesInListenerHosts(
 // VirtualServer and VirtualServerRoute. We need this here because upstreams are
 // values in the slice, but the balancing function takes pointers as it modifies
 // the upstreams.
-func (c *Configuration) balanceUpstreamProxies(upstreams []conf_v1.Upstream) error {
+func (c *Configuration) balanceUpstreamProxies(upstreams []conf_v1.Upstream) {
 	for i := range upstreams {
-		err := internalValidation.BalanceProxiesForUpstreams(&upstreams[i], c.isDirectiveAutoadjustEnabled)
-		if err != nil {
-			return fmt.Errorf("upstream %d: %w", i, err)
-		}
+		internalValidation.BalanceProxiesForUpstreams(&upstreams[i], c.isDirectiveAutoadjustEnabled)
 	}
-	return nil
 }

--- a/internal/validation/data_types.go
+++ b/internal/validation/data_types.go
@@ -271,15 +271,15 @@ func applyBufferSizeConstraints(proxyBufferSizeBytes, proxyBusyBuffersBytes, buf
 //
 // This function now works with string inputs and returns string outputs.
 // Proxy buffer format is always "number size" separated by a space.
-func BalanceProxyValues(proxyBuffers, proxyBufferSize, proxyBusyBuffers string, autoadjust bool) (string, string, string, []string, error) {
+func BalanceProxyValues(proxyBuffers, proxyBufferSize, proxyBusyBuffers string, autoadjust bool) (string, string, string, []string) {
 	if !autoadjust {
-		return proxyBuffers, proxyBufferSize, proxyBusyBuffers, []string{"auto adjust is turned off, no changes have been made to the proxy values"}, nil
+		return proxyBuffers, proxyBufferSize, proxyBusyBuffers, []string{"auto adjust is turned off, no changes have been made to the proxy values"}
 	}
 
 	modifications := make([]string, 0)
 
 	if proxyBuffers == "" && proxyBufferSize == "" && proxyBusyBuffers == "" {
-		return proxyBuffers, proxyBufferSize, proxyBusyBuffers, modifications, nil
+		return proxyBuffers, proxyBufferSize, proxyBusyBuffers, modifications
 	}
 
 	// Parse proxy buffers or use defaults
@@ -312,21 +312,21 @@ func BalanceProxyValues(proxyBuffers, proxyBufferSize, proxyBusyBuffers string, 
 	proxyBusyBuffersStr := bytesToSizeString(proxyBusyBuffersBytes)
 
 	resultProxyBuffers := fmt.Sprintf("%d %s", bufferNumber, bufferSizeStr)
-	return resultProxyBuffers, proxyBufferSizeStr, proxyBusyBuffersStr, modifications, nil
+	return resultProxyBuffers, proxyBufferSizeStr, proxyBusyBuffersStr, modifications
 }
 
 // BalanceProxiesForUpstreams balances the proxy buffer settings for an Upstream
 // struct. The only reason for this function is to convert between the data type
 // in the Upstream struct and the data types used in the balancing logic and
 // back.
-func BalanceProxiesForUpstreams(in *conf_v1.Upstream, autoadjust bool) error {
+func BalanceProxiesForUpstreams(in *conf_v1.Upstream, autoadjust bool) {
 	if in.ProxyBuffers == nil {
-		return nil
+		return
 	}
 
 	// When autoadjust is disabled, don't change anything - leave it broken!
 	if !autoadjust {
-		return nil
+		return
 	}
 
 	pb, err := newNumberSizeConfig(fmt.Sprintf("%d %s", in.ProxyBuffers.Number, in.ProxyBuffers.Size), autoadjust)
@@ -347,10 +347,7 @@ func BalanceProxiesForUpstreams(in *conf_v1.Upstream, autoadjust bool) error {
 		pbbs = "4k"
 	}
 
-	balancedPB, balancedPBS, balancedPBBS, _, err := BalanceProxyValues(pb, pbs, pbbs, autoadjust)
-	if err != nil {
-		return fmt.Errorf("error balancing proxy values: %w", err)
-	}
+	balancedPB, balancedPBS, balancedPBBS, _ := BalanceProxyValues(pb, pbs, pbbs, autoadjust)
 
 	// Parse the balanced proxy buffers string back to struct
 	if balancedPB != "" {
@@ -368,6 +365,4 @@ func BalanceProxiesForUpstreams(in *conf_v1.Upstream, autoadjust bool) error {
 
 	in.ProxyBufferSize = balancedPBS
 	in.ProxyBusyBuffersSize = balancedPBBS
-
-	return nil
 }

--- a/internal/validation/data_types_test.go
+++ b/internal/validation/data_types_test.go
@@ -187,11 +187,9 @@ func TestBalanceProxyValues(t *testing.T) {
 		wantProxyBuffers        string
 		wantProxyBufferSize     string
 		wantProxyBusyBufferSize string
-		wantErr                 bool
 	}{
 		{
 			name:    "All empty",
-			wantErr: false,
 		},
 
 		{
@@ -202,7 +200,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "2 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "4k",
-			wantErr:                 false,
 		},
 
 		{
@@ -213,7 +210,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "4 16k",
 			wantProxyBufferSize:     "16k",
 			wantProxyBusyBufferSize: "16k",
-			wantErr:                 false,
 		},
 
 		{
@@ -225,7 +221,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "8 1m",
 			wantProxyBufferSize:     "5m",
 			wantProxyBusyBufferSize: "5m",
-			wantErr:                 false,
 		},
 
 		{
@@ -248,7 +243,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "2 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "4k",
-			wantErr:                 false,
 		},
 
 		{
@@ -261,7 +255,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "8 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "16k",
-			wantErr:                 false,
 		},
 
 		{
@@ -274,7 +267,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "4 8k",
 			wantProxyBufferSize:     "8k",
 			wantProxyBusyBufferSize: "24k",
-			wantErr:                 false,
 		},
 
 		{
@@ -285,7 +277,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "2 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "4k",
-			wantErr:                 false,
 		},
 
 		{
@@ -297,7 +288,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "1024 1k",
 			wantProxyBufferSize:     "1023k",
 			wantProxyBusyBufferSize: "1023k",
-			wantErr:                 false,
 		},
 
 		{
@@ -309,7 +299,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "8 4k",
 			wantProxyBufferSize:     "28k",
 			wantProxyBusyBufferSize: "28k",
-			wantErr:                 false,
 		},
 
 		{
@@ -321,7 +310,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "2 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "4k",
-			wantErr:                 false,
 		},
 
 		{
@@ -332,7 +320,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "2 2k",
 			wantProxyBufferSize:     "2k",
 			wantProxyBusyBufferSize: "2k",
-			wantErr:                 false,
 		},
 
 		{
@@ -344,7 +331,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "2 2k",
 			wantProxyBufferSize:     "2k",
 			wantProxyBusyBufferSize: "2k",
-			wantErr:                 false,
 		},
 
 		{
@@ -355,7 +341,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "2 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "4k",
-			wantErr:                 false,
 		},
 
 		{
@@ -366,7 +351,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "16 1k",
 			wantProxyBufferSize:     "1k",
 			wantProxyBusyBufferSize: "1k",
-			wantErr:                 false,
 		},
 
 		{
@@ -377,7 +361,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "2 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "4k",
-			wantErr:                 false,
 		},
 
 		{
@@ -389,7 +372,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "2 1k",
 			wantProxyBufferSize:     "1k",
 			wantProxyBusyBufferSize: "1k",
-			wantErr:                 false,
 		},
 
 		{
@@ -401,7 +383,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "4 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "12k",
-			wantErr:                 false,
 		},
 
 		{
@@ -414,7 +395,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "4 8k",
 			wantProxyBufferSize:     "16k",
 			wantProxyBusyBufferSize: "16k",
-			wantErr:                 false,
 		},
 		// no no no no
 		{
@@ -426,7 +406,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "4 16k",
 			wantProxyBufferSize:     "8k",
 			wantProxyBusyBufferSize: "16k",
-			wantErr:                 false,
 		},
 
 		{
@@ -438,7 +417,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "2 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "4k",
-			wantErr:                 false,
 		},
 		{
 			name: "proxy_buffers is too small, but valid",
@@ -450,7 +428,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "24 1k",
 			wantProxyBufferSize:     "23k",
 			wantProxyBusyBufferSize: "23k",
-			wantErr:                 false,
 		},
 		{
 			name: "trio should pass unchanged",
@@ -462,7 +439,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "8 4k",
 			wantProxyBufferSize:     "8k",
 			wantProxyBusyBufferSize: "16k",
-			wantErr:                 false,
 		},
 		{
 			name: "proxy_busy_buffers is in MB",
@@ -474,7 +450,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "8 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "28k",
-			wantErr:                 false,
 		},
 
 		{
@@ -486,7 +461,6 @@ func TestBalanceProxyValues(t *testing.T) {
 			wantProxyBuffers:        "4 2k",
 			wantProxyBufferSize:     "2k",
 			wantProxyBusyBufferSize: "2k",
-			wantErr:                 false,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/validation/data_types_test.go
+++ b/internal/validation/data_types_test.go
@@ -189,7 +189,7 @@ func TestBalanceProxyValues(t *testing.T) {
 		wantProxyBusyBufferSize string
 	}{
 		{
-			name:    "All empty",
+			name: "All empty",
 		},
 
 		{

--- a/internal/validation/data_types_test.go
+++ b/internal/validation/data_types_test.go
@@ -506,9 +506,7 @@ func TestBalanceProxyValues(t *testing.T) {
 				t.Fatalf("Failed to parse proxyBusyBuffers: %v", err)
 			}
 
-			gotProxyBuffers, gotProxyBufferSize, gotProxyBusyBufferSize, m, err := BalanceProxyValues(pb, pbs, pbbs, true)
-
-			assert.NoError(t, err)
+			gotProxyBuffers, gotProxyBufferSize, gotProxyBusyBufferSize, m := BalanceProxyValues(pb, pbs, pbbs, true)
 
 			for _, mm := range m {
 				t.Logf("Modification: %s", mm)
@@ -529,7 +527,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 		wantProxyBuffers        string
 		wantProxyBufferSize     string
 		wantProxyBusyBufferSize string
-		wantErr                 bool
 	}{
 		{
 			name: "nil ProxyBuffers - no changes",
@@ -537,7 +534,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 				ProxyBuffers: nil,
 			},
 			autoadjust: true,
-			wantErr:    false,
 		},
 		{
 			name: "valid configuration unchanged",
@@ -553,7 +549,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "8 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "16k",
-			wantErr:                 false,
 		},
 		{
 			name: "invalid proxy buffers get default values",
@@ -569,7 +564,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "8 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "4k",
-			wantErr:                 false,
 		},
 		{
 			name: "minimum buffer count enforced",
@@ -585,7 +579,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "2 8k",
 			wantProxyBufferSize:     "8k",
 			wantProxyBusyBufferSize: "8k",
-			wantErr:                 false,
 		},
 		{
 			name: "maximum buffer count enforced",
@@ -601,7 +594,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "1024 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "8k",
-			wantErr:                 false,
 		},
 		{
 			name: "proxy buffer size too large gets adjusted",
@@ -617,7 +609,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "4 4k",
 			wantProxyBufferSize:     "12k",
 			wantProxyBusyBufferSize: "12k",
-			wantErr:                 false,
 		},
 		{
 			name: "proxy busy buffer size too large gets adjusted",
@@ -633,7 +624,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "4 8k",
 			wantProxyBufferSize:     "8k",
 			wantProxyBusyBufferSize: "24k",
-			wantErr:                 false,
 		},
 		{
 			name: "proxy busy buffer size too small gets adjusted",
@@ -649,7 +639,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "8 4k",
 			wantProxyBufferSize:     "8k",
 			wantProxyBusyBufferSize: "8k",
-			wantErr:                 false,
 		},
 		{
 			name: "empty proxy buffer size gets set to proxy buffers size",
@@ -665,7 +654,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "6 16k",
 			wantProxyBufferSize:     "16k",
 			wantProxyBusyBufferSize: "32k",
-			wantErr:                 false,
 		},
 		{
 			name: "autoadjust disabled - no changes to valid configuration",
@@ -681,7 +669,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "8 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "16k",
-			wantErr:                 false,
 		},
 		{
 			name: "autoadjust disabled - invalid buffer count unchanged",
@@ -697,7 +684,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "1 8k",
 			wantProxyBufferSize:     "8k",
 			wantProxyBusyBufferSize: "16k",
-			wantErr:                 false,
 		},
 		{
 			name: "autoadjust disabled - oversized buffer size unchanged",
@@ -713,7 +699,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "4 4k",
 			wantProxyBufferSize:     "64k",
 			wantProxyBusyBufferSize: "8k",
-			wantErr:                 false,
 		},
 		{
 			name: "autoadjust disabled - undersized busy buffer unchanged",
@@ -729,7 +714,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "8 4k",
 			wantProxyBufferSize:     "8k",
 			wantProxyBusyBufferSize: "2k",
-			wantErr:                 false,
 		},
 		{
 			name: "autoadjust disabled - oversized busy buffer unchanged",
@@ -745,7 +729,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "4 8k",
 			wantProxyBufferSize:     "8k",
 			wantProxyBusyBufferSize: "64k",
-			wantErr:                 false,
 		},
 		{
 			name: "autoadjust disabled - zero buffer count unchanged",
@@ -761,7 +744,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "0 4k",
 			wantProxyBufferSize:     "4k",
 			wantProxyBusyBufferSize: "8k",
-			wantErr:                 false,
 		},
 		{
 			name: "autoadjust disabled - extreme buffer count unchanged",
@@ -777,7 +759,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "2000 1k",
 			wantProxyBufferSize:     "1k",
 			wantProxyBusyBufferSize: "2k",
-			wantErr:                 false,
 		},
 		{
 			name: "autoadjust disabled - empty buffer size unchanged",
@@ -793,7 +774,6 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "6 16k",
 			wantProxyBufferSize:     "",
 			wantProxyBusyBufferSize: "32k",
-			wantErr:                 false,
 		},
 		{
 			name: "autoadjust disabled - invalid size values get defaults but no balancing",
@@ -809,18 +789,12 @@ func TestBalanceProxiesForUpstreams(t *testing.T) {
 			wantProxyBuffers:        "0 invalid",
 			wantProxyBufferSize:     "invalid",
 			wantProxyBusyBufferSize: "invalid",
-			wantErr:                 false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := BalanceProxiesForUpstreams(tt.upstream, tt.autoadjust)
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("BalanceProxiesForUpstreams() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			BalanceProxiesForUpstreams(tt.upstream, tt.autoadjust)
 
 			if tt.upstream.ProxyBuffers != nil {
 				gotProxyBuffers := fmt.Sprintf("%d %s", tt.upstream.ProxyBuffers.Number, tt.upstream.ProxyBuffers.Size)

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -88,10 +88,7 @@ func (vsv *VirtualServerValidator) ValidateVirtualServer(virtualServer *v1.Virtu
 // BalanceUpstreamProxies balances proxy buffer sizes for all upstreams in a VirtualServer.
 func (vsv *VirtualServerValidator) BalanceUpstreamProxies(virtualServer *v1.VirtualServer) error {
 	for i := range virtualServer.Spec.Upstreams {
-		err := internalValidation.BalanceProxiesForUpstreams(&virtualServer.Spec.Upstreams[i], vsv.isDirectiveAutoadjustEnabled)
-		if err != nil {
-			return fmt.Errorf("upstream %d: %w", i, err)
-		}
+		internalValidation.BalanceProxiesForUpstreams(&virtualServer.Spec.Upstreams[i], vsv.isDirectiveAutoadjustEnabled)
 	}
 	return nil
 }
@@ -99,10 +96,7 @@ func (vsv *VirtualServerValidator) BalanceUpstreamProxies(virtualServer *v1.Virt
 // BalanceUpstreamProxiesForRoute balances proxy buffer sizes for all upstreams in a VirtualServerRoute.
 func (vsv *VirtualServerValidator) BalanceUpstreamProxiesForRoute(virtualServerRoute *v1.VirtualServerRoute) error {
 	for i := range virtualServerRoute.Spec.Upstreams {
-		err := internalValidation.BalanceProxiesForUpstreams(&virtualServerRoute.Spec.Upstreams[i], vsv.isDirectiveAutoadjustEnabled)
-		if err != nil {
-			return fmt.Errorf("upstream %d: %w", i, err)
-		}
+		internalValidation.BalanceProxiesForUpstreams(&virtualServerRoute.Spec.Upstreams[i], vsv.isDirectiveAutoadjustEnabled)
 	}
 	return nil
 }

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -86,19 +86,17 @@ func (vsv *VirtualServerValidator) ValidateVirtualServer(virtualServer *v1.Virtu
 }
 
 // BalanceUpstreamProxies balances proxy buffer sizes for all upstreams in a VirtualServer.
-func (vsv *VirtualServerValidator) BalanceUpstreamProxies(virtualServer *v1.VirtualServer) error {
+func (vsv *VirtualServerValidator) BalanceUpstreamProxies(virtualServer *v1.VirtualServer) {
 	for i := range virtualServer.Spec.Upstreams {
 		internalValidation.BalanceProxiesForUpstreams(&virtualServer.Spec.Upstreams[i], vsv.isDirectiveAutoadjustEnabled)
 	}
-	return nil
 }
 
 // BalanceUpstreamProxiesForRoute balances proxy buffer sizes for all upstreams in a VirtualServerRoute.
-func (vsv *VirtualServerValidator) BalanceUpstreamProxiesForRoute(virtualServerRoute *v1.VirtualServerRoute) error {
+func (vsv *VirtualServerValidator) BalanceUpstreamProxiesForRoute(virtualServerRoute *v1.VirtualServerRoute) {
 	for i := range virtualServerRoute.Spec.Upstreams {
 		internalValidation.BalanceProxiesForUpstreams(&virtualServerRoute.Spec.Upstreams[i], vsv.isDirectiveAutoadjustEnabled)
 	}
-	return nil
 }
 
 // validateVirtualServerSpec validates a VirtualServerSpec.


### PR DESCRIPTION
### Proposed changes

That function (`BalanceProxyValues`) didn't return anything other than nil for error, so the return error argument was unnecessary.

That also means the error return in two other caller functions are also unnecessary, so have also been removed, and tests adjusted.

And because they didn't return errors, their callers also didn't need to deal with errors, so a few if branches were also removed.

![Made by Human](https://madebyhuman.iamjarl.com/badges/made-white.svg)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
