### PR TITLE
Switch registry name for LTS to match available registries

### DIFF
--- a/.github/config/config-plus-gcr-release-lts
+++ b/.github/config/config-plus-gcr-release-lts
@@ -4,4 +4,4 @@ export PUBLISH_OSS=false
 export PUBLISH_WAF=false
 export PUBLISH_DOS=false
 export PUBLISH_WAF_DOS=false
-export TARGET_PLUS_IMAGE_PREFIX=lts/nginx-ic/nginx-plus-ingress
+export TARGET_PLUS_IMAGE_PREFIX=nginx-ic/lts/nginx-plus-ingress

--- a/.github/config/config-plus-nginx-lts
+++ b/.github/config/config-plus-nginx-lts
@@ -4,4 +4,4 @@ export PUBLISH_OSS=false
 export PUBLISH_WAF=false
 export PUBLISH_DOS=false
 export PUBLISH_WAF_DOS=false
-export TARGET_PLUS_IMAGE_PREFIX=lts/nginx-ic/nginx-plus-ingress
+export TARGET_PLUS_IMAGE_PREFIX=nginx-ic/lts/nginx-plus-ingress

--- a/.github/data/patch-images-lts.json
+++ b/.github/data/patch-images-lts.json
@@ -1,6 +1,6 @@
 {
   "image": {
-    "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/lts/nginx-ic/nginx-plus-ingress",
+    "source_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/lts/nginx-plus-ingress",
     "target_image": "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic/nginx-plus-ingress",
     "platforms": "linux/arm64, linux/amd64"
   }

--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -130,7 +130,7 @@ jobs:
           fi
           sed -i "s|^name:.*|name: ${chart_name}|" kic/charts/nginx-ingress/Chart.yaml
           if [[ "${{ inputs.ic_version }}" =~ ^20[0-9]+-lts ]]; then
-            IMAGE_REPOSITORY="private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress"
+            IMAGE_REPOSITORY="private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress"
             sed -i "s|^  nginxplus: false|  nginxplus: true|" kic/charts/nginx-ingress/values.yaml
             sed -E -i "s|^(    )repository:.*|\1repository: ${IMAGE_REPOSITORY}|" kic/charts/nginx-ingress/values.yaml
             sed -E -i "s|^(    )(# *)?tag:.*|\1tag: \"${{ inputs.ic_version }}\"|" kic/charts/nginx-ingress/values.yaml

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -291,7 +291,7 @@ jobs:
         id: image_details
         run: |
           if ${{ matrix.images.lts == true }}; then
-            echo "name=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/lts/nginx-ic/nginx-plus-ingress" >> $GITHUB_OUTPUT
+            echo "name=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic/lts/nginx-plus-ingress" >> $GITHUB_OUTPUT
             echo "tag=${{ matrix.images.lts_tag }}" >> $GITHUB_OUTPUT
           else
             echo "name=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic${{ contains(matrix.images.nap_modules, 'dos') && '-dos' || '' }}${{ contains(matrix.images.nap_modules, 'waf') && '-nap' || '' }}${{ contains(matrix.images.image, 'v5') && '-v5' || '' }}/nginx${{ contains(matrix.images.image, 'plus') && '-plus' || '' }}-ingress" >> $GITHUB_OUTPUT

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -100,7 +100,7 @@ controller:
 
   image:
     ## The image repository of the Ingress Controller.
-    repository: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress
+    repository: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress
 
     ## The tag of the Ingress Controller image. If not specified the appVersion from Chart.yaml is used as a tag.
     tag: "2026-lts-r1"

--- a/charts/tests/__snapshots__/helmunit_test.snap
+++ b/charts/tests/__snapshots__/helmunit_test.snap
@@ -321,7 +321,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -772,7 +772,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: nginx-ingress
-        image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+        image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         imagePullPolicy: "IfNotPresent"
         ports:
         - name: http
@@ -1240,7 +1240,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: nginx-ingress
-        image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+        image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         imagePullPolicy: "IfNotPresent"
         ports:
         - name: http
@@ -1338,7 +1338,7 @@ spec:
           - -weight-changes-dynamic-reload=false
       initContainers:
       - name: init-nginx-ingress
-        image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+        image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         imagePullPolicy: "IfNotPresent"
         command: ['cp', '-vdR', '/etc/nginx/.', '/mnt/etc']
         resources:
@@ -1728,7 +1728,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -2184,7 +2184,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -2673,7 +2673,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -3130,7 +3130,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -3609,7 +3609,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -4085,7 +4085,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -4564,7 +4564,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -5028,7 +5028,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -5485,7 +5485,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -5942,7 +5942,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -6399,7 +6399,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -6876,7 +6876,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -7344,7 +7344,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -7802,7 +7802,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -8260,7 +8260,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -8780,7 +8780,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -9297,7 +9297,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -9761,7 +9761,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -10230,7 +10230,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -10704,7 +10704,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -11179,7 +11179,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -11662,7 +11662,7 @@ spec:
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:
-      - image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+      - image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         name: nginx-ingress
         imagePullPolicy: "IfNotPresent"
         ports:
@@ -11760,7 +11760,7 @@ spec:
           - -weight-changes-dynamic-reload=false
       initContainers:
       - name: init-nginx-ingress
-        image: private-registry.nginx.com/lts/nginx-ic/nginx-plus-ingress:2026-lts-r1
+        image: private-registry.nginx.com/nginx-ic/lts/nginx-plus-ingress:2026-lts-r1
         imagePullPolicy: "IfNotPresent"
         command: ['cp', '-vdR', '/etc/nginx/.', '/mnt/etc']
         resources:


### PR DESCRIPTION
### Proposed changes

private-registry.nginx.com/lts is not a registry that exists.  We should use private-registry.nginx.com/nginx-ic/lts instead. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
