### PR TITLE
Validate CORS origin port ranges

### DIFF
--- a/pkg/apis/configuration/validation/policy.go
+++ b/pkg/apis/configuration/validation/policy.go
@@ -1085,6 +1085,10 @@ func validateOriginFormat(origin string) error {
 		return validateWildcardOriginHost(origin, host)
 	}
 
+	if err := validateOriginPort(parsedOrigin.Port(), origin); err != nil {
+		return err
+	}
+
 	return validateExactOriginHost(host)
 }
 
@@ -1132,15 +1136,30 @@ func validateWildcardOriginHost(origin, host string) error {
 		if port == "" {
 			return fmt.Errorf("port cannot be empty when colon is present (invalid: %s)", origin)
 		}
-		// Validate port is numeric and in valid range
-		if _, err := strconv.Atoi(port); err != nil {
-			return fmt.Errorf("port must be numeric (invalid: %s)", origin)
+		if err := validateOriginPort(port, origin); err != nil {
+			return err
 		}
 	}
 
 	// Validate domain part using Kubernetes DNS validation
 	if errs := validation.IsDNS1123Subdomain(domainPart); len(errs) > 0 {
 		return fmt.Errorf("wildcard subdomain is not a valid DNS name: %s (invalid: %s)", strings.Join(errs, ", "), origin)
+	}
+
+	return nil
+}
+
+func validateOriginPort(port, origin string) error {
+	if port == "" {
+		return nil
+	}
+
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("port must be numeric (invalid: %s)", origin)
+	}
+	if portNum < 1 || portNum > 65535 {
+		return fmt.Errorf("port must be in the range 1-65535 (invalid: %s)", origin)
 	}
 
 	return nil

--- a/pkg/apis/configuration/validation/policy_test.go
+++ b/pkg/apis/configuration/validation/policy_test.go
@@ -3196,6 +3196,22 @@ func TestValidateCORS(t *testing.T) {
 			errMsg:    "origin must not include @",
 		},
 		{
+			name: "Invalid exact origin - out-of-range port",
+			cors: &v1.CORS{
+				AllowOrigin: []string{"https://example.com:99999"},
+			},
+			expectErr: true,
+			errMsg:    "port must be in the range 1-65535",
+		},
+		{
+			name: "Invalid wildcard origin - out-of-range port",
+			cors: &v1.CORS{
+				AllowOrigin: []string{"https://*.example.com:99999"},
+			},
+			expectErr: true,
+			errMsg:    "port must be in the range 1-65535",
+		},
+		{
 			name: "Invalid header name - non-RFC compliant",
 			cors: &v1.CORS{
 				AllowOrigin:  []string{"https://example.com"},


### PR DESCRIPTION
### Proposed changes

Fixes #9860

Tiny fix for CORS Policy validation. `allowOrigin` could accept ports outside `1-65535`, like `https://example.com:99999`, because the CRD only requires non-empty strings and the webhook check did not range-check the parsed port.

Repro, before this patch:

1. add a `TestValidateCORS` case with `https://example.com:99999` and `https://*.example.com:99999`
2. run `go test -tags=aws,helmunit ./pkg/apis/configuration/validation -run TestValidateCORS$`
3. both cases pass validation. not great lol

Now exact and wildcard origins share the same port-range check.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes (`make test` is blocked locally: `helm` is missing from PATH, and `internal/k8s/secrets/validation_test.go` references missing `embeds-ca.crt`)
- [x] I have updated necessary documentation (n/a, validation-only change)
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
