### PR TITLE
Loosen nginx-plus version to 36 in data.json

### DIFF
--- a/tests/data/modules/data.json
+++ b/tests/data/modules/data.json
@@ -33,7 +33,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -64,7 +64,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -110,7 +110,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -152,7 +152,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -186,7 +186,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -444,7 +444,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -475,7 +475,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -521,7 +521,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -563,7 +563,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -609,7 +609,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -651,7 +651,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -685,7 +685,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",

--- a/tests/data/modules/data.json
+++ b/tests/data/modules/data.json
@@ -267,7 +267,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-r4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -298,7 +298,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-r4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -329,7 +329,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-r4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",
@@ -375,7 +375,7 @@
       "packages": [
         {
           "name": "nginx-plus",
-          "version": "36-r4"
+          "version": "36"
         },
         {
           "name": "nginx-plus-module-njs",


### PR DESCRIPTION
### Proposed changes

Loosen nginx-plus version to 36 in data.json to allow pipelines to progress if a patch of NGINX+ is released

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
