### PR TITLE
Implement policy support checks for Ingress resources

### DIFF
--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -99,9 +99,12 @@ func newPoliciesConfig(bv bundleValidator) *policiesCfg {
 }
 
 // IsPolicySupportedOnIngress reports whether the given policy type is supported
-// on Ingress resources. Only AccessControl and CORS policies are supported on Ingress.
+// on Ingress resources.
 // This is the single source of truth for the Ingress policy allowlist and must be kept
 // in sync with any callers that filter policies for Ingress resources (e.g. syncPolicy).
+// To add support for a new policy type on Ingress, add its Spec field to this function.
+// Also ensure that createIngressEx() in controller.go loads any required secret or service
+// references for that policy type.
 func IsPolicySupportedOnIngress(pol *conf_v1.Policy) bool {
 	return pol.Spec.AccessControl != nil || pol.Spec.CORS != nil
 }

--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -98,6 +98,14 @@ func newPoliciesConfig(bv bundleValidator) *policiesCfg {
 	}
 }
 
+// IsPolicySupportedOnIngress reports whether the given policy type is supported
+// on Ingress resources. Only AccessControl and CORS policies are supported on Ingress.
+// This is the single source of truth for the Ingress policy allowlist and must be kept
+// in sync with any callers that filter policies for Ingress resources (e.g. syncPolicy).
+func IsPolicySupportedOnIngress(pol *conf_v1.Policy) bool {
+	return pol.Spec.AccessControl != nil || pol.Spec.CORS != nil
+}
+
 func (p *policiesCfg) addAccessControlConfig(accessControl *conf_v1.AccessControl) *validationResults {
 	res := newValidationResults()
 	p.Allow = append(p.Allow, accessControl.Allow...)
@@ -325,6 +333,11 @@ func (p *policiesCfg) addIngressMTLSConfig(
 
 	secretKey := fmt.Sprintf("%v/%v", polNamespace, ingressMTLS.ClientCertSecret)
 	secretRef := secretRefs[secretKey]
+	if secretRef == nil {
+		res.addWarningf("IngressMTLS policy %s references a secret %s that is not available", polKey, secretKey)
+		res.isError = true
+		return res
+	}
 	var secretType api_v1.SecretType
 	if secretRef.Secret != nil {
 		secretType = secretRef.Secret.Type
@@ -1005,6 +1018,14 @@ func generatePolicies(
 		key := fmt.Sprintf("%s/%s", polNamespace, p.Name)
 
 		if pol, exists := policies[key]; exists {
+			// Reject policy types that are not supported on Ingress resources.
+			// IsPolicySupportedOnIngress is the single source of truth for the allowlist.
+			if ownerDetails.parentType == "ing" && !IsPolicySupportedOnIngress(pol) {
+				warnings.AddWarningf(ownerDetails.owner, "Policy %s is not supported on Ingress resources", key)
+				return policiesCfg{
+					ErrorReturn: &version2.Return{Code: 500},
+				}, warnings
+			}
 			var res *validationResults
 			switch {
 			case pol.Spec.AccessControl != nil:

--- a/internal/configs/policy_test.go
+++ b/internal/configs/policy_test.go
@@ -3521,6 +3521,120 @@ func TestGeneratePoliciesFails(t *testing.T) {
 	}
 }
 
+func TestIsPolicySupportedOnIngress(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		policy   *conf_v1.Policy
+		expected bool
+	}{
+		{
+			name:     "AccessControl is supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{AccessControl: &conf_v1.AccessControl{Allow: []string{"127.0.0.1"}}}},
+			expected: true,
+		},
+		{
+			name:     "CORS is supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{CORS: &conf_v1.CORS{}}},
+			expected: true,
+		},
+		{
+			name:     "IngressMTLS is not supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{IngressMTLS: &conf_v1.IngressMTLS{ClientCertSecret: "ca"}}},
+			expected: false,
+		},
+		{
+			name:     "EgressMTLS is not supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{EgressMTLS: &conf_v1.EgressMTLS{}}},
+			expected: false,
+		},
+		{
+			name:     "RateLimit is not supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{RateLimit: &conf_v1.RateLimit{}}},
+			expected: false,
+		},
+		{
+			name:     "JWTAuth is not supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{JWTAuth: &conf_v1.JWTAuth{}}},
+			expected: false,
+		},
+		{
+			name:     "BasicAuth is not supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{BasicAuth: &conf_v1.BasicAuth{}}},
+			expected: false,
+		},
+		{
+			name:     "OIDC is not supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{OIDC: &conf_v1.OIDC{}}},
+			expected: false,
+		},
+		{
+			name:     "APIKey is not supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{APIKey: &conf_v1.APIKey{}}},
+			expected: false,
+		},
+		{
+			name:     "WAF is not supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{WAF: &conf_v1.WAF{}}},
+			expected: false,
+		},
+		{
+			name:     "Cache is not supported",
+			policy:   &conf_v1.Policy{Spec: conf_v1.PolicySpec{Cache: &conf_v1.Cache{}}},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsPolicySupportedOnIngress(tc.policy); got != tc.expected {
+				t.Errorf("IsPolicySupportedOnIngress() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGeneratePolicies_UnsupportedOnIngress(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ingOwnerDetails := policyOwnerDetails{
+		owner:           nil,
+		ownerName:       "cafe-ingress",
+		ownerNamespace:  "default",
+		parentNamespace: "default",
+		parentName:      "cafe-ingress",
+		parentType:      "ing",
+	}
+	policyRef := []conf_v1.PolicyReference{{Name: "test-policy", Namespace: "default"}}
+
+	unsupportedPolicies := map[string]*conf_v1.Policy{
+		"IngressMTLS": {ObjectMeta: meta_v1.ObjectMeta{Name: "test-policy", Namespace: "default"}, Spec: conf_v1.PolicySpec{IngressMTLS: &conf_v1.IngressMTLS{ClientCertSecret: "ca"}}},
+		"EgressMTLS":  {ObjectMeta: meta_v1.ObjectMeta{Name: "test-policy", Namespace: "default"}, Spec: conf_v1.PolicySpec{EgressMTLS: &conf_v1.EgressMTLS{}}},
+		"RateLimit":   {ObjectMeta: meta_v1.ObjectMeta{Name: "test-policy", Namespace: "default"}, Spec: conf_v1.PolicySpec{RateLimit: &conf_v1.RateLimit{}}},
+		"JWTAuth":     {ObjectMeta: meta_v1.ObjectMeta{Name: "test-policy", Namespace: "default"}, Spec: conf_v1.PolicySpec{JWTAuth: &conf_v1.JWTAuth{}}},
+		"BasicAuth":   {ObjectMeta: meta_v1.ObjectMeta{Name: "test-policy", Namespace: "default"}, Spec: conf_v1.PolicySpec{BasicAuth: &conf_v1.BasicAuth{}}},
+		"OIDC":        {ObjectMeta: meta_v1.ObjectMeta{Name: "test-policy", Namespace: "default"}, Spec: conf_v1.PolicySpec{OIDC: &conf_v1.OIDC{}}},
+		"APIKey":      {ObjectMeta: meta_v1.ObjectMeta{Name: "test-policy", Namespace: "default"}, Spec: conf_v1.PolicySpec{APIKey: &conf_v1.APIKey{}}},
+		"WAF":         {ObjectMeta: meta_v1.ObjectMeta{Name: "test-policy", Namespace: "default"}, Spec: conf_v1.PolicySpec{WAF: &conf_v1.WAF{}}},
+		"Cache":       {ObjectMeta: meta_v1.ObjectMeta{Name: "test-policy", Namespace: "default"}, Spec: conf_v1.PolicySpec{Cache: &conf_v1.Cache{}}},
+	}
+
+	for policyType, pol := range unsupportedPolicies {
+		t.Run(policyType, func(t *testing.T) {
+			t.Parallel()
+			policies := map[string]*conf_v1.Policy{"default/test-policy": pol}
+			result, warnings := generatePolicies(ctx, ingOwnerDetails, policyRef, policies, "spec", "", policyOptions{}, nil)
+
+			if result.ErrorReturn == nil || result.ErrorReturn.Code != 500 {
+				t.Errorf("generatePolicies() expected ErrorReturn{500} for unsupported policy type %s on Ingress, got %v", policyType, result.ErrorReturn)
+			}
+			if len(warnings[nil]) == 0 {
+				t.Errorf("generatePolicies() expected a warning for unsupported policy type %s on Ingress", policyType)
+			}
+		})
+	}
+}
+
 func TestGenerateLRZPolicyGroupMap(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/k8s/policy.go
+++ b/internal/k8s/policy.go
@@ -103,32 +103,31 @@ func (lbc *LoadBalancerController) syncPolicy(task task) {
 
 	// Loop through the resources that reference this policy and check if the policy type is supported on the resource. If not, log an error and emit an event.
 	// Note: if we ever support all policy types on all resources, this loop can be removed.
+	var filteredResources []Resource
 	for _, res := range resources {
 		switch impl := res.(type) {
 		// We only check for Ingress resources because VirtualServer and VirtualServerRoute support all policy types.
 		//   If a new resource type is added that supports a subset of policy types, a new case should be added here to check for supported policy types on that resource.
 		case *IngressConfiguration:
 			if !polExists {
+				filteredResources = append(filteredResources, res)
 				continue
 			}
 			pol := obj.(*conf_v1.Policy)
-			switch {
-			case pol.Spec.CORS != nil:
-				// CORS policy is supported on Ingress
-				continue
-			case pol.Spec.AccessControl != nil:
-				// Access Control policy is supported on Ingress
-				continue
-			default: // Unsupported policy type on Ingress
+			if !configs.IsPolicySupportedOnIngress(pol) {
 				msg := fmt.Sprintf("Policy %s/%s has unsupported type on Ingress resource %s/%s",
 					pol.Namespace, pol.Name, impl.Ingress.Namespace, impl.Ingress.Name)
 				nl.Error(lbc.Logger, msg)
 				lbc.recorder.Event(impl.Ingress, api_v1.EventTypeWarning, nl.EventReasonRejected, msg)
+				// Do not add to filteredResources: skip reloading this Ingress for an unsupported policy.
+				continue
 			}
+			filteredResources = append(filteredResources, res)
 		default:
-			continue
+			filteredResources = append(filteredResources, res)
 		}
 	}
+	resources = filteredResources
 
 	resourceExes := lbc.createExtendedResources(resources)
 

--- a/internal/k8s/policy.go
+++ b/internal/k8s/policy.go
@@ -106,7 +106,7 @@ func (lbc *LoadBalancerController) syncPolicy(task task) {
 	for _, res := range resources {
 		switch impl := res.(type) {
 		// We only check for Ingress resources because VirtualServer and VirtualServerRoute support all policy types.
-		//   If a new resource type is added that supports a subset of policy types, a new case should be added here to check for supported policy types on that resource.
+		// If Ingress support for a policy type is added in the future, the policy Spec must also be added in IsPolicySupportedOnIngress() in internal/configs/policy.go.
 		case *IngressConfiguration:
 			if !polExists {
 				continue

--- a/internal/k8s/policy.go
+++ b/internal/k8s/policy.go
@@ -103,14 +103,12 @@ func (lbc *LoadBalancerController) syncPolicy(task task) {
 
 	// Loop through the resources that reference this policy and check if the policy type is supported on the resource. If not, log an error and emit an event.
 	// Note: if we ever support all policy types on all resources, this loop can be removed.
-	var filteredResources []Resource
 	for _, res := range resources {
 		switch impl := res.(type) {
 		// We only check for Ingress resources because VirtualServer and VirtualServerRoute support all policy types.
 		//   If a new resource type is added that supports a subset of policy types, a new case should be added here to check for supported policy types on that resource.
 		case *IngressConfiguration:
 			if !polExists {
-				filteredResources = append(filteredResources, res)
 				continue
 			}
 			pol := obj.(*conf_v1.Policy)
@@ -119,15 +117,13 @@ func (lbc *LoadBalancerController) syncPolicy(task task) {
 					pol.Namespace, pol.Name, impl.Ingress.Namespace, impl.Ingress.Name)
 				nl.Error(lbc.Logger, msg)
 				lbc.recorder.Event(impl.Ingress, api_v1.EventTypeWarning, nl.EventReasonRejected, msg)
-				// Do not add to filteredResources: skip reloading this Ingress for an unsupported policy.
-				continue
+				// The reload still proceeds so that generatePolicies() surfaces the error
+				// (ErrorReturn 500) consistently regardless of which path triggered the sync.
 			}
-			filteredResources = append(filteredResources, res)
 		default:
-			filteredResources = append(filteredResources, res)
+			continue
 		}
 	}
-	resources = filteredResources
 
 	resourceExes := lbc.createExtendedResources(resources)
 


### PR DESCRIPTION
This pull request improves the handling and validation of policies applied to Ingress resources, ensuring only supported policy types are allowed and providing clear error reporting and test coverage. The main focus is to centralize and enforce the allowlist for Ingress policies, preventing unsupported policy types from being mistakenly applied.

Key changes include:

Policy validation and enforcement:

Introduced the IsPolicySupportedOnIngress function in policy.go to act as the single source of truth for which policy types are allowed on Ingress resources (currently only AccessControl and CORS). (internal/configs/policy.go [internal/configs/policy.goR106-R113](https://github.com/nginx/kubernetes-ingress/pull/9791/files#diff-11f6c47a234bd9a6a5b0c32b2288a74fc1ca166b0a496853ad9c3975aed6f310R106-R113))
Updated the generatePolicies function to reject and warn when unsupported policy types are referenced by Ingress resources, returning an error for such cases. (internal/configs/policy.go [internal/configs/policy.goR1148-R1155](https://github.com/nginx/kubernetes-ingress/pull/9791/files#diff-11f6c47a234bd9a6a5b0c32b2288a74fc1ca166b0a496853ad9c3975aed6f310R1148-R1155))
Refactored syncPolicy in policy.go to use the new IsPolicySupportedOnIngress function, simplifying and centralizing the logic for filtering supported policies on Ingress resources. (internal/k8s/policy.go [internal/k8s/policy.goR138-R162](https://github.com/nginx/kubernetes-ingress/pull/9791/files#diff-05f17bc129aaa22a94435a9906b4b35fe0d337a2cef456f7862909fd7b54d1a3R138-R162))
Testing:

Added comprehensive unit tests for IsPolicySupportedOnIngress to verify the allowlist logic for all policy types. (internal/configs/policy_test.go [internal/configs/policy_test.goR4227-R4340](https://github.com/nginx/kubernetes-ingress/pull/9791/files#diff-42d801fa2a507ec0acd9f55766cc7829b12f474046fa818c13c7b9b8935cbc26R4227-R4340))
Added tests to ensure generatePolicies returns errors and warnings when unsupported policy types are applied to Ingress resources. (internal/configs/policy_test.go [internal/configs/policy_test.goR4227-R4340](https://github.com/nginx/kubernetes-ingress/pull/9791/files#diff-42d801fa2a507ec0acd9f55766cc7829b12f474046fa818c13c7b9b8935cbc26R4227-R4340))
Error messaging:

Improved warning messages for missing secrets in IngressMTLS policies to be clearer and more consistent. (internal/configs/policy.go [internal/configs/policy.goL448-R456](https://github.com/nginx/kubernetes-ingress/pull/9791/files#diff-11f6c47a234bd9a6a5b0c32b2288a74fc1ca166b0a496853ad9c3975aed6f310L448-R456))

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
