### PR TITLE
Pull c-ares from subscribed repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,11 @@ ubi-image-nap-dos-plus: build ## Create Docker image for Ingress Controller (UBI
 	$(DOCKER_CMD) $(PLUS_ARGS) --secret id=rhel_license,src=rhel_license --build-arg BUILD_OS=ubi-9-plus-nap \
 		--build-arg NAP_MODULES=waf,dos --build-arg NAP_WAF_VERSION=$(NAP_WAF_VERSION) --build-arg NAP_AGENT_VERSION=$(NAP_AGENT_VERSION)
 
+.PHONY: ubi10-dependency-image-local
+ubi10-dependency-image-local: ## Build UBI10 dependency image locally (no push). Requires rhel_license. Set PLATFORM=linux/arm64 for arm64 (default: linux/amd64).
+	docker buildx build --platform $(PLATFORM) --file build/dependencies/Dockerfile.ubi10 \
+		--secret id=rhel_license,src=rhel_license --target final --load .
+
 .PHONY: all-images ## Create all the Docker images for Ingress Controller
 all-images:
 	docker builder prune -af; \

--- a/build/dependencies/Dockerfile.ubi10
+++ b/build/dependencies/Dockerfile.ubi10
@@ -2,14 +2,14 @@
 FROM redhat/ubi10@sha256:936bf25d1a9b2c0c00aa67ec55f8347273763b7c64317ba7404b4b87736b2af2 AS rpm-build
 RUN --mount=type=secret,id=rhel_license,dst=/tmp/rhel_license,mode=0644,required=false \
     mkdir -p /rpms/ \
+    && dnf install -y subscription-manager \
+    && source /tmp/rhel_license \
+    && subscription-manager register --org=${RHEL_ORGANIZATION} --activationkey=${RHEL_ACTIVATION_KEY} \
+    && subscription-manager attach \
     && dnf download --resolve --destdir=/rpms c-ares \
     && rm -rf /rpms/*devel* \
     && if [ "$(arch)" = "x86_64" ]; then \
-        dnf install -y subscription-manager \
-        && source /tmp/rhel_license \
-        && subscription-manager register --org=${RHEL_ORGANIZATION} --activationkey=${RHEL_ACTIVATION_KEY} \
-        && subscription-manager attach \
-        && dnf install -y --enablerepo=codeready-builder-for-rhel-10-x86_64-rpms createrepo_c \
+        dnf install -y --enablerepo=codeready-builder-for-rhel-10-x86_64-rpms createrepo_c \
         && dnf download --resolve --destdir=/rpms \
             --enablerepo=codeready-builder-for-rhel-10-x86_64-rpms \
             perl-Class-Accessor perl-File-BaseDir perl-HTML-Tree perl-IO-String perl-IO-stringy \
@@ -27,9 +27,9 @@ RUN --mount=type=secret,id=rhel_license,dst=/tmp/rhel_license,mode=0644,required
             protobuf perl-Bit-Vector perl-File-Slurp perl-IO-Socket-INET6 \
             perl-JSON perl-XML-LibXML perl-XML-Simple \
             boost-filesystem boost-iostreams cjson \
-        && subscription-manager unregister \
         && createrepo_c /rpms/; \
-    fi
+    fi \
+    && subscription-manager unregister
 
 FROM scratch AS final
 COPY --link --from=rpm-build /rpms /

--- a/build/dependencies/Dockerfile.ubi10
+++ b/build/dependencies/Dockerfile.ubi10
@@ -5,7 +5,6 @@ RUN --mount=type=secret,id=rhel_license,dst=/tmp/rhel_license,mode=0644,required
     && dnf install -y subscription-manager \
     && source /tmp/rhel_license \
     && subscription-manager register --org=${RHEL_ORGANIZATION} --activationkey=${RHEL_ACTIVATION_KEY} \
-    && subscription-manager attach \
     && dnf download --resolve --destdir=/rpms c-ares \
     && rm -rf /rpms/*devel* \
     && if [ "$(arch)" = "x86_64" ]; then \


### PR DESCRIPTION
This pull request refactors the `build/dependencies/Dockerfile.ubi10` to improve the order of operations and ensure proper subscription management during the build process. The main changes involve ensuring the c-ares package is installed when subscribed to RedHat.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
