### PR TITLE
fix oidc with config safety

### DIFF
--- a/internal/configs/configurator.go
+++ b/internal/configs/configurator.go
@@ -758,22 +758,29 @@ func (cnf *Configurator) addOrUpdateVirtualServer(virtualServerEx *VirtualServer
 	if err != nil {
 		return false, warnings, weightUpdates, fmt.Errorf("error generating VirtualServer config: %v: %w", name, err)
 	}
+
+	// Order matters only when -enable-config-safety=true: ConfigRollbackManager.CreateConfig
+	// runs `nginx -t` deletes the new file on failure.
+	// VS template emits `include oidc-conf.d/oidc_<ns>_<vs>.conf;`, so the OIDC config must
+	// exist on disk before the VS config is written. Without config safety the order is
+	// immaterial because validation only runs at Reload().
+	var oidcChanged bool
+	if vsCfg.Server.OIDC != nil {
+		oidcName := getFileNameForOIDCVirtualServer(virtualServerEx.VirtualServer)
+
+		oidcContent, err := cnf.templateExecutorV2.ExecuteOIDCTemplate(vsCfg.Server.OIDC)
+		if err != nil {
+			return false, warnings, weightUpdates, fmt.Errorf("error generating VirtualServer OIDC config: %v: %w", oidcName, err)
+		}
+		oidcChanged = cnf.nginxManager.CreateOIDCConfig(oidcName, oidcContent)
+	}
+
 	changed, err := cnf.nginxManager.CreateConfig(name, content)
 	if err != nil {
 		return false, warnings, weightUpdates, fmt.Errorf("error validating VirtualServer config %v: %w", name, err)
 	}
-
-	if vsCfg.Server.OIDC != nil {
-		name := getFileNameForOIDCVirtualServer(virtualServerEx.VirtualServer)
-
-		content, err := cnf.templateExecutorV2.ExecuteOIDCTemplate(vsCfg.Server.OIDC)
-		if err != nil {
-			return false, warnings, weightUpdates, fmt.Errorf("error generating VirtualServer OIDC config: %v: %w", name, err)
-		}
-		oidcChanged := cnf.nginxManager.CreateOIDCConfig(name, content)
-		if oidcChanged {
-			changed = true
-		}
+	if oidcChanged {
+		changed = true
 	}
 	cnf.virtualServers[name] = virtualServerEx
 

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -3670,3 +3672,175 @@ server {
     {{- end }}
 }`
 )
+
+// oidcIncludePattern matches the `include oidc-conf.d/<basename>.conf;` directive emitted by
+// the Plus VirtualServer template when Server.OIDC is set.
+var oidcIncludePattern = regexp.MustCompile(`include oidc-conf\.d/([^;\s]+)\.conf;`)
+
+// configSafetyEnabledFakeManager simulates the ConfigRollbackManager behavior that is active
+// only when the controller runs with -enable-config-safety=true: every CreateConfig call runs
+// `nginx -t` synchronously and fails if any `include oidc-conf.d/*.conf;` directive points at
+// a file that has not yet been written.
+// With config safety disabled, LocalManager.CreateConfig just writes the file and the validation
+// is deferred to Reload().
+type configSafetyEnabledFakeManager struct {
+	*nginx.FakeManager
+	mu          sync.Mutex
+	writtenOIDC map[string]bool
+	oidcCalls   int
+	vsCalls     int
+}
+
+func (m *configSafetyEnabledFakeManager) CreateOIDCConfig(name string, content []byte) bool {
+	m.mu.Lock()
+	if m.writtenOIDC == nil {
+		m.writtenOIDC = map[string]bool{}
+	}
+	m.writtenOIDC[name] = true
+	m.oidcCalls++
+	m.mu.Unlock()
+	return m.FakeManager.CreateOIDCConfig(name, content)
+}
+
+func (m *configSafetyEnabledFakeManager) CreateConfig(name string, content []byte) (bool, error) {
+	for _, match := range oidcIncludePattern.FindAllSubmatch(content, -1) {
+		included := string(match[1])
+		m.mu.Lock()
+		present := m.writtenOIDC[included]
+		m.mu.Unlock()
+		if !present {
+			return false, fmt.Errorf(
+				`nginx: [emerg] open() "/etc/nginx/oidc-conf.d/%s.conf" failed (2: No such file or directory) in /etc/nginx/conf.d/%s.conf`,
+				included, name,
+			)
+		}
+	}
+	m.mu.Lock()
+	m.vsCalls++
+	m.mu.Unlock()
+	return m.FakeManager.CreateConfig(name, content)
+}
+
+func createOIDCVirtualServerEx() *VirtualServerEx {
+	return &VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "cafe",
+				Namespace: "default",
+			},
+			Spec: conf_v1.VirtualServerSpec{
+				Host: "cafe.example.com",
+				Policies: []conf_v1.PolicyReference{
+					{Name: "oidc-policy"},
+				},
+				Upstreams: []conf_v1.Upstream{
+					{Name: "tea", Service: "tea-svc", Port: 80},
+				},
+				Routes: []conf_v1.Route{
+					{Path: "/tea", Action: &conf_v1.Action{Pass: "tea"}},
+				},
+			},
+		},
+		Policies: map[string]*conf_v1.Policy{
+			"default/oidc-policy": {
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "oidc-policy",
+					Namespace: "default",
+				},
+				Spec: conf_v1.PolicySpec{
+					OIDC: &conf_v1.OIDC{
+						AuthEndpoint:  "https://auth.example.com",
+						TokenEndpoint: "https://token.example.com",
+						JWKSURI:       "https://jwks.example.com",
+						ClientID:      "example-client-id",
+						ClientSecret:  "example-client-secret",
+						Scope:         "openid",
+					},
+				},
+			},
+		},
+		Endpoints: map[string][]string{
+			"default/tea-svc:80": {"10.0.0.10:80"},
+		},
+		SecretRefs: map[string]*secrets.SecretReference{
+			"default/example-client-secret": {
+				Secret: &api_v1.Secret{
+					Type: secrets.SecretTypeOIDC,
+					Data: map[string][]byte{
+						"client-secret": []byte("c2VjcmV0"),
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestAddOrUpdateVirtualServer_WithOIDCAndConfigSafetyEnabled_AppliesSuccessfully is the
+// test to make sure oidc config is written before the virtual server config when -enable-config-safety is enabled.
+func TestAddOrUpdateVirtualServer_WithOIDCAndConfigSafetyEnabled_AppliesSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	manager := &configSafetyEnabledFakeManager{FakeManager: nginx.NewFakeManager("/etc/nginx")}
+	cnf := createTestConfiguratorWithManager(t, manager)
+	cnf.isPlus = true
+
+	vsEx := createOIDCVirtualServerEx()
+
+	if _, err := cnf.AddOrUpdateVirtualServer(vsEx); err != nil {
+		t.Fatalf("AddOrUpdateVirtualServer failed under -enable-config-safety (OIDC config likely written after VS config): %v", err)
+	}
+
+	if manager.oidcCalls != 1 {
+		t.Errorf("expected exactly one CreateOIDCConfig call, got %d", manager.oidcCalls)
+	}
+	if manager.vsCalls != 1 {
+		t.Errorf("expected exactly one CreateConfig call for the VS, got %d", manager.vsCalls)
+	}
+
+	wantOIDC := getFileNameForOIDCVirtualServer(vsEx.VirtualServer)
+	if !manager.writtenOIDC[wantOIDC] {
+		t.Errorf("expected OIDC config %q to be written, written set: %v", wantOIDC, manager.writtenOIDC)
+	}
+}
+
+// TestAddOrUpdateVirtualServer_WithoutOIDCAndConfigSafetyEnabled_DoesNotWriteOIDCConfig
+// is the test to make sure oidc config is not written when the virtual server does not have OIDC and -enable-config-safety is enabled.
+func TestAddOrUpdateVirtualServer_WithoutOIDCAndConfigSafetyEnabled_DoesNotWriteOIDCConfig(t *testing.T) {
+	t.Parallel()
+
+	manager := &configSafetyEnabledFakeManager{FakeManager: nginx.NewFakeManager("/etc/nginx")}
+	cnf := createTestConfiguratorWithManager(t, manager)
+	cnf.isPlus = true
+
+	vsEx := &VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "cafe",
+				Namespace: "default",
+			},
+			Spec: conf_v1.VirtualServerSpec{
+				Host: "cafe.example.com",
+				Upstreams: []conf_v1.Upstream{
+					{Name: "tea", Service: "tea-svc", Port: 80},
+				},
+				Routes: []conf_v1.Route{
+					{Path: "/tea", Action: &conf_v1.Action{Pass: "tea"}},
+				},
+			},
+		},
+		Endpoints: map[string][]string{
+			"default/tea-svc:80": {"10.0.0.10:80"},
+		},
+	}
+
+	if _, err := cnf.AddOrUpdateVirtualServer(vsEx); err != nil {
+		t.Fatalf("AddOrUpdateVirtualServer returned unexpected error: %v", err)
+	}
+
+	if manager.oidcCalls != 0 {
+		t.Errorf("expected no CreateOIDCConfig calls for a VS without OIDC, got %d", manager.oidcCalls)
+	}
+	if manager.vsCalls != 1 {
+		t.Errorf("expected exactly one CreateConfig call for the VS, got %d", manager.vsCalls)
+	}
+}

--- a/tests/suite/test_oidc.py
+++ b/tests/suite/test_oidc.py
@@ -159,9 +159,21 @@ def keycloak_setup(request, kube_apis, test_namespace, ingress_controller_endpoi
             },
             {"example": "virtual-server-tls", "app_type": "simple"},
             {"secure": False},
-        )
+        ),
+        (
+            {
+                "type": "complete",
+                "extra_args": [
+                    f"-enable-oidc",
+                    "-enable-config-safety",
+                ],
+            },
+            {"example": "virtual-server-tls", "app_type": "simple"},
+            {"secure": False},
+        ),
     ],
     indirect=True,
+    ids=["http_without_config_safety", "http_with_config_safety"],
 )
 class TestOIDCHttp:
     @pytest.mark.parametrize("configmap", [cm_src, cm_zs_src])
@@ -205,9 +217,21 @@ class TestOIDCHttp:
             },
             {"example": "virtual-server-tls", "app_type": "simple"},
             {"secure": True},
-        )
+        ),
+        (
+            {
+                "type": "complete",
+                "extra_args": [
+                    f"-enable-oidc",
+                    "-enable-config-safety",
+                ],
+            },
+            {"example": "virtual-server-tls", "app_type": "simple"},
+            {"secure": True},
+        ),
     ],
     indirect=True,
+    ids=["https_without_config_safety", "https_with_config_safety"],
 )
 class TestOIDCHttps:
     @pytest.mark.parametrize("configmap", [cm_src, cm_zs_src])


### PR DESCRIPTION
### Proposed changes

- Fixes oidc when config-safety is enabled

```
Events:
  Type     Reason                   Age   From                      Message
  ----     ------                   ----  ----                      -------
  Warning  AddedOrUpdatedWithError  24m   nginx-ingress-controller  Configuration for default/webapp was added or updated ; but was not applied: error adding or updating VirtualServer default/webapp:error validating VirtualServer config vs_default_webapp: configuration validation failed for vs_default_webapp: nginx: [emerg] open() "/etc/nginx/oidc-conf.d/oidc_default_webapp.conf" failed (2: No such file or directory) in /etc/nginx/conf.d/vs_default_webapp.conf:21
  Normal   AddedOrUpdated           20m   nginx-ingress-controller  Configuration for default/webapp was added or updated
```
Event 1: oidc with config-safety on in 5.5.1
Event 2: oidc with config-safety on in this branch

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
