### PR TITLE
Remove archived nginx-service-mesh dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/nginx/nginx-plus-go-client/v3 v3.0.1
 	github.com/nginx/nginx-prometheus-exporter v1.5.1
 	github.com/nginx/telemetry-exporter v0.1.5
-	github.com/nginxinc/nginx-service-mesh v1.7.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spiffe/go-spiffe/v2 v2.8.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,6 @@ github.com/nginx/nginx-prometheus-exporter v1.5.1 h1:44jvKTJ4S0SydKbXw7H9V5VjcGd
 github.com/nginx/nginx-prometheus-exporter v1.5.1/go.mod h1:5b+M6fx4v6UQsihjrN/UeBBR2DabEsfgTjhqG/Xt12w=
 github.com/nginx/telemetry-exporter v0.1.5 h1:niCAHMii9a74UW3GuqpBt/n1/FIAKrZtTxtEH0MGSiU=
 github.com/nginx/telemetry-exporter v0.1.5/go.mod h1:O42B/CP5u5eNKNGd0OKKLoeUVkHPLwgrWcCRRX0KFgY=
-github.com/nginxinc/nginx-service-mesh v1.7.0 h1:oxKr+Jdbxkos10VTy5xF2UHCcmfIhqWNlsOK/zPnZDM=
-github.com/nginxinc/nginx-service-mesh v1.7.0/go.mod h1:8tREM3kSEUGyk8JT8hdCf/9ol2kEo7hLR8b+m5Yd8Fs=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -38,7 +38,6 @@ import (
 
 	k8spolicies "github.com/nginx/kubernetes-ingress/internal/k8s/policies"
 	"github.com/nginx/kubernetes-ingress/internal/k8s/secrets"
-	"github.com/nginxinc/nginx-service-mesh/pkg/spiffe"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 
 	"k8s.io/apimachinery/pkg/fields"
@@ -206,7 +205,7 @@ type LoadBalancerController struct {
 	metricsCollector              collectors.ControllerCollector
 	globalConfigurationValidator  *validation.GlobalConfigurationValidator
 	transportServerValidator      *validation.TransportServerValidator
-	spiffeCertFetcher             *spiffe.X509CertFetcher
+	spireAgentAddress             string
 	internalRoutesEnabled         bool
 	syncLock                      sync.Mutex
 	isNginxReady                  bool
@@ -351,13 +350,7 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 	}
 
 	lbc.syncQueue = newTaskQueue(lbc.Logger, lbc.sync)
-	var err error
-	if input.SpireAgentAddress != "" {
-		lbc.spiffeCertFetcher, err = spiffe.NewX509CertFetcher(input.SpireAgentAddress, nil)
-		if err != nil {
-			nl.Fatalf(lbc.Logger, "failed to initialize spiffe certfetcher: %v", err)
-		}
-	}
+	lbc.spireAgentAddress = input.SpireAgentAddress
 
 	isDynamicNs := input.WatchNamespaceLabel != ""
 
@@ -726,19 +719,29 @@ func (lbc *LoadBalancerController) Run() {
 		go lbc.namespaceWatcherController.Run(lbc.ctx.Done())
 	}
 
-	if lbc.spiffeCertFetcher != nil {
-		_, _, err := lbc.spiffeCertFetcher.Start(lbc.ctx)
+	if lbc.spireAgentAddress != "" {
 		lbc.addInternalRouteServer()
-		if err != nil {
-			nl.Fatal(lbc.Logger, err)
-		}
+
+		// certCh receives X.509 SVID updates from the SPIFFE Workload API.
+		// errCh receives a terminal error if the watch stops.
+		certCh := make(chan *workloadapi.X509Context)
+		errCh := make(chan error, 1)
+		watcher := &spiffeWatcher{certCh: certCh}
+
+		go func() {
+			if err := workloadapi.WatchX509Context(lbc.ctx, watcher, workloadapi.WithAddr("unix://"+lbc.spireAgentAddress)); err != nil {
+				errCh <- err
+			}
+		}()
 
 		// wait for initial bundle
 		timeoutch := make(chan bool, 1)
 		go func() { time.Sleep(time.Second * 30); timeoutch <- true }()
 		select {
-		case cert := <-lbc.spiffeCertFetcher.CertCh:
+		case cert := <-certCh:
 			lbc.syncSVIDRotation(cert)
+		case err := <-errCh:
+			nl.Fatalf(lbc.Logger, "error watching for SVID rotations: %v", err)
 		case <-timeoutch:
 			nl.Fatal(lbc.Logger, "Failed to download initial spiffe trust bundle")
 		}
@@ -746,10 +749,10 @@ func (lbc *LoadBalancerController) Run() {
 		go func() {
 			for {
 				select {
-				case err := <-lbc.spiffeCertFetcher.WatchErrCh:
+				case err := <-errCh:
 					nl.Errorf(lbc.Logger, "error watching for SVID rotations: %v", err)
 					return
-				case cert := <-lbc.spiffeCertFetcher.CertCh:
+				case cert := <-certCh:
 					lbc.syncSVIDRotation(cert)
 				}
 			}
@@ -1187,7 +1190,7 @@ func (lbc *LoadBalancerController) sync(task task) {
 		nl.Debugf(lbc.Logger, "Batch processing %v items", lbc.syncQueue.Len())
 	}
 	nl.Debugf(lbc.Logger, "Syncing %v", task.Key)
-	if lbc.spiffeCertFetcher != nil {
+	if lbc.spireAgentAddress != "" {
 		lbc.syncLock.Lock()
 		defer lbc.syncLock.Unlock()
 	}
@@ -4146,6 +4149,22 @@ func (lbc *LoadBalancerController) isHealthCheckEnabled(ing *networking.Ingress)
 func formatWarningMessages(w []string) string {
 	return strings.Join(w, "; ")
 }
+
+// spiffeWatcher implements workloadapi.X509ContextWatcher. It forwards X.509
+// SVID updates from the SPIFFE Workload API onto certCh. Watch errors are
+// surfaced via the error returned by workloadapi.WatchX509Context, so they are
+// not handled here.
+type spiffeWatcher struct {
+	certCh chan<- *workloadapi.X509Context
+}
+
+// OnX509ContextUpdate is called when a new X.509 context is fetched from the SPIFFE Workload API.
+func (w *spiffeWatcher) OnX509ContextUpdate(svidResponse *workloadapi.X509Context) {
+	w.certCh <- svidResponse
+}
+
+// OnX509ContextWatchError is called when there is an error watching for X.509 context updates.
+func (w *spiffeWatcher) OnX509ContextWatchError(_ error) {}
 
 func (lbc *LoadBalancerController) syncSVIDRotation(svidResponse *workloadapi.X509Context) {
 	lbc.syncLock.Lock()


### PR DESCRIPTION
### Proposed changes

The github.com/nginxinc/nginx-service-mesh module was archived 2.5 years ago. Its only use was a thin wrapper (pkg/spiffe.X509CertFetcher) around github.com/spiffe/go-spiffe/v2/workloadapi, which NIC already depends on directly.

Inline the SPIFFE Workload API watch logic into the controller using workloadapi.WatchX509Context and a small X509ContextWatcher implementation, preserving the existing rotation and startup behavior. Drop the dependency from go.mod and vendor.

Assisted-By: Claude Opus 4.8

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
