### PR TITLE
Fix path-regex handling for Exact ingress paths

### DIFF
--- a/internal/configs/version1/template_helper.go
+++ b/internal/configs/version1/template_helper.go
@@ -30,7 +30,7 @@ func makeLocationPath(loc *Location, ingressAnnotations map[string]string) strin
 		regexType, hasRegex := loc.MinionIngress.Annotations["nginx.org/path-regex"]
 
 		if isMergeable && ingressType == "minion" && hasRegex {
-			return makePathWithRegex(loc.Path, regexType)
+			return applyPathRegex(loc.Path, regexType)
 		}
 		if isMergeable && ingressType == "minion" && !hasRegex {
 			return loc.Path
@@ -42,7 +42,17 @@ func makeLocationPath(loc *Location, ingressAnnotations map[string]string) strin
 	if !ok {
 		return loc.Path
 	}
-	return makePathWithRegex(loc.Path, regexType)
+	return applyPathRegex(loc.Path, regexType)
+}
+
+// applyPathRegex applies a path-regex annotation to a location path.
+// If the path was already produced as an exact match location (`= /path`),
+// preserve it as-is to avoid generating an invalid regex location.
+func applyPathRegex(path, regexType string) string {
+	if strings.HasPrefix(strings.TrimSpace(path), "= ") {
+		return path
+	}
+	return makePathWithRegex(path, regexType)
 }
 
 // makePathWithRegex takes a path representing a location and a regexType

--- a/internal/configs/version1/template_helper_test.go
+++ b/internal/configs/version1/template_helper_test.go
@@ -45,6 +45,32 @@ func TestMakeLocationPath_WithRegexExactModifier(t *testing.T) {
 	}
 }
 
+func TestMakeLocationPath_WithExactPathAndRegexCaseSensitiveModifier(t *testing.T) {
+	t.Parallel()
+
+	want := "= /tea"
+	got := makeLocationPath(
+		&Location{Path: "= /tea"},
+		map[string]string{"nginx.org/path-regex": "case_sensitive"},
+	)
+	if got != want {
+		t.Errorf("got: %s, want: %s", got, want)
+	}
+}
+
+func TestMakeLocationPath_WithExactPathAndRegexCaseInsensitiveModifier(t *testing.T) {
+	t.Parallel()
+
+	want := "= /tea"
+	got := makeLocationPath(
+		&Location{Path: "= /tea"},
+		map[string]string{"nginx.org/path-regex": "case_insensitive"},
+	)
+	if got != want {
+		t.Errorf("got: %s, want: %s", got, want)
+	}
+}
+
 func TestMakeLocationPath_WithBogusRegexModifier(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Proposed changes

This PR fixes a conflict between `pathType: Exact` and the `nginx.org/path-regex` annotation (issue #9509).

When an Ingress path is exact, the controller generates a location path prefixed with `= ` (for example, `= /tea`).
Previously, regex modifiers from `nginx.org/path-regex` were still applied unconditionally, which could produce invalid/malformed location expressions like `~ "^= /tea"`.

Changes in this PR:
- add `applyPathRegex()` to avoid applying regex modifiers to already-exact location paths
- update `makeLocationPath()` to use this helper for both minion and non-minion ingress paths
- add regression tests to verify exact paths remain unchanged when `nginx.org/path-regex` is set (case_sensitive and case_insensitive)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
