### PR TITLE
fix illegal keyword path validation rejecting paths containing /var or /root as substring

### DIFF
--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -1399,11 +1399,11 @@ func ValidateEscapedString(body string, examples ...string) error {
 }
 
 const (
-	illegalKeywordFmt    = `/etc/|/root|/var|\\n|\\r`
+	illegalKeywordFmt    = `^/etc/|^/root(?:/|$)|^/var(?:/|$)|\\n|\\r$`
 	illegalKeywordErrMsg = `must not contain invalid paths`
 )
 
-var illegalKeywordFmtRegexp = regexp.MustCompile("^" + illegalKeywordFmt + "$")
+var illegalKeywordFmtRegexp = regexp.MustCompile(illegalKeywordFmt)
 
 func validateIllegalKeywords(path string, fieldPath *field.Path) field.ErrorList {
 	if illegalKeywordFmtRegexp.MatchString(path) {

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -6129,8 +6129,11 @@ func TestValidateIllegalKeywords(t *testing.T) {
 
 	invalidPaths := []string{
 		"/root",
+		"/root/",
+		"/root/.ssh",
 		"/etc/nginx/secrets",
 		"/etc/passwd",
+		"/var",
 		"/var/run/secrets",
 		`\n`,
 		`\r`,
@@ -6139,7 +6142,27 @@ func TestValidateIllegalKeywords(t *testing.T) {
 	for _, path := range invalidPaths {
 		allErrs := validateIllegalKeywords(path, field.NewPath("path"))
 		if len(allErrs) == 0 {
-			t.Errorf("validateCurlyBraces(%q) returned no errors for invalid input", path)
+			t.Errorf("validateIllegalKeywords(%q) returned no errors for invalid input", path)
+		}
+	}
+
+	validPaths := []string{
+		"/variables",
+		"/var-config",
+		"/manager/variables",
+		"/api/variables/list",
+		"/rootpage",
+		"/root-cause",
+		"/tree/root",
+		"/etcetera",
+		"/etcd",
+		"/fetch",
+	}
+
+	for _, path := range validPaths {
+		allErrs := validateIllegalKeywords(path, field.NewPath("path"))
+		if len(allErrs) != 0 {
+			t.Errorf("validateIllegalKeywords(%q) returned errors %v for valid input", path, allErrs)
 		}
 	}
 }


### PR DESCRIPTION
### Proposed changes

Fixes #10175

The `illegalKeywordFmt` regex in [internal/k8s/validation.go](https://github.com/nginx/kubernetes-ingress/blob/main/internal/k8s/validation.go#L1401-L1406) has an alternation precedence problem. The constant

    `/etc/|/root|/var|\\n|\\r`

is compiled as `"^" + fmt + "$"`, but since `|` has the lowest precedence in regular expressions, the `^` only anchors `/etc/` and the `$` only anchors `\\r`. This causes `/root` and `/var` to match as unanchored substrings, rejecting valid Ingress paths like `/variables`, `/var-config` or `/rootpage` with:

    spec.rules[0].http.path[0].path: Invalid value: "/variables": must not contain invalid paths

This change replaces the regex with a self-contained expression that embeds its own anchors, removing the `"^" + fmt + "$"` wrapping:

    `^/etc/|^/root(?:/|$)|^/var(?:/|$)|\\n|\\r$`
 
Each directory keyword is now anchored to match only as a leading path segment, while `\n` and `\r` remain matched anywhere / at end-of-string respectively — preserving existing behaviour.

### Behaviour before / after:

| Path | Before | After |
|------|--------|-------|
| `/root`, `/root/.ssh` | blocked ❌ | blocked ❌ |
| `/etc/passwd`, `/etc/nginx/secrets` | blocked ❌ | blocked ❌ |
| `/var`, `/var/run/secrets` | blocked ❌ | blocked ❌ |
| `/variables`, `/var-config` | blocked ❌ | allowed ✅ |
| `/manager/variables`, `/api/variables/list` | blocked ❌ | allowed ✅ |
| `/rootpage`, `/root-cause`, `/tree/root` | blocked ❌ | allowed ✅ |
| `/etcetera`, `/etcd` | allowed ✅ | allowed ✅ |

Notes:

- All test cases from the original PR #3094 still pass unchanged. The security
  intent (blocking paths that point at sensitive directories, see the hardening
  done around CVE-2022-30535) is preserved — only the unintended substring
  matching is removed.
- Added regression tests for both directions: paths that must stay blocked and paths that must no longer be rejected.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork