### PR TITLE
Trigger NGINX reload on IngressMTLS CA secret rotation

### DIFF
--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -3007,6 +3007,9 @@ server {
     {{- end }}
 
     {{- with $s.IngressMTLS }}
+    {{- if .ClientCertHash }}
+    # ssl_client_certificate content-hash: {{ .ClientCertHash }}
+    {{- end }}
     ssl_client_certificate {{ .ClientCert }};
     {{- if .ClientCrl }}
     ssl_crl {{ .ClientCrl }};

--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -498,18 +498,20 @@ func (p *policiesCfg) addIngressMTLSConfig(
 	// so that secret rotations cause the rendered config to change and
 	// trigger an NGINX reload. Hash only the keys we actually consume — never
 	// the whole Secret.Data map — so unrelated entries cannot leak into the
-	// rendered config as a side-channel fingerprint. If neither key is
-	// present we leave the hash empty so the template skips rendering the
-	// fingerprint comment (matches the existing "render only when non-empty"
-	// gate and keeps test fixtures with empty Secret.Data unaffected).
+	// rendered config as a side-channel fingerprint. The CRL bytes are only
+	// included when the in-secret ca.crl is the one actually rendered; when
+	// ingressMTLS.CrlFileName is set the CRL is read from a separate file
+	// that we do not have access to here, so we fingerprint only the CA
+	// bundle. If no CA bytes are present we leave the hash empty so the
+	// template skips rendering the fingerprint comment.
 	caCert := secretRef.Secret.Data[secrets.CAKey]
 	caCrl := secretRef.Secret.Data[CACrlKey]
-	var clientCertHash string
-	if len(caCert) > 0 || len(caCrl) > 0 {
-		clientCertHash = secrets.ComputeContentHash(caCert, caCrl)
-	}
 
 	if ingressMTLS.CrlFileName != "" {
+		var clientCertHash string
+		if len(caCert) > 0 {
+			clientCertHash = secrets.ComputeContentHash(caCert)
+		}
 		p.IngressMTLS = &version2.IngressMTLS{
 			ClientCert:     caFields[0],
 			ClientCrl:      fmt.Sprintf("%s/%s", DefaultSecretPath, ingressMTLS.CrlFileName),
@@ -518,6 +520,10 @@ func (p *policiesCfg) addIngressMTLSConfig(
 			VerifyDepth:    verifyDepth,
 		}
 	} else if _, hasCrlKey := secretRef.Secret.Data[CACrlKey]; hasCrlKey {
+		var clientCertHash string
+		if len(caCert) > 0 || len(caCrl) > 0 {
+			clientCertHash = secrets.ComputeContentHash(caCert, caCrl)
+		}
 		p.IngressMTLS = &version2.IngressMTLS{
 			ClientCert:     caFields[0],
 			ClientCrl:      caFields[1],
@@ -526,6 +532,10 @@ func (p *policiesCfg) addIngressMTLSConfig(
 			VerifyDepth:    verifyDepth,
 		}
 	} else {
+		var clientCertHash string
+		if len(caCert) > 0 {
+			clientCertHash = secrets.ComputeContentHash(caCert)
+		}
 		p.IngressMTLS = &version2.IngressMTLS{
 			ClientCert:     caFields[0],
 			ClientCertHash: clientCertHash,

--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -490,7 +490,10 @@ func (p *policiesCfg) addIngressMTLSConfig(
 
 	caFields := strings.Fields(secretRef.Path)
 
-	if _, hasCrlKey := secretRef.Secret.Data[CACrlKey]; hasCrlKey && ingressMTLS.CrlFileName != "" {
+	caCert := secretRef.Secret.Data[secrets.CAKey]
+	caCrl, hasCrlKey := secretRef.Secret.Data[CACrlKey]
+
+	if hasCrlKey && ingressMTLS.CrlFileName != "" {
 		res.addWarningf("Both ca.crl in the Secret and ingressMTLS.crlFileName fields cannot be used. ca.crl in %s will be ignored and %s will be applied", secretKey, polKey)
 	}
 
@@ -499,19 +502,33 @@ func (p *policiesCfg) addIngressMTLSConfig(
 	// trigger an NGINX reload. Hash only the keys we actually consume — never
 	// the whole Secret.Data map — so unrelated entries cannot leak into the
 	// rendered config as a side-channel fingerprint. The CRL bytes are only
-	// included when the in-secret ca.crl is the one actually rendered; when
-	// ingressMTLS.CrlFileName is set the CRL is read from a separate file
-	// that we do not have access to here, so we fingerprint only the CA
-	// bundle. If no CA bytes are present we leave the hash empty so the
+	// included when the in-secret ca.crl is the one actually rendered.
+	//
+	// Known gap: when ingressMTLS.CrlFileName is set, the CRL is read from a
+	// separate file under DefaultSecretPath that this code has no handle on,
+	// so we fingerprint only the CA bundle. As a result, rotating only the
+	// CRL file (without touching the CA bundle) will not change the rendered
+	// config and therefore will not trigger a reload through this mechanism.
+	// This asymmetry is documented on the IngressMTLS.CrlFileName API field;
+	// users who need reload-on-CRL-rotation should store the CRL under the
+	// ca.crl key of clientCertSecret instead.
+	//
+	// If no relevant bytes are present we leave the hash empty so the
 	// template skips rendering the fingerprint comment.
-	caCert := secretRef.Secret.Data[secrets.CAKey]
-	caCrl := secretRef.Secret.Data[CACrlKey]
-
-	if ingressMTLS.CrlFileName != "" {
-		var clientCertHash string
-		if len(caCert) > 0 {
-			clientCertHash = secrets.ComputeContentHash(caCert)
+	hashInputs := [][]byte{caCert}
+	if ingressMTLS.CrlFileName == "" && hasCrlKey {
+		hashInputs = append(hashInputs, caCrl)
+	}
+	var clientCertHash string
+	for _, b := range hashInputs {
+		if len(b) > 0 {
+			clientCertHash = secrets.ComputeContentHash(hashInputs...)
+			break
 		}
+	}
+
+	switch {
+	case ingressMTLS.CrlFileName != "":
 		p.IngressMTLS = &version2.IngressMTLS{
 			ClientCert:     caFields[0],
 			ClientCrl:      fmt.Sprintf("%s/%s", DefaultSecretPath, ingressMTLS.CrlFileName),
@@ -519,11 +536,7 @@ func (p *policiesCfg) addIngressMTLSConfig(
 			VerifyClient:   verifyClient,
 			VerifyDepth:    verifyDepth,
 		}
-	} else if _, hasCrlKey := secretRef.Secret.Data[CACrlKey]; hasCrlKey {
-		var clientCertHash string
-		if len(caCert) > 0 || len(caCrl) > 0 {
-			clientCertHash = secrets.ComputeContentHash(caCert, caCrl)
-		}
+	case hasCrlKey:
 		p.IngressMTLS = &version2.IngressMTLS{
 			ClientCert:     caFields[0],
 			ClientCrl:      caFields[1],
@@ -531,11 +544,7 @@ func (p *policiesCfg) addIngressMTLSConfig(
 			VerifyClient:   verifyClient,
 			VerifyDepth:    verifyDepth,
 		}
-	} else {
-		var clientCertHash string
-		if len(caCert) > 0 {
-			clientCertHash = secrets.ComputeContentHash(caCert)
-		}
+	default:
 		p.IngressMTLS = &version2.IngressMTLS{
 			ClientCert:     caFields[0],
 			ClientCertHash: clientCertHash,

--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -494,25 +494,43 @@ func (p *policiesCfg) addIngressMTLSConfig(
 		res.addWarningf("Both ca.crl in the Secret and ingressMTLS.crlFileName fields cannot be used. ca.crl in %s will be ignored and %s will be applied", secretKey, polKey)
 	}
 
+	// Fingerprint the exact bytes that feed ssl_client_certificate / ssl_crl
+	// so that secret rotations cause the rendered config to change and
+	// trigger an NGINX reload. Hash only the keys we actually consume — never
+	// the whole Secret.Data map — so unrelated entries cannot leak into the
+	// rendered config as a side-channel fingerprint. If neither key is
+	// present we leave the hash empty so the template skips rendering the
+	// fingerprint comment (matches the existing "render only when non-empty"
+	// gate and keeps test fixtures with empty Secret.Data unaffected).
+	caCert := secretRef.Secret.Data[secrets.CAKey]
+	caCrl := secretRef.Secret.Data[CACrlKey]
+	var clientCertHash string
+	if len(caCert) > 0 || len(caCrl) > 0 {
+		clientCertHash = secrets.ComputeContentHash(caCert, caCrl)
+	}
+
 	if ingressMTLS.CrlFileName != "" {
 		p.IngressMTLS = &version2.IngressMTLS{
-			ClientCert:   caFields[0],
-			ClientCrl:    fmt.Sprintf("%s/%s", DefaultSecretPath, ingressMTLS.CrlFileName),
-			VerifyClient: verifyClient,
-			VerifyDepth:  verifyDepth,
+			ClientCert:     caFields[0],
+			ClientCrl:      fmt.Sprintf("%s/%s", DefaultSecretPath, ingressMTLS.CrlFileName),
+			ClientCertHash: clientCertHash,
+			VerifyClient:   verifyClient,
+			VerifyDepth:    verifyDepth,
 		}
 	} else if _, hasCrlKey := secretRef.Secret.Data[CACrlKey]; hasCrlKey {
 		p.IngressMTLS = &version2.IngressMTLS{
-			ClientCert:   caFields[0],
-			ClientCrl:    caFields[1],
-			VerifyClient: verifyClient,
-			VerifyDepth:  verifyDepth,
+			ClientCert:     caFields[0],
+			ClientCrl:      caFields[1],
+			ClientCertHash: clientCertHash,
+			VerifyClient:   verifyClient,
+			VerifyDepth:    verifyDepth,
 		}
 	} else {
 		p.IngressMTLS = &version2.IngressMTLS{
-			ClientCert:   caFields[0],
-			VerifyClient: verifyClient,
-			VerifyDepth:  verifyDepth,
+			ClientCert:     caFields[0],
+			ClientCertHash: clientCertHash,
+			VerifyClient:   verifyClient,
+			VerifyDepth:    verifyDepth,
 		}
 	}
 	return res

--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/nginx/kubernetes-ingress/internal/configs/version2"
@@ -520,11 +521,8 @@ func (p *policiesCfg) addIngressMTLSConfig(
 		hashInputs = append(hashInputs, caCrl)
 	}
 	var clientCertHash string
-	for _, b := range hashInputs {
-		if len(b) > 0 {
-			clientCertHash = secrets.ComputeContentHash(hashInputs...)
-			break
-		}
+	if slices.ContainsFunc(hashInputs, func(b []byte) bool { return len(b) > 0 }) {
+		clientCertHash = secrets.ComputeContentHash(hashInputs...)
 	}
 
 	switch {

--- a/internal/configs/policy_test.go
+++ b/internal/configs/policy_test.go
@@ -3268,7 +3268,7 @@ func TestGeneratePoliciesFails(t *testing.T) {
 				IngressMTLS: &version2.IngressMTLS{
 					ClientCert:     ingressMTLSCertPath,
 					ClientCrl:      ingressMTLSCrlPath,
-					ClientCertHash: "8085a4cfe04579ef59523f8ca09e9a2bb5d6053242979e645bd16eaa11b87c88",
+					ClientCertHash: "",
 					VerifyClient:   "on",
 					VerifyDepth:    1,
 				},

--- a/internal/configs/policy_test.go
+++ b/internal/configs/policy_test.go
@@ -712,10 +712,11 @@ func TestGeneratePolicies(t *testing.T) {
 			expected: policiesCfg{
 				Context: ctx,
 				IngressMTLS: &version2.IngressMTLS{
-					ClientCert:   mTLSCertPath,
-					ClientCrl:    mTLSCrlPath,
-					VerifyClient: "off",
-					VerifyDepth:  1,
+					ClientCert:     mTLSCertPath,
+					ClientCrl:      mTLSCrlPath,
+					ClientCertHash: "8085a4cfe04579ef59523f8ca09e9a2bb5d6053242979e645bd16eaa11b87c88",
+					VerifyClient:   "off",
+					VerifyDepth:    1,
 				},
 			},
 			msg: "ingressMTLS reference with ca.crl field in secret",
@@ -3265,10 +3266,11 @@ func TestGeneratePoliciesFails(t *testing.T) {
 			expected: policiesCfg{
 				Context: ctx,
 				IngressMTLS: &version2.IngressMTLS{
-					ClientCert:   ingressMTLSCertPath,
-					ClientCrl:    ingressMTLSCrlPath,
-					VerifyClient: "on",
-					VerifyDepth:  1,
+					ClientCert:     ingressMTLSCertPath,
+					ClientCrl:      ingressMTLSCrlPath,
+					ClientCertHash: "8085a4cfe04579ef59523f8ca09e9a2bb5d6053242979e645bd16eaa11b87c88",
+					VerifyClient:   "on",
+					VerifyDepth:    1,
 				},
 				ErrorReturn: nil,
 			},

--- a/internal/configs/policy_test.go
+++ b/internal/configs/policy_test.go
@@ -52,6 +52,16 @@ func TestGeneratePolicies(t *testing.T) {
 				},
 				Path: mTLSCertAndCrlPath,
 			},
+			"default/ingress-mtls-secret-cert-and-crl": {
+				Secret: &api_v1.Secret{
+					Type: secrets.SecretTypeCA,
+					Data: map[string][]byte{
+						"ca.crt": []byte("base64cert"),
+						"ca.crl": []byte("base64crl"),
+					},
+				},
+				Path: mTLSCertAndCrlPath,
+			},
 			"default/egress-mtls-secret": {
 				Secret: &api_v1.Secret{
 					Type: api_v1.SecretTypeTLS,
@@ -754,6 +764,40 @@ func TestGeneratePolicies(t *testing.T) {
 				},
 			},
 			msg: "ingressMTLS reference with crl field in policy",
+		},
+		{
+			policyRefs: []conf_v1.PolicyReference{
+				{
+					Name:      "ingress-mtls-policy-cert-and-crl-secret",
+					Namespace: "default",
+				},
+			},
+			policies: map[string]*conf_v1.Policy{
+				"default/ingress-mtls-policy-cert-and-crl-secret": {
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:      "ingress-mtls-policy-cert-and-crl-secret",
+						Namespace: "default",
+					},
+					Spec: conf_v1.PolicySpec{
+						IngressMTLS: &conf_v1.IngressMTLS{
+							ClientCertSecret: "ingress-mtls-secret-cert-and-crl",
+							VerifyClient:     "off",
+						},
+					},
+				},
+			},
+			context: "spec",
+			expected: policiesCfg{
+				Context: ctx,
+				IngressMTLS: &version2.IngressMTLS{
+					ClientCert:     mTLSCertPath,
+					ClientCrl:      mTLSCrlPath,
+					ClientCertHash: secrets.ComputeContentHash([]byte("base64cert"), []byte("base64crl")),
+					VerifyClient:   "off",
+					VerifyDepth:    1,
+				},
+			},
+			msg: "ingressMTLS with in-secret ca.crl includes ca.crl bytes in hash",
 		},
 		{
 			policyRefs: []conf_v1.PolicyReference{
@@ -3280,6 +3324,61 @@ func TestGeneratePoliciesFails(t *testing.T) {
 				},
 			},
 			msg: "ingress mtls ca.crl and ingressMTLS.Crl set",
+		},
+		{
+			policyRefs: []conf_v1.PolicyReference{
+				{
+					Name:      "ingress-mtls-policy",
+					Namespace: "default",
+				},
+			},
+			policies: map[string]*conf_v1.Policy{
+				"default/ingress-mtls-policy": {
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:      "ingress-mtls-policy",
+						Namespace: "default",
+					},
+					Spec: conf_v1.PolicySpec{
+						IngressMTLS: &conf_v1.IngressMTLS{
+							ClientCertSecret: "ingress-mtls-secret",
+							CrlFileName:      "default-ingress-mtls-secret-ca.crl",
+						},
+					},
+				},
+			},
+			policyOpts: policyOptions{
+				tls: true,
+				secretRefs: map[string]*secrets.SecretReference{
+					"default/ingress-mtls-secret": {
+						Secret: &api_v1.Secret{
+							Type: secrets.SecretTypeCA,
+							Data: map[string][]byte{
+								"ca.crt": []byte("base64cert"),
+								"ca.crl": []byte("base64crl"),
+							},
+						},
+						Path: ingressMTLSCertPath,
+					},
+				},
+			},
+			context: "spec",
+			expected: policiesCfg{
+				Context: ctx,
+				IngressMTLS: &version2.IngressMTLS{
+					ClientCert:     ingressMTLSCertPath,
+					ClientCrl:      ingressMTLSCrlPath,
+					ClientCertHash: secrets.ComputeContentHash([]byte("base64cert")),
+					VerifyClient:   "on",
+					VerifyDepth:    1,
+				},
+				ErrorReturn: nil,
+			},
+			expectedWarnings: Warnings{
+				nil: {
+					`Both ca.crl in the Secret and ingressMTLS.crlFileName fields cannot be used. ca.crl in default/ingress-mtls-secret will be ignored and default/ingress-mtls-policy will be applied`,
+				},
+			},
+			msg: "ingress mtls CrlFileName set excludes ca.crl bytes from hash",
 		},
 		{
 			policyRefs: []conf_v1.PolicyReference{

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -79,6 +79,9 @@ server {
 	{{- end}}
 
 	{{- with $server.IngressMTLS }}
+	{{- if .ClientCertHash }}
+	# ssl_client_certificate content-hash: {{ .ClientCertHash }}
+	{{- end }}
 	ssl_client_certificate {{ .ClientCert }};
 	{{- if .ClientCrl }}
 	ssl_crl {{ .ClientCrl }};

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -78,6 +78,9 @@ server {
 	{{- end}}
 
 	{{- with $server.IngressMTLS }}
+	{{- if .ClientCertHash }}
+	# ssl_client_certificate content-hash: {{ .ClientCertHash }}
+	{{- end }}
 	ssl_client_certificate {{ .ClientCert }};
 	{{- if .ClientCrl }}
 	ssl_crl {{ .ClientCrl }};

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -125,10 +125,18 @@ type SSL struct {
 
 // IngressMTLS defines TLS configuration for a server. This is a subset of TLS specifically for clients auth.
 type IngressMTLS struct {
-	ClientCert   string
-	ClientCrl    string
-	VerifyClient string
-	VerifyDepth  int
+	ClientCert string
+	ClientCrl  string
+	// ClientCertHash is a stable digest of the CA secret data. It is rendered
+	// as a comment alongside ssl_client_certificate so that rotating the CA
+	// secret causes the rendered NGINX config to differ, which triggers a
+	// reload. Without this, NGINX would continue to use the CA cert it
+	// loaded into memory at config-load time until an unrelated event
+	// produced a reload, since only the file contents (not the path) change
+	// across rotations.
+	ClientCertHash string
+	VerifyClient   string
+	VerifyDepth    int
 }
 
 // EgressMTLS defines upstream TLS configuration applied at server or location scope.

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -192,6 +192,9 @@ server {
     {{- end }}
 
     {{- with $s.IngressMTLS }}
+    {{- if .ClientCertHash }}
+    # ssl_client_certificate content-hash: {{ .ClientCertHash }}
+    {{- end }}
     ssl_client_certificate {{ .ClientCert }};
     {{- if .ClientCrl }}
     ssl_crl {{ .ClientCrl }};

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -98,6 +98,9 @@ server {
     {{- end }}
 
     {{- with $s.IngressMTLS }}
+    {{- if .ClientCertHash }}
+    # ssl_client_certificate content-hash: {{ .ClientCertHash }}
+    {{- end }}
     ssl_client_certificate {{ .ClientCert }};
     {{- if .ClientCrl }}
     ssl_crl {{ .ClientCrl }};

--- a/internal/configs/version2/template_executor_test.go
+++ b/internal/configs/version2/template_executor_test.go
@@ -296,6 +296,9 @@ server {
     {{- end }}
 
     {{- with $s.IngressMTLS }}
+    {{- if .ClientCertHash }}
+    # ssl_client_certificate content-hash: {{ .ClientCertHash }}
+    {{- end }}
     ssl_client_certificate {{ .ClientCert }};
     {{- if .ClientCrl }}
     ssl_crl {{ .ClientCrl }};

--- a/internal/k8s/secrets/store.go
+++ b/internal/k8s/secrets/store.go
@@ -1,6 +1,9 @@
 package secrets
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 
 	api_v1 "k8s.io/api/core/v1"
@@ -12,6 +15,32 @@ type SecretReference struct {
 	Secret *api_v1.Secret
 	Path   string
 	Error  error
+}
+
+// ComputeContentHash returns a stable hex-encoded SHA-256 digest of the supplied
+// byte slices, with each slice length-prefixed so that two distinct positional
+// sequences (e.g. {"ab", ""} vs {"a", "b"}) hash to different digests. The
+// argument order is part of the input — callers should pass values in a fixed
+// order tied to the consuming NGINX directive.
+//
+// It exists so directives that reference secret-backed files via static paths
+// (e.g. ssl_client_certificate, ssl_trusted_certificate, auth_jwt_key_file,
+// auth_basic_user_file) can embed a fingerprint of the specific bytes they
+// consume into the rendered config. That makes the rendered config differ
+// whenever the referenced data rotates, which triggers an NGINX reload via
+// the existing configsChanged detection path. Hashing only the consumed bytes
+// (rather than the full Secret.Data map) avoids fingerprinting unrelated
+// entries that might appear in the Secret.
+func ComputeContentHash(values ...[]byte) string {
+	h := sha256.New()
+	var lenBuf [8]byte
+	for _, v := range values {
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(v)))
+		// hash.Hash.Write never returns an error; discards satisfy errcheck.
+		_, _ = h.Write(lenBuf[:])
+		_, _ = h.Write(v)
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // SecretFileManager manages secrets on the file system.

--- a/internal/k8s/secrets/store_hash_test.go
+++ b/internal/k8s/secrets/store_hash_test.go
@@ -7,18 +7,21 @@ import (
 	"testing"
 )
 
-func TestComputeContentHash_NoArgsAndEmpty(t *testing.T) {
+func TestComputeContentHash_NoArgs(t *testing.T) {
 	t.Parallel()
 	emptyDigest := sha256.Sum256(nil)
 	want := hex.EncodeToString(emptyDigest[:])
 	if got := ComputeContentHash(); got != want {
 		t.Errorf("ComputeContentHash() with no args: got %q, want %q", got, want)
 	}
+}
 
+func TestComputeContentHash_NoArgsDiffersFromEmptySlice(t *testing.T) {
+	t.Parallel()
 	// A single zero-length slice still contributes its 8-byte length prefix
 	// (all zeros), so it must differ from the no-args case.
-	if got := ComputeContentHash(nil); got == want {
-		t.Errorf("ComputeContentHash(nil) should differ from ComputeContentHash(): both = %q", got)
+	if ComputeContentHash() == ComputeContentHash(nil) {
+		t.Fatalf("expected ComputeContentHash() and ComputeContentHash(nil) to differ")
 	}
 }
 

--- a/internal/k8s/secrets/store_hash_test.go
+++ b/internal/k8s/secrets/store_hash_test.go
@@ -1,0 +1,83 @@
+package secrets
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+)
+
+func TestComputeContentHash_NoArgsAndEmpty(t *testing.T) {
+	t.Parallel()
+	emptyDigest := sha256.Sum256(nil)
+	want := hex.EncodeToString(emptyDigest[:])
+	if got := ComputeContentHash(); got != want {
+		t.Errorf("ComputeContentHash() with no args: got %q, want %q", got, want)
+	}
+
+	// A single zero-length slice still contributes its 8-byte length prefix
+	// (all zeros), so it must differ from the no-args case.
+	if got := ComputeContentHash(nil); got == want {
+		t.Errorf("ComputeContentHash(nil) should differ from ComputeContentHash(): both = %q", got)
+	}
+}
+
+func TestComputeContentHash_KnownAnswer(t *testing.T) {
+	t.Parallel()
+	// Lock down the exact wire format (8-byte big-endian length prefix
+	// followed by the value bytes) by hashing the same byte sequence by
+	// hand and comparing. Any change to the hashing protocol will break
+	// this test and force a deliberate update.
+	values := [][]byte{[]byte("ca-cert-bytes"), []byte("ca-crl-bytes")}
+
+	h := sha256.New()
+	var lenBuf [8]byte
+	for _, v := range values {
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(v)))
+		_, _ = h.Write(lenBuf[:])
+		_, _ = h.Write(v)
+	}
+	want := hex.EncodeToString(h.Sum(nil))
+
+	if got := ComputeContentHash(values...); got != want {
+		t.Errorf("ComputeContentHash(%q): got %q, want %q", values, got, want)
+	}
+}
+
+func TestComputeContentHash_DistinguishesBoundaries(t *testing.T) {
+	t.Parallel()
+	// Without length-prefixing, ("ab", "") and ("a", "b") would produce
+	// identical concatenated bytes and therefore identical digests.
+	if ComputeContentHash([]byte("ab"), []byte("")) == ComputeContentHash([]byte("a"), []byte("b")) {
+		t.Fatalf(`expected different digests for ("ab","") vs ("a","b")`)
+	}
+}
+
+func TestComputeContentHash_PositionalOrderMatters(t *testing.T) {
+	t.Parallel()
+	// Argument order is part of the input — swapping must produce a
+	// different digest so callers can distinguish e.g. (caCert, crl) from
+	// (crl, caCert).
+	a := []byte("first")
+	b := []byte("second")
+	if ComputeContentHash(a, b) == ComputeContentHash(b, a) {
+		t.Fatalf("expected order-sensitive digest, but swapping arguments produced the same hash")
+	}
+}
+
+func TestComputeContentHash_ChangesOnValueUpdate(t *testing.T) {
+	t.Parallel()
+	if ComputeContentHash([]byte("old-ca")) == ComputeContentHash([]byte("new-ca")) {
+		t.Fatalf("expected different digests when value bytes change")
+	}
+}
+
+func TestComputeContentHash_NilEqualsEmpty(t *testing.T) {
+	t.Parallel()
+	// nil and []byte{} are both zero-length so they must hash identically
+	// (the length prefix is the same and there are no value bytes). This
+	// pins the documented behaviour and prevents accidental divergence.
+	if ComputeContentHash(nil) != ComputeContentHash([]byte{}) {
+		t.Fatalf("expected nil and empty slice to hash identically")
+	}
+}


### PR DESCRIPTION
### Proposed changes



When the CA Secret referenced by a Policy resource's `ingressMTLS` block is updated (e.g. to rotate the CA certificate), the on-disk CA file is rewritten but NGINX continues to use the previously-loaded CA in memory until some unrelated event triggers a reload. This can leave clients authenticating against a stale CA for an indeterminate amount of time.

With [ssl-dynamic-reload](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/command-line-arguments/#-ssl-dynamic-reload) enabled (the default), `handleSecretUpdate` only reloads NGINX when the rendered config bytes change. The `ssl_client_certificate` directive uses a static file path, so a CA secret update rewrites the file on disk without changing the rendered config — and the reload is skipped. 

Dynamic SSL reload only covers the server cert directives (`ssl_certificate` / `ssl_certificate_key`) via the variable-path mechanism; `ssl_client_certificate` is parsed into NGINX memory at config-load time and requires a reload to pick up new content.

Proposed fix: embed a stable SHA-256 digest of the secret's Data payload in the rendered NGINX config as a comment adjacent to the `ssl_client_certificate` directive. When the CA secret is rotated the digest changes, the rendered config differs, the existing `configsChanged` detection path picks it up, and a reload is triggered. Dynamic SSL reload for server certs is left untouched.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
