### PR TITLE
Fix prerequisite for the make all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ help: Makefile ## Display this help
 	@grep -E '^(override )?[a-zA-Z0-9_-]+ \??\+?= .*? ## .*$$' $< | sort | awk 'BEGIN {FS = " \\??\\+?= .*? ## "; printf "\nVariables:\n\n"}; {gsub(/override /, "", $$1); printf "    \033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: all
-all: test lint verify-codegen update-crds debian-image
+all: test lint verify-codegen update-crds debian-image-plus
 
 .PHONY: lint
 lint: ## Run linter


### PR DESCRIPTION
### Proposed changes

Previously it has 'debian-image', but as everything that isn't needed for the LTS release was stripped out, so did 'debian-image'.

The make all-images target correctly calls 'debian-image-plus', so the fix is to change 'debian-image' -> 'debian-image-plus' for the make all target.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
