### PR TITLE
Allow docker-scout to continue on error (#9894)

### DIFF
--- a/.github/workflows/build-oss.yml
+++ b/.github/workflows/build-oss.yml
@@ -253,4 +253,5 @@ jobs:
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
           summary: true
+        continue-on-error: true
         if: ${{ inputs.authenticated && steps.build-push.conclusion == 'success' }}

--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -287,6 +287,7 @@ jobs:
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
           summary: true
+        continue-on-error: true
         if: ${{ inputs.authenticated && steps.build-push.conclusion == 'success' }}
 
       - name: Clean up secrets

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -429,11 +429,11 @@ jobs:
         with:
           command: cves
           image: ${{ steps.meta.outputs.tags }}
-          ignore-base: true
           sarif-file: "${{ steps.directory.outputs.directory }}/scout.sarif"
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
           summary: true
+        continue-on-error: true
 
       - name: Upload Scan Results to Github Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -441,11 +441,13 @@ jobs:
           name: "${{ github.ref_name }}-${{ steps.directory.outputs.directory }}"
           path: "${{ steps.directory.outputs.directory }}/"
           overwrite: true
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
       - name: Upload Scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: "${{ steps.directory.outputs.directory }}/"
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
   scan-docker-plus:
     name: Scan ${{ matrix.image }}-${{ matrix.target }}
@@ -545,11 +547,11 @@ jobs:
         with:
           command: cves
           image: ${{ steps.meta.outputs.tags }}
-          ignore-base: true
           sarif-file: "${{ steps.directory.outputs.directory }}/scout.sarif"
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
           summary: true
+        continue-on-error: true
 
       - name: Upload Scan Results to Github Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -557,11 +559,13 @@ jobs:
           name: "${{ github.ref_name }}-${{ steps.directory.outputs.directory }}"
           path: "${{ steps.directory.outputs.directory }}/"
           overwrite: true
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
       - name: Upload Scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: "${{ steps.directory.outputs.directory }}/"
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
   scan-docker-nap:
     name: Scan ${{ matrix.image }}-${{ matrix.target }}-${{ matrix.nap_modules }}
@@ -668,11 +672,11 @@ jobs:
         with:
           command: cves
           image: ${{ steps.meta.outputs.tags }}
-          ignore-base: true
           sarif-file: "${{ steps.directory.outputs.directory }}/scout.sarif"
           write-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }} # to be able to write the comment
           summary: true
+        continue-on-error: true
 
       - name: Upload Scan Results to Github Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -680,12 +684,13 @@ jobs:
           name: "${{ github.ref_name }}-${{ steps.directory.outputs.directory }}"
           path: "${{ steps.directory.outputs.directory }}/"
           overwrite: true
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
       - name: Upload Scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: "${{ steps.directory.outputs.directory }}/"
-        continue-on-error: true
+        if: ${{ steps.docker-scout.outcome == 'success' }}
 
   update-release-draft:
     name: Update Release Draft


### PR DESCRIPTION
* Add DockerHub login step for Docker Scout in build workflows

* Make scans consistent

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
