### PR TITLE
filter by only ingress controller events when updating status

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -2521,6 +2521,7 @@ func (lbc *LoadBalancerController) updateVirtualServersStatusFromEvents() error 
 			var latestEvent api_v1.Event
 			for _, event := range events.Items {
 				if event.CreationTimestamp.After(timestamp) && event.ReportingController == EventReporterName {
+					timestamp = event.CreationTimestamp.Time
 					latestEvent = event
 				}
 			}
@@ -2564,7 +2565,8 @@ func (lbc *LoadBalancerController) updateVirtualServerRoutesStatusFromEvents() e
 			var timestamp time.Time
 			var latestEvent api_v1.Event
 			for _, event := range events.Items {
-				if event.CreationTimestamp.After(timestamp) {
+				if event.CreationTimestamp.After(timestamp) && event.ReportingController == EventReporterName {
+					timestamp = event.CreationTimestamp.Time
 					latestEvent = event
 				}
 			}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -78,6 +78,8 @@ const (
 	ingressClassKey = "kubernetes.io/ingress.class"
 	// IngressControllerName holds Ingress Controller name
 	IngressControllerName = "nginx.org/ingress-controller"
+	// EventReporterName
+	EventReporterName = "nginx-ingress-controller"
 
 	typeKeyword                                     = "type"
 	helmReleaseType                                 = "helm.sh/release.v1"
@@ -2518,7 +2520,7 @@ func (lbc *LoadBalancerController) updateVirtualServersStatusFromEvents() error 
 			var timestamp time.Time
 			var latestEvent api_v1.Event
 			for _, event := range events.Items {
-				if event.CreationTimestamp.After(timestamp) {
+				if event.CreationTimestamp.After(timestamp) && event.ReportingController == EventReporterName {
 					latestEvent = event
 				}
 			}

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nginx/kubernetes-ingress/internal/metrics/collectors"
 	"github.com/nginx/kubernetes-ingress/internal/nginx"
 	conf_v1 "github.com/nginx/kubernetes-ingress/pkg/apis/configuration/v1"
+	fake_versioned "github.com/nginx/kubernetes-ingress/pkg/client/clientset/versioned/fake"
 	api_v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -4740,6 +4741,422 @@ func TestGenerateExternalAuthEndpoints(t *testing.T) {
 				if !reflect.DeepEqual(gotEps, expectedEps) {
 					t.Errorf("key %q: expected %v, got %v", key, expectedEps, gotEps)
 				}
+			}
+		})
+	}
+}
+
+func TestUpdateVirtualServersStatusFromEvents_FiltersEventsByReportingController(t *testing.T) {
+	t.Parallel()
+
+	vsName := "test-vs"
+	vsNamespace := "default"
+
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		events         []api_v1.Event
+		expectedState  string
+		expectedReason string
+	}{
+		{
+			name: "only NIC event - should use NIC event",
+			events: []api_v1.Event{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-nic",
+						Namespace:         vsNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsName,
+						UID:  "test-vs-uid",
+					},
+					Reason:              "AddedOrUpdated",
+					Message:             "Configuration for VirtualServer was added or updated",
+					ReportingController: EventReporterName,
+				},
+			},
+			expectedState:  conf_v1.StateValid,
+			expectedReason: "AddedOrUpdated",
+		},
+		{
+			name: "third-party event newer than NIC event - should ignore third-party and use NIC event",
+			events: []api_v1.Event{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-nic",
+						Namespace:         vsNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime.Add(-1 * time.Minute)),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsName,
+						UID:  "test-vs-uid",
+					},
+					Reason:              "AddedOrUpdated",
+					Message:             "Configuration for VirtualServer was added or updated",
+					ReportingController: EventReporterName,
+				},
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-kyverno",
+						Namespace:         vsNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsName,
+						UID:  "test-vs-uid",
+					},
+					Reason:              "PolicyViolation",
+					Message:             "policy ns-policy/require-labels: validation error",
+					ReportingController: "kyverno-admission",
+				},
+			},
+			expectedState:  conf_v1.StateValid,
+			expectedReason: "AddedOrUpdated",
+		},
+		{
+			name: "only third-party events - should not update status (empty state)",
+			events: []api_v1.Event{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-kyverno",
+						Namespace:         vsNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsName,
+						UID:  "test-vs-uid",
+					},
+					Reason:              "PolicyViolation",
+					Message:             "policy ns-policy/require-labels: validation error",
+					ReportingController: "kyverno-admission",
+				},
+			},
+			expectedState:  "",
+			expectedReason: "",
+		},
+		{
+			name: "multiple NIC events - should use latest NIC event",
+			events: []api_v1.Event{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-nic-old",
+						Namespace:         vsNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime.Add(-2 * time.Minute)),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsName,
+						UID:  "test-vs-uid",
+					},
+					Reason:              "AddedOrUpdatedWithError",
+					Message:             "Configuration was rejected",
+					ReportingController: EventReporterName,
+				},
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-nic-new",
+						Namespace:         vsNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsName,
+						UID:  "test-vs-uid",
+					},
+					Reason:              "AddedOrUpdated",
+					Message:             "Configuration for VirtualServer was added or updated",
+					ReportingController: EventReporterName,
+				},
+			},
+			expectedState:  conf_v1.StateValid,
+			expectedReason: "AddedOrUpdated",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			vs := &conf_v1.VirtualServer{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      vsName,
+					Namespace: vsNamespace,
+					UID:       "test-vs-uid",
+				},
+				Spec: conf_v1.VirtualServerSpec{
+					Host: "test.example.com",
+				},
+				Status: conf_v1.VirtualServerStatus{
+					State:   "initial",
+					Reason:  "initial",
+					Message: "initial",
+				},
+			}
+
+			var runtimeObjects []runtime.Object
+			for i := range tc.events {
+				runtimeObjects = append(runtimeObjects, &tc.events[i])
+			}
+			fakeK8sClient := fake.NewClientset(runtimeObjects...)
+
+			fakeConfClient := fake_versioned.NewSimpleClientset(
+				&conf_v1.VirtualServerList{
+					Items: []conf_v1.VirtualServer{*vs},
+				},
+			)
+
+			vsLister := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+			err := vsLister.Add(vs)
+			if err != nil {
+				t.Fatalf("Error adding VirtualServer to lister: %v", err)
+			}
+
+			nsi := map[string]*namespacedInformer{
+				vsNamespace: {
+					virtualServerLister:       vsLister,
+					areCustomResourcesEnabled: true,
+				},
+			}
+
+			su := &statusUpdater{
+				namespacedInformers: nsi,
+				confClient:          fakeConfClient,
+				keyFunc:             cache.DeletionHandlingMetaNamespaceKeyFunc,
+				logger:              nl.LoggerFromContext(context.Background()),
+			}
+
+			lbc := &LoadBalancerController{
+				client:              fakeK8sClient,
+				ingressClass:        "nginx",
+				namespacedInformers: nsi,
+				statusUpdater:       su,
+				Logger:              nl.LoggerFromContext(context.Background()),
+			}
+
+			err = lbc.updateVirtualServersStatusFromEvents()
+			if err != nil {
+				t.Fatalf("updateVirtualServersStatusFromEvents() returned error: %v", err)
+			}
+
+			updatedVs, err := fakeConfClient.K8sV1().VirtualServers(vsNamespace).Get(context.TODO(), vsName, meta_v1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Error getting VirtualServer: %v", err)
+			}
+
+			if updatedVs.Status.State != tc.expectedState {
+				t.Errorf("expected state %q, got %q", tc.expectedState, updatedVs.Status.State)
+			}
+			if updatedVs.Status.Reason != tc.expectedReason {
+				t.Errorf("expected reason %q, got %q", tc.expectedReason, updatedVs.Status.Reason)
+			}
+		})
+	}
+}
+
+func TestUpdateVirtualServerRoutesStatusFromEvents_FiltersEventsByReportingController(t *testing.T) {
+	t.Parallel()
+
+	vsrName := "test-vsr"
+	vsrNamespace := "default"
+
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		events         []api_v1.Event
+		expectedState  string
+		expectedReason string
+	}{
+		{
+			name: "only NIC event - should use NIC event",
+			events: []api_v1.Event{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-nic",
+						Namespace:         vsrNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsrName,
+						UID:  "test-vsr-uid",
+					},
+					Reason:              "AddedOrUpdated",
+					Message:             "Configuration for VirtualServerRoute was added or updated",
+					ReportingController: EventReporterName,
+				},
+			},
+			expectedState:  conf_v1.StateValid,
+			expectedReason: "AddedOrUpdated",
+		},
+		{
+			name: "third-party event newer than NIC event - should ignore third-party and use NIC event",
+			events: []api_v1.Event{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-nic",
+						Namespace:         vsrNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime.Add(-1 * time.Minute)),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsrName,
+						UID:  "test-vsr-uid",
+					},
+					Reason:              "AddedOrUpdated",
+					Message:             "Configuration for VirtualServerRoute was added or updated",
+					ReportingController: EventReporterName,
+				},
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-kyverno",
+						Namespace:         vsrNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsrName,
+						UID:  "test-vsr-uid",
+					},
+					Reason:              "PolicyViolation",
+					Message:             "policy ns-policy/require-labels: validation error",
+					ReportingController: "kyverno-admission",
+				},
+			},
+			expectedState:  conf_v1.StateValid,
+			expectedReason: "AddedOrUpdated",
+		},
+		{
+			name: "only third-party events - should not update status (empty state)",
+			events: []api_v1.Event{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-kyverno",
+						Namespace:         vsrNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsrName,
+						UID:  "test-vsr-uid",
+					},
+					Reason:              "PolicyViolation",
+					Message:             "policy ns-policy/require-labels: validation error",
+					ReportingController: "kyverno-admission",
+				},
+			},
+			expectedState:  "",
+			expectedReason: "",
+		},
+		{
+			name: "multiple NIC events - should use latest NIC event",
+			events: []api_v1.Event{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-nic-old",
+						Namespace:         vsrNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime.Add(-2 * time.Minute)),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsrName,
+						UID:  "test-vsr-uid",
+					},
+					Reason:              "AddedOrUpdatedWithError",
+					Message:             "Configuration was rejected",
+					ReportingController: EventReporterName,
+				},
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:              "event-nic-new",
+						Namespace:         vsrNamespace,
+						CreationTimestamp: meta_v1.NewTime(baseTime),
+					},
+					InvolvedObject: api_v1.ObjectReference{
+						Name: vsrName,
+						UID:  "test-vsr-uid",
+					},
+					Reason:              "AddedOrUpdated",
+					Message:             "Configuration for VirtualServerRoute was added or updated",
+					ReportingController: EventReporterName,
+				},
+			},
+			expectedState:  conf_v1.StateValid,
+			expectedReason: "AddedOrUpdated",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			vsr := &conf_v1.VirtualServerRoute{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      vsrName,
+					Namespace: vsrNamespace,
+					UID:       "test-vsr-uid",
+				},
+				Spec: conf_v1.VirtualServerRouteSpec{
+					Host: "test.example.com",
+				},
+				Status: conf_v1.VirtualServerRouteStatus{
+					State:   "initial",
+					Reason:  "initial",
+					Message: "initial",
+				},
+			}
+
+			var runtimeObjects []runtime.Object
+			for i := range tc.events {
+				runtimeObjects = append(runtimeObjects, &tc.events[i])
+			}
+			fakeK8sClient := fake.NewClientset(runtimeObjects...)
+
+			fakeConfClient := fake_versioned.NewSimpleClientset(
+				&conf_v1.VirtualServerRouteList{
+					Items: []conf_v1.VirtualServerRoute{*vsr},
+				},
+			)
+
+			vsrLister := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+			err := vsrLister.Add(vsr)
+			if err != nil {
+				t.Fatalf("Error adding VirtualServerRoute to lister: %v", err)
+			}
+
+			nsi := map[string]*namespacedInformer{
+				vsrNamespace: {
+					virtualServerRouteLister:  vsrLister,
+					areCustomResourcesEnabled: true,
+				},
+			}
+
+			su := &statusUpdater{
+				namespacedInformers: nsi,
+				confClient:          fakeConfClient,
+				keyFunc:             cache.DeletionHandlingMetaNamespaceKeyFunc,
+				logger:              nl.LoggerFromContext(context.Background()),
+			}
+
+			lbc := &LoadBalancerController{
+				client:              fakeK8sClient,
+				ingressClass:        "nginx",
+				namespacedInformers: nsi,
+				statusUpdater:       su,
+				Logger:              nl.LoggerFromContext(context.Background()),
+			}
+
+			err = lbc.updateVirtualServerRoutesStatusFromEvents()
+			if err != nil {
+				t.Fatalf("updateVirtualServerRoutesStatusFromEvents() returned error: %v", err)
+			}
+
+			updatedVsr, err := fakeConfClient.K8sV1().VirtualServerRoutes(vsrNamespace).Get(context.TODO(), vsrName, meta_v1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Error getting VirtualServerRoute: %v", err)
+			}
+
+			if updatedVsr.Status.State != tc.expectedState {
+				t.Errorf("expected state %q, got %q", tc.expectedState, updatedVsr.Status.State)
+			}
+			if updatedVsr.Status.Reason != tc.expectedReason {
+				t.Errorf("expected reason %q, got %q", tc.expectedReason, updatedVsr.Status.Reason)
 			}
 		})
 	}

