### PR TITLE
Allow docker-scout to continue on error

### DIFF
--- a/.github/workflows/build-oss.yml
+++ b/.github/workflows/build-oss.yml
@@ -253,4 +253,5 @@ jobs:
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
           summary: true
+        continue-on-error: true
         if: ${{ inputs.authenticated && steps.build-push.conclusion == 'success' }}

--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -287,6 +287,7 @@ jobs:
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
           summary: true
+        continue-on-error: true
         if: ${{ inputs.authenticated && steps.build-push.conclusion == 'success' }}
 
       - name: Clean up secrets

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -429,11 +429,11 @@ jobs:
         with:
           command: cves
           image: ${{ steps.meta.outputs.tags }}
-          ignore-base: true
           sarif-file: "${{ steps.directory.outputs.directory }}/scout.sarif"
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
           summary: true
+        continue-on-error: true
 
       - name: Upload Scan Results to Github Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -446,6 +446,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "${{ steps.directory.outputs.directory }}/"
+        continue-on-error: true
 
   scan-docker-plus:
     name: Scan ${{ matrix.image }}-${{ matrix.target }}
@@ -550,6 +551,7 @@ jobs:
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
           summary: true
+        continue-on-error: true
 
       - name: Upload Scan Results to Github Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -562,6 +564,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "${{ steps.directory.outputs.directory }}/"
+        continue-on-error: true
 
   scan-docker-nap:
     name: Scan ${{ matrix.image }}-${{ matrix.target }}-${{ matrix.nap_modules }}
@@ -673,6 +676,7 @@ jobs:
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
           summary: true
+        continue-on-error: true
 
       - name: Upload Scan Results to Github Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -441,12 +441,13 @@ jobs:
           name: "${{ github.ref_name }}-${{ steps.directory.outputs.directory }}"
           path: "${{ steps.directory.outputs.directory }}/"
           overwrite: true
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
       - name: Upload Scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "${{ steps.directory.outputs.directory }}/"
-        continue-on-error: true
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
   scan-docker-plus:
     name: Scan ${{ matrix.image }}-${{ matrix.target }}
@@ -546,7 +547,6 @@ jobs:
         with:
           command: cves
           image: ${{ steps.meta.outputs.tags }}
-          ignore-base: true
           sarif-file: "${{ steps.directory.outputs.directory }}/scout.sarif"
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
@@ -559,12 +559,13 @@ jobs:
           name: "${{ github.ref_name }}-${{ steps.directory.outputs.directory }}"
           path: "${{ steps.directory.outputs.directory }}/"
           overwrite: true
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
       - name: Upload Scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "${{ steps.directory.outputs.directory }}/"
-        continue-on-error: true
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
   scan-docker-nap:
     name: Scan ${{ matrix.image }}-${{ matrix.target }}-${{ matrix.nap_modules }}
@@ -671,7 +672,6 @@ jobs:
         with:
           command: cves
           image: ${{ steps.meta.outputs.tags }}
-          ignore-base: true
           sarif-file: "${{ steps.directory.outputs.directory }}/scout.sarif"
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
@@ -684,12 +684,13 @@ jobs:
           name: "${{ github.ref_name }}-${{ steps.directory.outputs.directory }}"
           path: "${{ steps.directory.outputs.directory }}/"
           overwrite: true
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
       - name: Upload Scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "${{ steps.directory.outputs.directory }}/"
-        continue-on-error: true
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
   update-release-draft:
     name: Update Release Draft


### PR DESCRIPTION
### Proposed changes

This change:
- sets docker-scout to continue on error.  This prevents pipeline failures when we get rate-limited by github when downloading the docker scout binary
- Updates the PR workflow to only scan changed layers, not base image layers
- Updates the image promotion workflow to scan all image layers.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
