### PR TITLE
Use CSPRNG base64url for PKCE secrets

### DIFF
--- a/internal/configs/oidc/openid_connect.js
+++ b/internal/configs/oidc/openid_connect.js
@@ -448,6 +448,11 @@ function initiateNewAuth(r) {
     r.return(302, r.variables.oidc_authz_endpoint + getAuthZArgs(r));
 }
 
+function randomB64url(size) {
+    return Buffer.from(crypto.getRandomValues(new Uint8Array(size)))
+        .toString('base64url');
+}
+
 // Generate the authorization request arguments
 function getAuthZArgs(r) {
     var c = require('crypto');
@@ -471,10 +476,8 @@ function getAuthZArgs(r) {
     ];
 
     if (r.variables.oidc_pkce_enable == 1) {
-        var pkce_code_verifier = c.createHmac('sha256', r.variables.oidc_hmac_key)
-            .update(String(Math.random())).digest('hex');
-        r.variables.pkce_id = c.createHash('sha256')
-            .update(String(Math.random())).digest('base64url');
+        var pkce_code_verifier = randomB64url(32);
+        r.variables.pkce_id = randomB64url(32);
         var pkce_code_challenge = c.createHash('sha256')
             .update(pkce_code_verifier).digest('base64url');
         r.variables.pkce_code_verifier = pkce_code_verifier;


### PR DESCRIPTION
Replace the HMAC/hash-wrapped Math.random() PKCE values with crypto.getRandomValues via a small randomB64url() helper. Hashing does not add entropy to a CSPRNG, and the 32 bytes from getRandomValues are a ready-to-use secret, so createHmac/createHash are dropped for the verifier and state (pkce_id). The code_challenge remains BASE64URL(SHA256(code_verifier)) as required by PKCE S256.

Adjusts the test assertion for code_verifier from 64-hex to 43-char base64url to match the new format.

Porting https://github.com/nginxinc/nginx-openid-connect/pull/127

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
