### PR TITLE
Improve TransportServer, `nginx.org/limit-req-key` annotation, and zone size validation

### DIFF
--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/nginx/kubernetes-ingress/internal/configs/version2"
@@ -1272,6 +1273,23 @@ func generateLimitReq(zoneName string, rateLimitPol *conf_v1.RateLimit) version2
 	return limitReq
 }
 
+// normalizeRateLimitZoneSize appends "k" to a bare number if its byte value
+// would be below NGINX's minimum shared memory zone size (32k).
+// Per the CRD API contract, bare numbers below 32k are treated as kilobytes.
+// Bare numbers >= 32768 are valid byte values and left unchanged.
+func normalizeRateLimitZoneSize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	last := s[len(s)-1]
+	if last >= '0' && last <= '9' {
+		if n, err := strconv.Atoi(s); err == nil && n < 32768 {
+			return s + "k"
+		}
+	}
+	return s
+}
+
 func generateLimitReqZone(zoneName string, policy *conf_v1.Policy, podReplicas int, zoneSync bool) (version2.LimitReqZone, string) {
 	rateLimitPol := policy.Spec.RateLimit
 	rate := rateLimitPol.Rate
@@ -1287,7 +1305,7 @@ func generateLimitReqZone(zoneName string, policy *conf_v1.Policy, podReplicas i
 	return version2.LimitReqZone{
 		ZoneName: zoneName,
 		Key:      rateLimitPol.Key,
-		ZoneSize: rateLimitPol.ZoneSize,
+		ZoneSize: normalizeRateLimitZoneSize(rateLimitPol.ZoneSize),
 		Rate:     rate,
 		Sync:     zoneSync,
 	}, warningText
@@ -1316,7 +1334,7 @@ func generateGroupedLimitReqZone(
 	lrz := version2.LimitReqZone{
 		ZoneName: zoneName,
 		Key:      rateLimitPol.Key,
-		ZoneSize: rateLimitPol.ZoneSize,
+		ZoneSize: normalizeRateLimitZoneSize(rateLimitPol.ZoneSize),
 		Rate:     rate,
 		Sync:     zoneSync,
 	}

--- a/internal/configs/policy_test.go
+++ b/internal/configs/policy_test.go
@@ -4854,3 +4854,32 @@ func TestAddWafConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeRateLimitZoneSize(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{input: "", expected: ""},
+		{input: "10m", expected: "10m"},
+		{input: "10M", expected: "10M"},
+		{input: "32k", expected: "32k"},
+		{input: "32K", expected: "32K"},
+		{input: "32", expected: "32k"},
+		{input: "100", expected: "100k"},
+		{input: "31", expected: "31k"},
+		{input: "0", expected: "0k"},
+		{input: "32767", expected: "32767k"},
+		{input: "32768", expected: "32768"},
+		{input: "65536", expected: "65536"},
+		{input: "1000000", expected: "1000000"},
+	}
+
+	for _, test := range tests {
+		result := normalizeRateLimitZoneSize(test.input)
+		if result != test.expected {
+			t.Errorf("normalizeRateLimitZoneSize(%q) = %q, expected %q", test.input, result, test.expected)
+		}
+	}
+}

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -59,6 +59,7 @@ const (
 	maxFailsAnnotation                    = "nginx.org/max-fails"
 	maxConnsAnnotation                    = "nginx.org/max-conns"
 	failTimeoutAnnotation                 = "nginx.org/fail-timeout"
+	limitReqKeyAnnotation                 = "nginx.org/limit-req-key"
 	appProtectEnableAnnotation            = "appprotect.f5.com/app-protect-enable"
 	appProtectSecurityLogEnableAnnotation = "appprotect.f5.com/app-protect-security-log-enable"
 	appProtectPolicyAnnotation            = "appprotect.f5.com/app-protect-policy"
@@ -83,6 +84,7 @@ const (
 	commaDelimiter     = ","
 	annotationValueFmt = `([^"$\\]|\\[^$])*`
 	jwtTokenValueFmt   = "\\$" + annotationValueFmt
+	limitReqKeyFmt     = `^(\$\{[a-zA-Z_][a-zA-Z0-9_]*\}|\$[a-zA-Z_][a-zA-Z0-9_]*)+$`
 )
 
 const (
@@ -93,6 +95,7 @@ const (
 var (
 	validAnnotationValueRegex         = regexp.MustCompile("^" + annotationValueFmt + "$")
 	validJWTTokenAnnotationValueRegex = regexp.MustCompile("^" + jwtTokenValueFmt + "$")
+	validLimitReqKeyRegex             = regexp.MustCompile(limitReqKeyFmt)
 )
 
 type annotationValidationContext struct {
@@ -314,6 +317,10 @@ var (
 		failTimeoutAnnotation: {
 			validateRequiredAnnotation,
 			validateTimeAnnotation,
+		},
+		limitReqKeyAnnotation: {
+			validateRequiredAnnotation,
+			validateLimitReqKeyAnnotation,
 		},
 		appProtectEnableAnnotation: {
 			validateAppProtectOnlyAnnotation,
@@ -546,6 +553,14 @@ func validateJWTRealm(context *annotationValidationContext) field.ErrorList {
 func validateJWTTokenAnnotation(context *annotationValidationContext) field.ErrorList {
 	if !validJWTTokenAnnotationValueRegex.MatchString(context.value) {
 		msg := validation.RegexError(jwtTokenValueFmtErrMsg, jwtTokenValueFmt, "$http_token", "$cookie_auth_token")
+		return field.ErrorList{field.Invalid(context.fieldPath, context.value, msg)}
+	}
+	return nil
+}
+
+func validateLimitReqKeyAnnotation(context *annotationValidationContext) field.ErrorList {
+	if !validLimitReqKeyRegex.MatchString(context.value) {
+		msg := validation.RegexError(`must consist of one or more NGINX variable references ($varname or ${varname}); must not contain ';', '"', '\', or newline characters`, limitReqKeyFmt, "$binary_remote_addr", "${request_uri}")
 		return field.ErrorList{field.Invalid(context.fieldPath, context.value, msg)}
 	}
 	return nil

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -3052,6 +3052,85 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 
 		{
 			annotations: map[string]string{
+				"nginx.org/limit-req-key": "$binary_remote_addr",
+			},
+			specServices:          map[string]bool{},
+			isPlus:                false,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors:        nil,
+			msg:                   "valid nginx.org/limit-req-key annotation, simple variable",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.org/limit-req-key": "${binary_remote_addr}",
+			},
+			specServices:          map[string]bool{},
+			isPlus:                false,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors:        nil,
+			msg:                   "valid nginx.org/limit-req-key annotation, braced variable",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.org/limit-req-key": "$binary_remote_addr$request_uri",
+			},
+			specServices:          map[string]bool{},
+			isPlus:                false,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors:        nil,
+			msg:                   "valid nginx.org/limit-req-key annotation, multiple variables",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.org/limit-req-key": "} limit_req_zone $x zone=z:1m rate=1r/s; server {",
+			},
+			specServices:          map[string]bool{},
+			isPlus:                false,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors: []string{
+				`annotations.nginx.org/limit-req-key: Invalid value: "} limit_req_zone $x zone=z:1m rate=1r/s; server {": must consist of one or more NGINX variable references ($varname or ${varname}); must not contain ';', '"', '\', or newline characters (e.g. '$binary_remote_addr',  or '${request_uri}', regex used for validation is '^(\$\{[a-zA-Z_][a-zA-Z0-9_]*\}|\$[a-zA-Z_][a-zA-Z0-9_]*)+$')`,
+			},
+			msg: "invalid nginx.org/limit-req-key annotation, injection attempt with semicolon and braces",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.org/limit-req-key": "$binary_remote_addr; evil",
+			},
+			specServices:          map[string]bool{},
+			isPlus:                false,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors: []string{
+				`annotations.nginx.org/limit-req-key: Invalid value: "$binary_remote_addr; evil": must consist of one or more NGINX variable references ($varname or ${varname}); must not contain ';', '"', '\', or newline characters (e.g. '$binary_remote_addr',  or '${request_uri}', regex used for validation is '^(\$\{[a-zA-Z_][a-zA-Z0-9_]*\}|\$[a-zA-Z_][a-zA-Z0-9_]*)+$')`,
+			},
+			msg: "invalid nginx.org/limit-req-key annotation, semicolon injection",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.org/limit-req-key": "not_a_variable",
+			},
+			specServices:          map[string]bool{},
+			isPlus:                false,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors: []string{
+				`annotations.nginx.org/limit-req-key: Invalid value: "not_a_variable": must consist of one or more NGINX variable references ($varname or ${varname}); must not contain ';', '"', '\', or newline characters (e.g. '$binary_remote_addr',  or '${request_uri}', regex used for validation is '^(\$\{[a-zA-Z_][a-zA-Z0-9_]*\}|\$[a-zA-Z_][a-zA-Z0-9_]*)+$')`,
+			},
+			msg: "invalid nginx.org/limit-req-key annotation, no NGINX variable",
+		},
+
+		{
+			annotations: map[string]string{
 				"appprotect.f5.com/app-protect-enable": "true",
 			},
 			specServices:          map[string]bool{},

--- a/pkg/apis/configuration/validation/policy.go
+++ b/pkg/apis/configuration/validation/policy.go
@@ -910,7 +910,7 @@ func validateRateLimitZoneSize(zoneSize string, fieldPath *field.Path) field.Err
 	mbZoneSize := strings.TrimSuffix(strings.ToLower(zoneSize), "m")
 	mbZoneSizeNum, mbErr := strconv.Atoi(mbZoneSize)
 
-	if err == nil && kbZoneSizeNum < 32 || mbErr == nil && mbZoneSizeNum == 0 {
+	if (err == nil && kbZoneSizeNum < 32) || (mbErr == nil && mbZoneSizeNum == 0) {
 		allErrs = append(allErrs, field.Invalid(fieldPath, zoneSize, "must be greater than 31k"))
 	}
 	return allErrs

--- a/pkg/apis/configuration/validation/transportserver.go
+++ b/pkg/apis/configuration/validation/transportserver.go
@@ -180,7 +180,7 @@ func validateTransportServerUpstreams(upstreams []conf_v1.TransportServerUpstrea
 
 		allErrs = append(allErrs, validateServiceName(u.Service, idxPath.Child("service"))...)
 		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.MaxFails, idxPath.Child("maxFails"))...)
-		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.MaxFails, idxPath.Child("maxConns"))...)
+		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.MaxConns, idxPath.Child("maxConns"))...)
 		allErrs = append(allErrs, validateTime(u.FailTimeout, idxPath.Child("failTimeout"))...)
 
 		for _, msg := range validation.IsValidPortNum(u.Port) {
@@ -287,7 +287,7 @@ func validateHealthCheckMatch(match *conf_v1.TransportServerMatch, fieldPath *fi
 	}
 
 	allErrs := validateMatchExpect(match.Expect, fieldPath.Child("expect"))
-	allErrs = append(allErrs, validateMatchSend(match.Expect, fieldPath.Child("send"))...)
+	allErrs = append(allErrs, validateMatchSend(match.Send, fieldPath.Child("send"))...)
 	return allErrs
 }
 


### PR DESCRIPTION
### Proposed changes

* Adds improved validation to the limit-req-key annotation . 
* Fixed typos in pkg/apis/configuration/validation/transportserver.go
* Added normalisation of bare numbers for limit req zone size following CRD docs (bare numbers assume 'k'). Bare numbers above and including 32768 will not get the 'k' suffix, they are already valid as is, and adding the suffix would mean increasing memory need thousand fold, which is not desirable. Numbers 1..31 already get caught with existing validation.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
