### PR TITLE
Ensure runners version of yq is used

### DIFF
--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -128,7 +128,11 @@ jobs:
             echo "Invalid chart_name: must match Helm chart name pattern ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" >&2
             exit 1
           fi
-          CHART_NAME="$chart_name" yq -i '.name = strenv(CHART_NAME)' kic/charts/nginx-ingress/Chart.yaml
+          if [[ ! -x /usr/bin/yq ]]; then
+            echo "/usr/bin/yq not found"
+            exit 1
+          fi
+          CHART_NAME="$chart_name" /usr/bin/yq -i '.name = strenv(CHART_NAME)' kic/charts/nginx-ingress/Chart.yaml
           if [[ "${{ inputs.ic_version }}" =~ ^20[0-9]+-lts ]]; then
             IMAGE_REPOSITORY="private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress"
             sed -i "s|^  nginxplus: false|  nginxplus: true|" kic/charts/nginx-ingress/values.yaml


### PR DESCRIPTION
### Proposed changes

We are seeing the `python` version of `yq` being used on the image promotion workflow.  This change ensures the runner `yq` version is present and used.

Fixes https://github.com/nginx/kubernetes-ingress/actions/runs/26046793104/job/76611751097

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
