### PR TITLE
Loosen nginx-plus version to 36 in data.json

### DIFF
--- a/tests/data/modules/data.json
+++ b/tests/data/modules/data.json
@@ -33,7 +33,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -64,7 +64,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -114,7 +114,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -156,7 +156,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -190,7 +190,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -456,7 +456,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -487,7 +487,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -537,7 +537,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -579,7 +579,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -629,7 +629,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -671,7 +671,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -705,7 +705,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",

--- a/tests/data/modules/data.json
+++ b/tests/data/modules/data.json
@@ -275,7 +275,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-r4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -306,7 +306,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-r4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -337,7 +337,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-r4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -387,7 +387,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-r4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",


### PR DESCRIPTION
### Proposed changes

Loosen nginx-plus version to 36 in data.json to allow pipelines to progress if a patch of NGINX+ is released

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
