### PR TITLE
Prebuild secrets-gen binary and add setup-go to setup-smoke

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -82,10 +82,10 @@ jobs:
 
       - name: Restore secrets-gen binary cache
         id: secrets-gen-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: hack/secrets-gen/secrets-gen
-          key: nic-secrets-gen-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('hack/secrets-gen/**', 'internal/configs/**/*.go', 'internal/k8s/secrets/**/*.go', 'go.mod', 'go.sum') }}
+          key: nic-secrets-gen-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('hack/secrets-gen/**', 'internal/**/*.go', 'go.mod', 'go.sum') }}
 
       - name: Setup Golang Environment for secrets-gen build
         if: steps.secrets-gen-cache.outputs.cache-hit != 'true' && !inputs.force
@@ -100,6 +100,13 @@ jobs:
         env:
           GOPATH: ${{ inputs.go-path }}
           GOPROXY: ${{ inputs.go-proxy }}
+
+      - name: Save secrets-gen binary to cache
+        if: steps.secrets-gen-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: hack/secrets-gen/secrets-gen
+          key: nic-secrets-gen-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('hack/secrets-gen/**', 'internal/**/*.go', 'go.mod', 'go.sum') }}
 
       - name: Setup netrc
         run: |

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -80,6 +80,27 @@ jobs:
           go-version-file: go.mod
         if: ${{ inputs.force }}
 
+      - name: Restore secrets-gen binary cache
+        id: secrets-gen-cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: hack/secrets-gen/secrets-gen
+          key: nic-secrets-gen-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('hack/secrets-gen/**', 'internal/configs/**/*.go', 'internal/k8s/secrets/**/*.go', 'go.mod', 'go.sum') }}
+
+      - name: Setup Golang Environment for secrets-gen build
+        if: steps.secrets-gen-cache.outputs.cache-hit != 'true' && !inputs.force
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build secrets-gen binary
+        if: steps.secrets-gen-cache.outputs.cache-hit != 'true'
+        run: |
+          go build -trimpath -ldflags='-s -w' -o hack/secrets-gen/secrets-gen ./hack/secrets-gen
+        env:
+          GOPATH: ${{ inputs.go-path }}
+          GOPROXY: ${{ inputs.go-proxy }}
+
       - name: Setup netrc
         run: |
           cat <<EOF > $HOME/.netrc

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -54,7 +54,21 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Golang Environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Restore secrets-gen binary cache
+        id: secrets-gen-cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: hack/secrets-gen/secrets-gen
+          key: nic-secrets-gen-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('hack/secrets-gen/**', 'internal/configs/**/*.go', 'internal/k8s/secrets/**/*.go', 'go.mod', 'go.sum') }}
+
       - name: Generate Secrets for tests
+        env:
+          SECRETS_GEN_BIN: ${{ steps.secrets-gen-cache.outputs.cache-hit == 'true' && format('{0}/hack/secrets-gen/secrets-gen', github.workspace) || '' }}
         run: |
           make secrets
 

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: hack/secrets-gen/secrets-gen
-          key: nic-secrets-gen-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('hack/secrets-gen/**', 'internal/configs/**/*.go', 'internal/k8s/secrets/**/*.go', 'go.mod', 'go.sum') }}
+          key: nic-secrets-gen-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('hack/secrets-gen/**', 'internal/**/*.go', 'go.mod', 'go.sum') }}
 
       - name: Generate Secrets for tests
         env:

--- a/hack/secrets-gen/Makefile
+++ b/hack/secrets-gen/Makefile
@@ -1,19 +1,26 @@
 SECRETS ?= ../secrets.json
 DEBUG ?= false
+SECRETS_GEN_BIN ?=
 
 OPTIONS :=
 ifeq ($(DEBUG),true)
 OPTIONS += -debug
 endif
 
+ifeq ($(SECRETS_GEN_BIN),)
+RUN_CMD := go run ./...
+else
+RUN_CMD := $(SECRETS_GEN_BIN)
+endif
+
 .PHONY: run
 run: ## Create just in time TLS certificates needed for tests and examples
-	@go run ./... $(OPTIONS) -secrets-path  $(SECRETS)
+	@$(RUN_CMD) $(OPTIONS) -secrets-path  $(SECRETS)
 
 .PHONY: clean
 clean: ## Clean just in time TLS certificates needed for tests and examples
-	@go run ./... $(OPTIONS) -clean -secrets-path $(SECRETS)
+	@$(RUN_CMD) $(OPTIONS) -clean -secrets-path $(SECRETS)
 
 .PHONY: ignore
 ignore:
-	@go run ./... $(OPTIONS) -gitignore -secrets-path $(SECRETS)
+	@$(RUN_CMD) $(OPTIONS) -gitignore -secrets-path $(SECRETS)


### PR DESCRIPTION
### Proposed changes

Without setup-go, secrets-gen pulled in a docker container, which took about a minute per group of e2e tests. This change should cut down the time for generating the secrets for each of those down to maybe 5s, saving approximately an hour cumulative time per CI run across all shards.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
