### PR TITLE
Add nodePort for LoadBalancer only if allocateLoadBalancerNodePorts

### DIFF
--- a/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/nginx-ingress/templates/controller-service.yaml
@@ -54,7 +54,7 @@ spec:
     targetPort: {{ .Values.controller.service.httpPort.targetPort }}
     protocol: TCP
     name: {{ .Values.controller.service.httpPort.name }}
-  {{- if or (eq .Values.controller.service.type "LoadBalancer") (eq .Values.controller.service.type "NodePort") }}
+  {{- if or (eq .Values.controller.service.type "NodePort") (and (eq .Values.controller.service.type "LoadBalancer") (ternary .Values.controller.service.allocateLoadBalancerNodePorts true (hasKey .Values.controller.service "allocateLoadBalancerNodePorts"))) }}
     nodePort: {{ .Values.controller.service.httpPort.nodePort }}
   {{- end }}
 {{- end }}
@@ -63,7 +63,7 @@ spec:
     targetPort: {{ .Values.controller.service.httpsPort.targetPort }}
     protocol: TCP
     name: {{ .Values.controller.service.httpsPort.name }}
-  {{- if or (eq .Values.controller.service.type "LoadBalancer") (eq .Values.controller.service.type "NodePort") }}
+  {{- if or (eq .Values.controller.service.type "NodePort") (and (eq .Values.controller.service.type "LoadBalancer") (ternary .Values.controller.service.allocateLoadBalancerNodePorts true (hasKey .Values.controller.service "allocateLoadBalancerNodePorts"))) }}
     nodePort: {{ .Values.controller.service.httpsPort.nodePort }}
   {{- end }}
 {{- end }}

--- a/charts/nginx-ingress/values.schema.json
+++ b/charts/nginx-ingress/values.schema.json
@@ -1443,7 +1443,7 @@
               ]
             },
             "allocateLoadBalancerNodePorts": {
-              "default": false,
+              "default": true,
               "title": "The allocateLoadBalancerNodePorts Schema",
               "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.35.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/allocateLoadBalancerNodePorts"
             },

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -518,7 +518,7 @@ controller:
     loadBalancerSourceRanges: []
 
     ## Whether to automatically allocate NodePorts (only for LoadBalancers).
-    # allocateLoadBalancerNodePorts: false
+    # allocateLoadBalancerNodePorts: true
 
     ## Dual stack preference.
     ## Valid values: SingleStack, PreferDualStack, RequireDualStack


### PR DESCRIPTION
### Proposed changes

In v3.7.0 the chart started to set nodePort field for LoadBalancer service type in addition to NodePort type. But if we disable allocateLoadBalancerNodePorts, we don't need to set nodePorts.

Also, allocateLoadBalancerNodePorts is true by default (in k8s), not false.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