--- a/internal/k8s/transport_server.go
+++ b/internal/k8s/transport_server.go
@@ -194,8 +194,9 @@ func (lbc *LoadBalancerController) updateTransportServersStatusFromEvents() erro
 			var timestamp time.Time
 			var latestEvent api_v1.Event
 			for _, event := range events.Items {
-				if event.CreationTimestamp.After(timestamp) {
+				if event.ReportingController == EventReporterName && event.CreationTimestamp.After(timestamp) {
 					latestEvent = event
+					timestamp = event.CreationTimestamp.Time
 				}
 			}
 


### PR DESCRIPTION
### Proposed changes
# PR: Filter events by reporting controller when updating VirtualServer/VirtualServerRoute status

## Summary

This PR fixes a bug where VirtualServer and VirtualServerRoute resources could have their `status.state` field overwritten with an empty string during leader election, and their `status.reason` and `status.message` fields polluted with messages from third-party controllers.

## Problem

When a new leader is elected, the controller calls `updateVirtualServersStatusFromEvents()` and `updateVirtualServerRoutesStatusFromEvents()` to restore status from Kubernetes events. The functions find the latest event for each resource and derive the status from the event's `Reason` field using `getStatusFromEventTitle()`.

The bug occurs because:

1. The functions iterated over **all** events for a VirtualServer/VirtualServerRoute, not just events created by the ingress controller
2. Third-party controllers (e.g., Kyverno) create events on these resources with their own `Reason` values (e.g., `PolicyViolation`)
3. `getStatusFromEventTitle()` returns an empty string for unrecognized event reasons
4. If a third-party event is the most recent event, the status is updated with `state: ""`

### Trigger Scenario

1. VirtualServer exists with valid `status.state` (e.g., "Valid")
2. Kyverno evaluates the VirtualServer and creates a `PolicyViolation` event
3. Leader election occurs (pod restart, scaling, etc.)
4. New leader calls `updateVirtualServersStatusFromEvents()`
5. Kyverno's `PolicyViolation` event is the most recent event
6. `getStatusFromEventTitle("PolicyViolation")` returns `""`
7. Status is updated with empty `state`, overwriting the valid state

## Solution

Filter events to only consider those created by the ingress controller by checking `event.ReportingController == EventReporterName`. 

Additionally, fixed a bug where the timestamp variable wasn't being updated in the loop, which could cause incorrect "latest" event selection when multiple NIC events exist.

## Changes

### `internal/k8s/controller.go`

**`updateVirtualServersStatusFromEvents()`** (line ~2488):
- Added `timestamp = event.CreationTimestamp.Time` to correctly track the latest event timestamp

**`updateVirtualServerRoutesStatusFromEvents()`** (line ~2533):
- Added `&& event.ReportingController == EventReporterName` filter condition
- Added `timestamp = event.CreationTimestamp.Time` to correctly track the latest event timestamp

### `internal/k8s/controller_test.go`

Added two new test functions with 4 test cases each:

- `TestUpdateVirtualServersStatusFromEvents_FiltersEventsByReportingController`
- `TestUpdateVirtualServerRoutesStatusFromEvents_FiltersEventsByReportingController`

Test cases cover:
1. Only NIC event - should use NIC event
2. Third-party event newer than NIC event - should ignore third-party and use NIC event
3. Only third-party events - should not update status (empty state)
4. Multiple NIC events - should use latest NIC event by timestamp

## Testing

```bash
go test -v -run "TestUpdateVirtualServersStatusFromEvents_FiltersEventsByReportingController|TestUpdateVirtualServerRoutesStatusFromEvents_FiltersEventsByReportingController" ./internal/k8s/...
```

All 8 test cases pass.

## Related Issue

Fixes #10229


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
