### PR TITLE
fix Unguarded conflict between pathType: Exact and nginx.org/path-regex annotation

### DIFF
--- a/internal/configs/version1/template_helper.go
+++ b/internal/configs/version1/template_helper.go
@@ -30,7 +30,7 @@ func makeLocationPath(loc *Location, ingressAnnotations map[string]string) strin
 		regexType, hasRegex := loc.MinionIngress.Annotations["nginx.org/path-regex"]
 
 		if isMergeable && ingressType == "minion" && hasRegex {
-			return makePathWithRegex(loc.Path, regexType)
+			return applyPathRegex(loc.Path, regexType)
 		}
 		if isMergeable && ingressType == "minion" && !hasRegex {
 			return loc.Path
@@ -42,7 +42,17 @@ func makeLocationPath(loc *Location, ingressAnnotations map[string]string) strin
 	if !ok {
 		return loc.Path
 	}
-	return makePathWithRegex(loc.Path, regexType)
+	return applyPathRegex(loc.Path, regexType)
+}
+
+// applyPathRegex applies a path-regex annotation to a location path.
+// If the path was already produced as an exact match location (`= /path`),
+// preserve it as-is to avoid generating an invalid regex location.
+func applyPathRegex(path, regexType string) string {
+	if strings.HasPrefix(strings.TrimSpace(path), "= ") {
+		return path
+	}
+	return makePathWithRegex(path, regexType)
 }
 
 // makePathWithRegex takes a path representing a location and a regexType

--- a/internal/configs/version1/template_helper_test.go
+++ b/internal/configs/version1/template_helper_test.go
@@ -45,6 +45,19 @@ func TestMakeLocationPath_WithRegexExactModifier(t *testing.T) {
 	}
 }
 
+func TestMakeLocationPath_PathRegexSetDoesNotModifyExactPath(t *testing.T)  {
+	t.Parallel()
+
+	want := "= /coffee"
+	got := makeLocationPath(
+		&Location{Path: "= /coffee"},
+		map[string]string{"nginx.org/path-regex": "case_sensitive"},
+	)
+	if got != want {
+		t.Errorf("got: %s, want: %s", got, want)
+	}
+}
+
 func TestMakeLocationPath_WithBogusRegexModifier(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Proposed changes

- Copied almost entirely from a closed PR (https://github.com/nginx/kubernetes-ingress/pull/9766) 
- Otherwise, if path-regex is set (case_sensitive or case_insensitive) and there is a Ingress path with PathType exact then the generated location block is invalid 
- Previously generated a block like this `location ~ "\^= <url path>" {}` which cannot match any URL (it's matching the literal path `= <url path>` and valid URL paths cannot contain ` ` or `=` characters) 
- If the Ingress rule has PathType = Exact then we should just ignore the regex directive on the parent Ingress and match the path literally

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
