### PR TITLE
Refactor keepalive annotation in Ingress

### DIFF
--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -2599,7 +2599,7 @@ upstream {{$upstream.Name}} {
 	{{- end}}
 	{{- range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}};{{end}}
-	{{- if $.Keepalive}}keepalive {{$.Keepalive}};{{end}}
+	{{- if $upstream.Keepalive}}keepalive {{$upstream.Keepalive}};{{end}}
 }
 {{end -}}
 
@@ -2771,7 +2771,7 @@ server {
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection $connection_upgrade;
 		{{- else}}
-		{{- if $.Keepalive}}
+		{{- if $location.Upstream.Keepalive}}
 		proxy_set_header Connection "";{{end}}
 		{{- end}}
 		{{- if $location.LocationSnippets}}

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -708,15 +708,9 @@ func generateNginxCfg(ncp NginxCfgParams) (version1.IngressNginxConfig, Warnings
 		servers = append(servers, server)
 	}
 
-	var keepalive string
-	if cfgParams.Keepalive > 0 {
-		keepalive = fmt.Sprint(cfgParams.Keepalive)
-	}
-
 	return version1.IngressNginxConfig{
 		Upstreams:   upstreamMapToSlice(upstreams),
 		Servers:     servers,
-		Keepalive:   keepalive,
 		CORSHeaders: policyCfg.CORSHeaders,
 		Ingress: version1.Ingress{
 			Name:        ncp.ingEx.Ingress.Name,
@@ -1108,6 +1102,9 @@ func createUpstream(ingEx *IngressEx, name string, backend *networking.IngressBa
 	ups.LBMethod = cfg.LBMethod
 	ups.UpstreamZoneSize = cfg.UpstreamZoneSize
 	ups.StickyCookie = stickyCookie
+	if cfg.Keepalive > 0 {
+		ups.Keepalive = fmt.Sprint(cfg.Keepalive)
+	}
 	return ups, warning
 }
 
@@ -1179,7 +1176,6 @@ func generateNginxCfgForMergeableIngresses(ncp NginxCfgParams) (version1.Ingress
 	healthChecks := make(map[string]version1.HealthCheck)
 	var limitReqZones []version1.LimitReqZone
 	var maps []version2.Map
-	var keepalive string
 
 	// replace master with a deepcopy because we will modify it
 	originalMaster := ncp.mergeableIngs.Master.Ingress
@@ -1222,10 +1218,6 @@ func generateNginxCfgForMergeableIngresses(ncp NginxCfgParams) (version1.Ingress
 
 	upstreams = append(upstreams, masterNginxCfg.Upstreams...)
 	maps = append(maps, masterNginxCfg.Maps...)
-
-	if masterNginxCfg.Keepalive != "" {
-		keepalive = masterNginxCfg.Keepalive
-	}
 
 	minions := ncp.mergeableIngs.Minions
 	grpcOnly := true
@@ -1354,7 +1346,6 @@ func generateNginxCfgForMergeableIngresses(ncp NginxCfgParams) (version1.Ingress
 	return version1.IngressNginxConfig{
 		Servers:                 []version1.Server{masterServer},
 		Upstreams:               upstreams,
-		Keepalive:               keepalive,
 		Ingress:                 masterNginxCfg.Ingress,
 		SpiffeClientCerts:       ncp.staticParams.NginxServiceMesh && !ncp.BaseCfgParams.SpiffeServerCerts,
 		DynamicSSLReloadEnabled: ncp.staticParams.DynamicSSLReload,

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -5699,3 +5699,123 @@ func TestGenerateNginxCfgForMergeableIngressesWithExternalAuthAndProxySetHeaders
 		t.Errorf("generateNginxCfgForMergeableIngresses() returned warnings: %v", warnings)
 	}
 }
+
+// TestGenerateNginxCfgKeepalivePerUpstream verifies that nginx.org/keepalive is
+// applied per-upstream (not as a global config-level value), and that in a
+// mergeable master/minion setup:
+//  1. A keepalive annotation on the master is inherited by minions that don't
+//     set their own.
+//  2. A minion's own keepalive annotation overrides the inherited master value.
+//  3. A minion explicitly setting keepalive "0" disables it even when the master
+//     enables it.
+func TestGenerateNginxCfgKeepalivePerUpstream(t *testing.T) {
+	t.Parallel()
+
+	const (
+		coffeeUpstreamName = "default-cafe-ingress-coffee-minion-cafe.example.com-coffee-svc-80"
+		teaUpstreamName    = "default-cafe-ingress-tea-minion-cafe.example.com-tea-svc-80"
+	)
+
+	tests := []struct {
+		name            string
+		masterKeepalive string
+		coffeeKeepalive string // empty = not set
+		teaKeepalive    string // empty = not set
+		wantCoffeeKA    string // expected Keepalive on coffee upstream
+		wantTeaKA       string // expected Keepalive on tea upstream
+	}{
+		{
+			name:            "master keepalive only – inherited by both minions",
+			masterKeepalive: "30",
+			wantCoffeeKA:    "30",
+			wantTeaKA:       "30",
+		},
+		{
+			name:            "minion overrides master keepalive",
+			masterKeepalive: "30",
+			coffeeKeepalive: "64",
+			wantCoffeeKA:    "64",
+			wantTeaKA:       "30",
+		},
+		{
+			name:            "minion explicitly disables keepalive (0) while master enables it",
+			masterKeepalive: "30",
+			coffeeKeepalive: "0",
+			wantCoffeeKA:    "",
+			wantTeaKA:       "30",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mergeableIngresses := createMergeableCafeIngress()
+			mergeableIngresses.Master.Ingress.Annotations["nginx.org/keepalive"] = tc.masterKeepalive
+			setMinionKeepalive(mergeableIngresses.Minions, "coffee", tc.coffeeKeepalive)
+			setMinionKeepalive(mergeableIngresses.Minions, "tea", tc.teaKeepalive)
+
+			configParams := NewDefaultConfigParams(context.Background(), false)
+			result, warnings := generateNginxCfgForMergeableIngresses(NginxCfgParams{
+				mergeableIngs:        mergeableIngresses,
+				apResources:          nil,
+				dosResource:          nil,
+				BaseCfgParams:        configParams,
+				isPlus:               false,
+				isResolverConfigured: false,
+				staticParams:         &StaticConfigParams{},
+				isWildcardEnabled:    false,
+			})
+
+			if len(warnings) != 0 {
+				t.Errorf("generateNginxCfgForMergeableIngresses() returned warnings: %v", warnings)
+			}
+
+			upstreams := upstreamsByName(result.Upstreams)
+			assertUpstreamKeepalive(t, "coffee", upstreams[coffeeUpstreamName].Keepalive, tc.wantCoffeeKA)
+			assertUpstreamKeepalive(t, "tea", upstreams[teaUpstreamName].Keepalive, tc.wantTeaKA)
+
+			// The location's embedded upstream must match so the template renders
+			// keepalive and proxy_set_header Connection "" correctly.
+			wantLocationKA := map[string]string{
+				coffeeUpstreamName: tc.wantCoffeeKA,
+				teaUpstreamName:    tc.wantTeaKA,
+			}
+			for _, loc := range result.Servers[0].Locations {
+				if want, ok := wantLocationKA[loc.Upstream.Name]; ok {
+					assertUpstreamKeepalive(t, loc.Upstream.Name+" location", loc.Upstream.Keepalive, want)
+				}
+			}
+		})
+	}
+}
+
+// setMinionKeepalive sets nginx.org/keepalive on every minion whose name
+// contains substr, but only when value is non-empty.
+func setMinionKeepalive(minions []*IngressEx, substr, value string) {
+	if value == "" {
+		return
+	}
+	for i, m := range minions {
+		if strings.Contains(m.Ingress.Name, substr) {
+			minions[i].Ingress.Annotations["nginx.org/keepalive"] = value
+		}
+	}
+}
+
+// upstreamsByName indexes a slice of upstreams by name for O(1) lookup.
+func upstreamsByName(upstreams []version1.Upstream) map[string]version1.Upstream {
+	m := make(map[string]version1.Upstream, len(upstreams))
+	for _, u := range upstreams {
+		m[u.Name] = u
+	}
+	return m
+}
+
+// assertUpstreamKeepalive fails t if got != want.
+func assertUpstreamKeepalive(t *testing.T, label, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s Keepalive = %q, want %q", label, got, want)
+	}
+}

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -17,7 +17,6 @@ type UpstreamLabels struct {
 type IngressNginxConfig struct {
 	Upstreams               []Upstream
 	Servers                 []Server
-	Keepalive               string
 	Maps                    []version2.Map
 	CORSHeaders             []version2.AddHeader
 	Ingress                 Ingress
@@ -44,6 +43,7 @@ type Upstream struct {
 	QueueTimeout     int64
 	UpstreamZoneSize string
 	UpstreamLabels   UpstreamLabels
+	Keepalive        string
 }
 
 // UpstreamServer describes a server in an NGINX upstream.

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -12,7 +12,7 @@ upstream {{$upstream.Name}} {
 	{{- if $upstream.StickyCookie}}
 	sticky cookie {{$upstream.StickyCookie}};
 	{{- end}}
-	{{- if $.Keepalive}}keepalive {{$.Keepalive}};{{end}}
+	{{- if $upstream.Keepalive}}keepalive {{$upstream.Keepalive}};{{end}}
 	{{- if $upstream.UpstreamServers -}}
 	{{- if $upstream.Queue}}
 	queue {{$upstream.Queue}} timeout={{$upstream.QueueTimeout}}s;
@@ -452,7 +452,7 @@ server {
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection $connection_upgrade;
 		{{- else}}
-		{{- if $.Keepalive}}
+		{{- if $location.Upstream.Keepalive}}
 		proxy_set_header Connection "";{{end}}
 		{{- end}}
 		{{- if not $location.AuthRequestOff}}

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -11,8 +11,8 @@ upstream {{$upstream.Name}} {
 	{{- range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}};
 	{{- end}}
-	{{- if $.Keepalive}}
-	keepalive {{$.Keepalive}};
+	{{- if $upstream.Keepalive}}
+	keepalive {{$upstream.Keepalive}};
 	{{- end}}
 	{{- if $upstream.StickyCookie}}
 	sticky cookie {{$upstream.StickyCookie}};
@@ -354,7 +354,7 @@ server {
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection $connection_upgrade;
 		{{- else}}
-		{{- if $.Keepalive}}
+		{{- if $location.Upstream.Keepalive}}
 		proxy_set_header Connection "";{{end}}
 		{{- end}}
 		{{- if not $location.AuthRequestOff}}

--- a/internal/configs/version1/template_executor_test.go
+++ b/internal/configs/version1/template_executor_test.go
@@ -491,7 +491,7 @@ upstream {{$upstream.Name}} {
 	{{- if $upstream.StickyCookie}}
 	sticky cookie {{$upstream.StickyCookie}};
 	{{- end}}
-	{{- if $.Keepalive}}keepalive {{$.Keepalive}};{{end}}
+	{{- if $upstream.Keepalive}}keepalive {{$upstream.Keepalive}};{{end}}
 	{{- if $upstream.UpstreamServers -}}
 	{{- if $upstream.Queue}}
 	queue {{$upstream.Queue}} timeout={{$upstream.QueueTimeout}}s;
@@ -866,7 +866,7 @@ server {
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection $connection_upgrade;
 		{{- else}}
-		{{- if $.Keepalive}}
+		{{- if $location.Upstream.Keepalive}}
 		proxy_set_header Connection "";{{end}}
 		{{- end}}
 		{{- range $value := $location.LocationSnippets}}

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -3751,7 +3751,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/tea",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -3794,8 +3794,7 @@ var (
 				AppProtectDosAllowListPath:   "/etc/nginx/dos/allowlist/default_test.example.com",
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -3812,7 +3811,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/tea",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -3837,8 +3836,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Maps: []version2.Map{
 			{
 				Source:   "$http_origin",
@@ -3925,7 +3923,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/tea",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -3942,8 +3940,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -4062,7 +4059,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                 "/tea",
-						Upstream:             testUpstream,
+						Upstream:             testUpstreamWithKeepalive,
 						ProxyConnectTimeout:  "10s",
 						ProxyReadTimeout:     "10s",
 						ProxySendTimeout:     "10s",
@@ -4106,8 +4103,7 @@ var (
 				AppProtectDosAllowListPath:   "/etc/nginx/dos/allowlist/default_test.example.com",
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -4131,7 +4127,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/tea",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -4142,8 +4138,7 @@ var (
 				HealthChecks: map[string]HealthCheck{"test": healthCheck},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -4319,7 +4314,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/tea/[A-Z0-9]{3}",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -4345,8 +4340,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:        "cafe-ingress",
 			Namespace:   "default",
@@ -4376,7 +4370,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/tea/[A-Z0-9]{3}",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -4402,8 +4396,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:        "cafe-ingress",
 			Namespace:   "default",
@@ -4433,7 +4426,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/tea",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -4459,8 +4452,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:        "cafe-ingress",
 			Namespace:   "default",
@@ -4490,7 +4482,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/tea",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -4516,8 +4508,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:        "cafe-ingress",
 			Namespace:   "default",
@@ -5674,7 +5665,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/tea",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -5695,8 +5686,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -5992,6 +5982,21 @@ var (
 var testUpstream = Upstream{
 	Name:             "test",
 	UpstreamZoneSize: "256k",
+	UpstreamServers: []UpstreamServer{
+		{
+			Address:     "127.0.0.1:8181",
+			MaxFails:    0,
+			MaxConns:    0,
+			FailTimeout: "1s",
+			SlowStart:   "5s",
+		},
+	},
+}
+
+var testUpstreamWithKeepalive = Upstream{
+	Name:             "test",
+	UpstreamZoneSize: "256k",
+	Keepalive:        "16",
 	UpstreamServers: []UpstreamServer{
 		{
 			Address:     "127.0.0.1:8181",

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -5993,20 +5993,11 @@ var testUpstream = Upstream{
 	},
 }
 
-var testUpstreamWithKeepalive = Upstream{
-	Name:             "test",
-	UpstreamZoneSize: "256k",
-	Keepalive:        "16",
-	UpstreamServers: []UpstreamServer{
-		{
-			Address:     "127.0.0.1:8181",
-			MaxFails:    0,
-			MaxConns:    0,
-			FailTimeout: "1s",
-			SlowStart:   "5s",
-		},
-	},
-}
+var testUpstreamWithKeepalive = func() Upstream {
+	u := testUpstream
+	u.Keepalive = "16"
+	return u
+}()
 
 var (
 	headers     = map[string]string{"Test-Header": "test-header-value"}

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -4156,7 +4156,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/coffee",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "60s",
 						ProxyReadTimeout:    "60s",
 						ProxySendTimeout:    "60s",
@@ -4166,8 +4166,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -4186,7 +4185,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/coffee",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "60s",
 						ProxyReadTimeout:    "60s",
 						ProxySendTimeout:    "60s",
@@ -4196,8 +4195,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -4215,7 +4213,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/coffee",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "60s",
 						ProxyReadTimeout:    "60s",
 						ProxySendTimeout:    "60s",
@@ -4225,8 +4223,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -4243,7 +4240,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/coffee",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "60s",
 						ProxyReadTimeout:    "60s",
 						ProxySendTimeout:    "60s",
@@ -4254,8 +4251,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -4272,7 +4268,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/coffee",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "60s",
 						ProxyReadTimeout:    "60s",
 						ProxySendTimeout:    "60s",
@@ -4284,8 +4280,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -4749,7 +4744,7 @@ var (
 				Locations: []Location{
 					{
 						Path:                "/tea",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -4760,8 +4755,7 @@ var (
 				HealthChecks: map[string]HealthCheck{"test": healthCheck},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -5719,7 +5713,7 @@ var (
 					},
 					{
 						Path:                "/tea",
-						Upstream:            testUpstream,
+						Upstream:            testUpstreamWithKeepalive,
 						ProxyConnectTimeout: "10s",
 						ProxyReadTimeout:    "10s",
 						ProxySendTimeout:    "10s",
@@ -5740,8 +5734,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
@@ -5783,8 +5776,7 @@ var (
 				},
 			},
 		},
-		Upstreams: []Upstream{testUpstream},
-		Keepalive: "16",
+		Upstreams: []Upstream{testUpstreamWithKeepalive},
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",


### PR DESCRIPTION
This pull request refactors how the `keepalive` setting is handled for NGINX upstreams in the configuration generator. Instead of storing a global `Keepalive` field at the configuration level, the `keepalive` value is now managed per-upstream, which allows for more granular control and better reflects the actual NGINX configuration structure. This change impacts the Go structs, template files, and related tests.

**Refactoring `keepalive` handling to be per-upstream:**

* The `Keepalive` field is removed from the top-level `IngressNginxConfig` struct and added to the `Upstream` struct, ensuring that `keepalive` is now an attribute of each upstream rather than a shared/global value. [[1]](diffhunk://#diff-d83d1a6fee6e805767c13fa71a9f99f90aababbe0a913061cb2587e724f9f41aL20) [[2]](diffhunk://#diff-d83d1a6fee6e805767c13fa71a9f99f90aababbe0a913061cb2587e724f9f41aR46)
* The logic for assigning the `keepalive` value is moved from the configuration generation functions to the upstream creation function, so each upstream is assigned its own `keepalive` value if applicable. [[1]](diffhunk://#diff-92c0ea851013e748f27d1c7d7e4c1a9eda68c72fbe819f43f8feb286700862abL666-L674) [[2]](diffhunk://#diff-92c0ea851013e748f27d1c7d7e4c1a9eda68c72fbe819f43f8feb286700862abR1060-R1062) [[3]](diffhunk://#diff-92c0ea851013e748f27d1c7d7e4c1a9eda68c72fbe819f43f8feb286700862abL1134) [[4]](diffhunk://#diff-92c0ea851013e748f27d1c7d7e4c1a9eda68c72fbe819f43f8feb286700862abL1178-L1181) [[5]](diffhunk://#diff-92c0ea851013e748f27d1c7d7e4c1a9eda68c72fbe819f43f8feb286700862abL1294)

**Template and test updates:**

* All NGINX configuration templates and their tests are updated to reference `keepalive` from the upstream object rather than the top-level config, ensuring the rendered NGINX configs are correct. [[1]](diffhunk://#diff-3fa9c77a3bbf85f40125fc72e3f59f856547f19c4968a88caea8dce6d465a21bL15-R15) [[2]](diffhunk://#diff-3fa9c77a3bbf85f40125fc72e3f59f856547f19c4968a88caea8dce6d465a21bL431-R431) [[3]](diffhunk://#diff-518361de54bd530d294ed149fb24b29f64adcbe966772f63d6ae7aab42fad593L14-R15) [[4]](diffhunk://#diff-518361de54bd530d294ed149fb24b29f64adcbe966772f63d6ae7aab42fad593L323-R323) [[5]](diffhunk://#diff-c2faedec4620ae0c852e7a4f649feabb27016a868f192b6d9a01202197aec46bL2415-R2415) [[6]](diffhunk://#diff-c2faedec4620ae0c852e7a4f649feabb27016a868f192b6d9a01202197aec46bL2587-R2587) [[7]](diffhunk://#diff-7e4ae92fb406b593a4f70d245dd030ed708dcebd882b59fa91bf452476013529L467-R467) [[8]](diffhunk://#diff-7e4ae92fb406b593a4f70d245dd030ed708dcebd882b59fa91bf452476013529L639-R639)
* Unit tests are updated to use upstreams with the new `Keepalive` field and to remove expectations for a top-level `Keepalive` field. A new `testUpstreamWithKeepalive` is introduced for test coverage. [[1]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3329-R3329) [[2]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3372-R3372) [[3]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3390-R3389) [[4]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3415-R3414) [[5]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3503-R3501) [[6]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3520-R3518) [[7]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3640-R3637) [[8]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3684-R3681) [[9]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3709-R3705) [[10]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3720-R3716) [[11]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3750-R3745) [[12]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3776-R3771) [[13]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3807-R3801) [[14]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3833-R3827) [[15]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3864-R3857) [[16]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3890-R3883) [[17]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3921-R3913) [[18]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL3947-R3939) [[19]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL5002-R4993) [[20]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bL5023-R5014) [[21]](diffhunk://#diff-960f14f5da962e1ec6b529e542c685185ae5b1e6091d6add265d73cd78e8678bR5224-R5238)

These changes make the configuration more flexible and the codebase more maintainable by aligning the Go structs and templates with how NGINX actually handles upstream keepalive settings.

Fixes #9835 


### Tested

- ConfigMap: keepalive - upstreams inherit ConfigMap value
- ConfigMap: keepalive & Master: annotation - upstreams inherit master annotation value
- ConfigMap: keepalive & Minion: annotation - upstreams inherit ConfigMap value, minion upstream gets minion annotation value
- Master: annotation - upstreams inherit master annotation value
- Master: annotation & Minion: annotation - upstreams inherit master annotation value, minion upstream gets minion annotation value


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
