### PR TITLE
Add telemetry support for ExternalAuth policies

### DIFF
--- a/internal/telemetry/cluster.go
+++ b/internal/telemetry/cluster.go
@@ -272,6 +272,8 @@ func (c *Collector) PolicyCount() map[string]int {
 			policyCounters["Cache"]++
 		case spec.CORS != nil:
 			policyCounters["CORS"]++
+		case spec.ExternalAuth != nil:
+			policyCounters["ExternalAuth"]++
 		}
 	}
 	return policyCounters

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -167,6 +167,7 @@ func (c *Collector) Collect(ctx context.Context) {
 			WAFPolicies:                int64(report.WAFCount),
 			CachePolicies:              int64(report.CacheCount),
 			CORSPolicies:               int64(report.CORSCount),
+			ExternalAuthPolicies:       int64(report.ExternalAuthCount),
 
 			GlobalConfiguration: report.GlobalConfiguration,
 			IngressAnnotations:  report.IngressAnnotations,
@@ -224,6 +225,7 @@ type Report struct {
 	WAFCount                int
 	CacheCount              int
 	CORSCount               int
+	ExternalAuthCount       int
 	GlobalConfiguration     bool
 	IngressAnnotations      []string
 	AppProtectVersion       string
@@ -304,6 +306,7 @@ func (c *Collector) BuildReport(ctx context.Context) (Report, error) {
 		wafCount                int
 		cacheCount              int
 		corsCount               int
+		externalAuthCount       int
 	)
 	// Collect Custom Resources (Policies) only if CR enabled at startup.
 	if c.Config.CustomResourcesEnabled {
@@ -321,6 +324,7 @@ func (c *Collector) BuildReport(ctx context.Context) (Report, error) {
 		wafCount = policies["WAF"]
 		cacheCount = policies["Cache"]
 		corsCount = policies["CORS"]
+		externalAuthCount = policies["ExternalAuth"]
 	}
 
 	ingressAnnotations := c.IngressAnnotations()
@@ -385,6 +389,7 @@ func (c *Collector) BuildReport(ctx context.Context) (Report, error) {
 		WAFCount:                wafCount,
 		CacheCount:              cacheCount,
 		CORSCount:               corsCount,
+		ExternalAuthCount:       externalAuthCount,
 		GlobalConfiguration:     c.Config.GlobalConfiguration,
 		IngressAnnotations:      ingressAnnotations,
 		AppProtectVersion:       appProtectVersion,

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -283,6 +283,13 @@ func TestCollectPolicyCountOnCustomResourcesEnabled(t *testing.T) {
 			want: 1,
 		},
 		{
+			name: "ExternalAuthPolicy",
+			policies: func() []*conf_v1.Policy {
+				return []*conf_v1.Policy{externalAuthPolicy}
+			},
+			want: 1,
+		},
+		{
 			name: "MultiplePolicies",
 			policies: func() []*conf_v1.Policy {
 				return []*conf_v1.Policy{rateLimitPolicy, wafPolicy, oidcPolicy}
@@ -435,6 +442,7 @@ func TestCollectPoliciesReportOnEnabledCustomResources(t *testing.T) {
 				oidcPolicy,
 				cachePolicy,
 				corsPolicy,
+				externalAuthPolicy,
 			}
 		},
 		CustomResourcesEnabled: true,
@@ -457,12 +465,13 @@ func TestCollectPoliciesReportOnEnabledCustomResources(t *testing.T) {
 	}
 
 	nicResourceCounts := telemetry.NICResourceCounts{
-		RateLimitPolicies:  0,
-		WAFPolicies:        2,
-		OIDCPolicies:       1,
-		EgressMTLSPolicies: 2,
-		CachePolicies:      1,
-		CORSPolicies:       1,
+		RateLimitPolicies:    0,
+		WAFPolicies:          2,
+		OIDCPolicies:         1,
+		EgressMTLSPolicies:   2,
+		CachePolicies:        1,
+		CORSPolicies:         1,
+		ExternalAuthPolicies: 1,
 	}
 
 	td := telemetry.Data{
@@ -2912,6 +2921,21 @@ var (
 		},
 		Spec: conf_v1.PolicySpec{
 			CORS: &conf_v1.CORS{},
+		},
+		Status: conf_v1.PolicyStatus{},
+	}
+
+	externalAuthPolicy = &conf_v1.Policy{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "Policy",
+			APIVersion: "k8s.nginx.org/v1",
+		},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "external-auth-policy",
+			Namespace: "default",
+		},
+		Spec: conf_v1.PolicySpec{
+			ExternalAuth: &conf_v1.ExternalAuth{},
 		},
 		Status: conf_v1.PolicyStatus{},
 	}

--- a/internal/telemetry/data.avdl
+++ b/internal/telemetry/data.avdl
@@ -138,6 +138,6 @@ It is the UID of the `kube-system` Namespace. */
 		
 		/** ExternalAuthPolicies is the number of ExternalAuth policies managed by NGINX Ingress Controller */
 		long? ExternalAuthPolicies = null;
-
+		
 	}
 }

--- a/internal/telemetry/data.avdl
+++ b/internal/telemetry/data.avdl
@@ -136,5 +136,8 @@ It is the UID of the `kube-system` Namespace. */
 		/** CORSPolicies is the number of CORS policies managed by NGINX Ingress Controller */
 		long? CORSPolicies = null;
 		
+		/** ExternalAuthPolicies is the number of ExternalAuth policies managed by NGINX Ingress Controller */
+		long? ExternalAuthPolicies = null;
+
 	}
 }

--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -148,4 +148,6 @@ type NICResourceCounts struct {
 	CachePolicies int64
 	// CORSPolicies is the number of CORS policies managed by NGINX Ingress Controller
 	CORSPolicies int64
+	// ExternalAuthPolicies is the number of ExternalAuth policies managed by NGINX Ingress Controller
+	ExternalAuthPolicies int64
 }

--- a/internal/telemetry/nicresourcecounts_attributes_generated.go
+++ b/internal/telemetry/nicresourcecounts_attributes_generated.go
@@ -46,6 +46,7 @@ func (d *NICResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("VariablesRateLimitPolicies", d.VariablesRateLimitPolicies))
 	attrs = append(attrs, attribute.Int64("CachePolicies", d.CachePolicies))
 	attrs = append(attrs, attribute.Int64("CORSPolicies", d.CORSPolicies))
+	attrs = append(attrs, attribute.Int64("ExternalAuthPolicies", d.ExternalAuthPolicies))
 
 	return attrs
 }


### PR DESCRIPTION
Add External Auth Policy to telemetry data

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
