### PR TITLE
ci: gate all public workflow jobs on main repository name

### DIFF
--- a/.github/scripts/validate-workflow-gating.sh
+++ b/.github/scripts/validate-workflow-gating.sh
@@ -10,101 +10,124 @@ set -euo pipefail
 # different workflows are needed due to access requirements and different jobs. Separating
 # them into different files allows us to keep various branches up to date where we don't need
 # to deal with merge conflicts in the workflow files.
-workflows=$(find .github/workflows -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) ! -name "mirror-*")
+#
+# A job's `if:` condition is "correctly gated" when it has one of these shapes:
+#
+#     github.repository == 'nginx/kubernetes-ingress'
+#     github.repository == 'nginx/kubernetes-ingress' && ( <extra conditions> )
+#
+# The gate must come first, and any extra conditions must be wrapped in a single
+# balanced parenthesis group. GitHub Actions gives `&&` higher precedence than
+# `||`, so without the single-group requirement a top-level `||` could bypass the
+# gate, e.g. "gate && (a) || (b)" parses as "(gate && (a)) || (b)" and would run
+# on a fork/mirror. (Unbalanced parentheses are rejected by GitHub Actions' own
+# syntax validation, so we only guard against the balanced-but-bypassing case.)
 
-# Determine which yq binary to use.
-YQ_BIN="yq"
-if ! command -v yq &> /dev/null; then
-  if [ -f "/tmp/yq" ]; then
-    YQ_BIN="/tmp/yq"
-  else
-    echo "❌ Error: yq is not installed." >&2
-    exit 1
-  fi
-fi
+# Returns 0 only if the entire string is one balanced parenthesis group,
+# e.g. "(a && (b || c))". Rejects "(a) || (b)" (the first '(' closes before the
+# end) and any unbalanced input.
+is_single_group() {
+  local s="$1" depth=0 i
+  [[ "$s" == "("* ]] || return 1
+  for ((i = 0; i < ${#s}; i++)); do
+    case "${s:i:1}" in
+    "(") depth=$((depth + 1)) ;;
+    ")") depth=$((depth - 1)) ;;
+    esac
+    # Returning to depth 0 before the final char means it is not a single group.
+    if ((depth == 0 && i < ${#s} - 1)); then
+      return 1
+    fi
+  done
+  ((depth == 0))
+}
 
-errors=0
-
+# Validates a single job's `if:` condition. Prints a message and returns 1 when
+# the job is not correctly gated; returns 0 otherwise.
 validate_if_condition() {
-  local job_name="$1"
-  local cond="$2"
+  local job_name="$1" cond="$2"
+
+  # Normalize all whitespace (including newlines) to single spaces.
+  cond=$(printf '%s' "$cond" | tr -s '[:space:]' ' ' | sed 's/^ *//;s/ *$//')
 
   if [ -z "$cond" ]; then
     echo "  - Job '$job_name' has no 'if:' condition (ungated)."
     return 1
   fi
 
-  # Normalize spaces without stripping quotes
-  cond=$(echo "$cond" | tr -s '[:space:]' ' ' | sed 's/^ //;s/ $//')
-
-  local gate_single="github.repository == 'nginx/kubernetes-ingress'"
-  local gate_double='github.repository == "nginx/kubernetes-ingress"'
-
-  if [[ "$cond" != *"$gate_single"* && "$cond" != *"$gate_double"* ]]; then
-    echo "  - Job '$job_name' does not contain the required repository gate."
+  # <gate>  or  <gate> && ( ... ). The alternation forces the quotes to match
+  # (there is no mixed '..." branch). Capture group 2 is the optional tail and
+  # group 3 is the tail's inner parenthesised content.
+  local gate_re='^github\.repository == ('\''nginx/kubernetes-ingress'\''|"nginx/kubernetes-ingress")( && \((.+)\))?$'
+  if [[ ! "$cond" =~ $gate_re ]]; then
+    echo "  - Job '$job_name' is not correctly gated: '$cond'"
+    echo "    Expected: github.repository == 'nginx/kubernetes-ingress'  [ && ( ... ) ]"
     return 1
   fi
 
-  local prev=""
-  local simplified="$cond"
-  while [[ "$simplified" != "$prev" ]]; do
-    prev="$simplified"
-    simplified="${simplified//\(\)/}"
-    if [[ "$simplified" =~ \(([^()]+)\) ]]; then
-      local inner="${BASH_REMATCH[1]}"
-      local replacement="()"
-      if [[ "$inner" == *"$gate_single"* || "$inner" == *"$gate_double"* || "$inner" == *"GATE"* ]]; then
-        replacement="GATE"
-      fi
-      simplified="${simplified/\($inner\)/$replacement}"
-    fi
-  done
-
-  # Final cleanup of any empty parentheses
-  simplified="${simplified//\(\)/}"
-
-  if [[ "$simplified" != *"$gate_single"* && "$simplified" != *"$gate_double"* && "$simplified" != *"GATE"* ]]; then
-    echo "  - Job '$job_name': Gate is missing after simplifying."
-    return 1
-  fi
-
-  if [[ "$simplified" == *"||"* ]]; then
-    echo "  - Job '$job_name' has an ineffectual repository gate because of a top-level '||' operator: '$cond'"
+  # If there is a parenthesised tail, it must be one balanced group so that a
+  # top-level '||' cannot bypass the gate (rejects e.g. "gate && (a) || (b)").
+  if [ -n "${BASH_REMATCH[2]}" ] && ! is_single_group "(${BASH_REMATCH[3]})"; then
+    echo "  - Job '$job_name' extra conditions must be a single ( ... ) group: '$cond'"
     return 1
   fi
 
   return 0
 }
 
-for file in $workflows; do
-  # Extract job names and if conditions (removing internal newlines)
-  if ! jobs_data=$($YQ_BIN '.jobs | to_entries | .[] | .key + ":::" + (.value.if // "" | split("\n") | join(" "))' "$file" 2>&1); then
-    echo "❌ Error: Failed to parse or evaluate '$file' with yq:"
-    echo "   $jobs_data"
-    errors=$((errors + 1))
-    continue
+main() {
+  local workflows
+  workflows=$(find .github/workflows -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) ! -name "mirror-*")
+
+  # Determine which yq binary to use.
+  local YQ_BIN="yq"
+  if ! command -v yq &>/dev/null; then
+    if [ -f "/tmp/yq" ]; then
+      YQ_BIN="/tmp/yq"
+    else
+      echo "❌ Error: yq is not installed." >&2
+      exit 1
+    fi
   fi
 
-  file_has_errors=0
-  while IFS= read -r line; do
-    [ -z "$line" ] && continue
-    job_name="${line%%:::*}"
-    if_cond="${line#*:::}"
+  local errors=0
+  local file jobs_data file_has_errors line job_name if_cond
 
-    if ! validate_if_condition "$job_name" "$if_cond"; then
-      if [ "$file_has_errors" -eq 0 ]; then
-        echo "❌ File '$file' has ungated or poorly gated jobs:"
-        file_has_errors=1
-      fi
+  for file in $workflows; do
+    # Extract job names and if conditions (removing internal newlines)
+    if ! jobs_data=$($YQ_BIN '.jobs | to_entries | .[] | .key + ":::" + (.value.if // "" | split("\n") | join(" "))' "$file" 2>&1); then
+      echo "❌ Error: Failed to parse or evaluate '$file' with yq:"
+      echo "   $jobs_data"
       errors=$((errors + 1))
+      continue
     fi
-  done <<< "$jobs_data"
-done
 
-if [ "$errors" -ne 0 ]; then
-  echo "❌ Workflow validation failed! All public jobs must have strict repository gating."
-  exit 1
-else
-  echo "✅ All public workflows are successfully gated."
-  exit 0
+    file_has_errors=0
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      job_name="${line%%:::*}"
+      if_cond="${line#*:::}"
+
+      if ! validate_if_condition "$job_name" "$if_cond"; then
+        if [ "$file_has_errors" -eq 0 ]; then
+          echo "❌ File '$file' has ungated or poorly gated jobs:"
+          file_has_errors=1
+        fi
+        errors=$((errors + 1))
+      fi
+    done <<<"$jobs_data"
+  done
+
+  if [ "$errors" -ne 0 ]; then
+    echo "❌ Workflow validation failed! All public jobs must have strict repository gating."
+    exit 1
+  else
+    echo "✅ All public workflows are successfully gated."
+    exit 0
+  fi
+}
+
+# Only run the driver when executed directly, not when sourced (e.g. by tests).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
 fi

--- a/.github/scripts/validate-workflow-gating.sh
+++ b/.github/scripts/validate-workflow-gating.sh
@@ -29,28 +29,35 @@ fi
 errors=0
 
 for file in $workflows; do
-  # Run yq directly to find any jobs missing repository gating
-  failed_jobs=$($YQ_BIN '
+  # 1. Capture yq stderr and exit status; do not suppress failures
+  if ! failed_jobs=$($YQ_BIN '
     select(.jobs != null) |
     .jobs |
     with_entries(select(
       .value.if == null or
-      ((.value.if | (contains("nginx/kubernetes-ingress") or contains("github.repository_owner"))) | not)
+      ((.value.if | (contains("github.repository == '\''nginx/kubernetes-ingress'\''") or contains("github.repository == \"nginx/kubernetes-ingress\""))) | not)
     )) |
     keys |
     .[]
-  ' "$file" 2>/dev/null || true)
+  ' "$file" 2>&1); then
+    echo "❌ Error: Failed to parse or evaluate '$file' with yq:"
+    echo "   $failed_jobs"
+    errors=$((errors + 1))
+    continue
+  fi
 
-  # List each job that has an issue in it.
+  # 2. Use a native Bash loop instead of sed (resolves Shellcheck SC2001)
   if [ -n "$failed_jobs" ]; then
+    echo "❌ File '$file' has ungated jobs:"
     while IFS= read -r job; do
       [ -n "$job" ] && echo "  - Job: $job"
     done <<< "$failed_jobs"
+    errors=$((errors + 1))
   fi
 done
 
 if [ "$errors" -ne 0 ]; then
-  echo "❌ Workflow validation failed! All public jobs must have repository/owner gating."
+  echo "❌ Workflow validation failed! All public jobs must have strict repository gating."
   exit 1
 else
   echo "✅ All public workflows are successfully gated."

--- a/.github/scripts/validate-workflow-gating.sh
+++ b/.github/scripts/validate-workflow-gating.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# This is called from the lint-format.yml workflow file.
+#
+# Purpose of this is to make sure that every job in workflow files that don't start with
+# "mirror-" have a gate that only runs them on the main repository (nginx/kubernetes-ingress).
+#
+# Workflow files starting with "mirror-" will be used in mirror repositories where slightly
+# different workflows are needed due to access requirements and different jobs. Separating
+# them into different files allows us to keep various branches up to date where we don't need
+# to deal with merge conflicts in the workflow files.
+
 # Find all workflow files, excluding mirror-specific ones
 workflows=$(find .github/workflows -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) | grep -v "mirror-")
 
-# Determine which yq binary to use
+# Determine which yq binary to use. yq is used to validate that the workflow files
+# do have the necessary "if" gate.
 YQ_BIN="yq"
 if ! command -v yq &> /dev/null; then
   if [ -f "/tmp/yq" ]; then
@@ -30,6 +41,7 @@ for file in $workflows; do
     .[]
   ' "$file" 2>/dev/null || true)
 
+  # List each job that has an issue in it.
   if [ -n "$failed_jobs" ]; then
     echo "❌ File '$file' has ungated jobs:"
     # Indent and display each failed job

--- a/.github/scripts/validate-workflow-gating.sh
+++ b/.github/scripts/validate-workflow-gating.sh
@@ -43,10 +43,9 @@ for file in $workflows; do
 
   # List each job that has an issue in it.
   if [ -n "$failed_jobs" ]; then
-    echo "❌ File '$file' has ungated jobs:"
-    # Indent and display each failed job
-    echo "$failed_jobs" | sed 's/^/  - Job: /'
-    errors=$((errors + 1))
+    while IFS= read -r job; do
+      [ -n "$job" ] && echo "  - Job: $job"
+    done <<< "$failed_jobs"
   fi
 done
 

--- a/.github/scripts/validate-workflow-gating.sh
+++ b/.github/scripts/validate-workflow-gating.sh
@@ -25,32 +25,80 @@ fi
 
 errors=0
 
+validate_if_condition() {
+  local job_name="$1"
+  local cond="$2"
+
+  if [ -z "$cond" ]; then
+    echo "  - Job '$job_name' has no 'if:' condition (ungated)."
+    return 1
+  fi
+
+  # Normalize spaces without stripping quotes
+  cond=$(echo "$cond" | tr -s '[:space:]' ' ' | sed 's/^ //;s/ $//')
+
+  local gate_single="github.repository == 'nginx/kubernetes-ingress'"
+  local gate_double='github.repository == "nginx/kubernetes-ingress"'
+
+  if [[ "$cond" != *"$gate_single"* && "$cond" != *"$gate_double"* ]]; then
+    echo "  - Job '$job_name' does not contain the required repository gate."
+    return 1
+  fi
+
+  local prev=""
+  local simplified="$cond"
+  while [[ "$simplified" != "$prev" ]]; do
+    prev="$simplified"
+    simplified="${simplified//\(\)/}"
+    if [[ "$simplified" =~ \(([^()]+)\) ]]; then
+      local inner="${BASH_REMATCH[1]}"
+      local replacement="()"
+      if [[ "$inner" == *"$gate_single"* || "$inner" == *"$gate_double"* || "$inner" == *"GATE"* ]]; then
+        replacement="GATE"
+      fi
+      simplified="${simplified/\($inner\)/$replacement}"
+    fi
+  done
+
+  # Final cleanup of any empty parentheses
+  simplified="${simplified//\(\)/}"
+
+  if [[ "$simplified" != *"$gate_single"* && "$simplified" != *"$gate_double"* && "$simplified" != *"GATE"* ]]; then
+    echo "  - Job '$job_name': Gate is missing after simplifying."
+    return 1
+  fi
+
+  if [[ "$simplified" == *"||"* ]]; then
+    echo "  - Job '$job_name' has an ineffectual repository gate because of a top-level '||' operator: '$cond'"
+    return 1
+  fi
+
+  return 0
+}
+
 for file in $workflows; do
-  # 1. Capture yq stderr and exit status; do not suppress failures
-  if ! failed_jobs=$($YQ_BIN '
-    select(.jobs != null) |
-    .jobs |
-    with_entries(select(
-      .value.if == null or
-      ((.value.if | (contains("github.repository == '\''nginx/kubernetes-ingress'\''") or contains("github.repository == \"nginx/kubernetes-ingress\""))) | not)
-    )) |
-    keys |
-    .[]
-  ' "$file" 2>&1); then
+  # Extract job names and if conditions (removing internal newlines)
+  if ! jobs_data=$($YQ_BIN '.jobs | to_entries | .[] | .key + ":::" + (.value.if // "" | split("\n") | join(" "))' "$file" 2>&1); then
     echo "❌ Error: Failed to parse or evaluate '$file' with yq:"
-    echo "   $failed_jobs"
+    echo "   $jobs_data"
     errors=$((errors + 1))
     continue
   fi
 
-  # 2. Use a native Bash loop instead of sed (resolves Shellcheck SC2001)
-  if [ -n "$failed_jobs" ]; then
-    echo "❌ File '$file' has ungated jobs:"
-    while IFS= read -r job; do
-      [ -n "$job" ] && echo "  - Job: $job"
-    done <<< "$failed_jobs"
-    errors=$((errors + 1))
-  fi
+  file_has_errors=0
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    job_name="${line%%:::*}"
+    if_cond="${line#*:::}"
+
+    if ! validate_if_condition "$job_name" "$if_cond"; then
+      if [ "$file_has_errors" -eq 0 ]; then
+        echo "❌ File '$file' has ungated or poorly gated jobs:"
+        file_has_errors=1
+      fi
+      errors=$((errors + 1))
+    fi
+  done <<< "$jobs_data"
 done
 
 if [ "$errors" -ne 0 ]; then

--- a/.github/scripts/validate-workflow-gating.sh
+++ b/.github/scripts/validate-workflow-gating.sh
@@ -10,13 +10,9 @@ set -euo pipefail
 # different workflows are needed due to access requirements and different jobs. Separating
 # them into different files allows us to keep various branches up to date where we don't need
 # to deal with merge conflicts in the workflow files.
+workflows=$(find .github/workflows -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) ! -name "mirror-*")
 
-# Find all workflow files, excluding mirror-specific ones
-workflows=$(find .github/workflows -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) | grep -v "mirror-")
-
-# Determine which yq binary to use. yq is used to validate that the workflow files
-# do have the necessary "if" gate.
-YQ_BIN="yq"
+# Determine which yq binary to use.
 if ! command -v yq &> /dev/null; then
   if [ -f "/tmp/yq" ]; then
     YQ_BIN="/tmp/yq"

--- a/.github/scripts/validate-workflow-gating.sh
+++ b/.github/scripts/validate-workflow-gating.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find all workflow files, excluding mirror-specific ones
+workflows=$(find .github/workflows -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) | grep -v "mirror-")
+
+# Determine which yq binary to use
+YQ_BIN="yq"
+if ! command -v yq &> /dev/null; then
+  if [ -f "/tmp/yq" ]; then
+    YQ_BIN="/tmp/yq"
+  else
+    echo "❌ Error: yq is not installed." >&2
+    exit 1
+  fi
+fi
+
+errors=0
+
+for file in $workflows; do
+  # Run yq directly to find any jobs missing repository gating
+  failed_jobs=$($YQ_BIN '
+    select(.jobs != null) |
+    .jobs |
+    with_entries(select(
+      .value.if == null or
+      ((.value.if | (contains("nginx/kubernetes-ingress") or contains("github.repository_owner"))) | not)
+    )) |
+    keys |
+    .[]
+  ' "$file" 2>/dev/null || true)
+
+  if [ -n "$failed_jobs" ]; then
+    echo "❌ File '$file' has ungated jobs:"
+    # Indent and display each failed job
+    echo "$failed_jobs" | sed 's/^/  - Job: /'
+    errors=$((errors + 1))
+  fi
+done
+
+if [ "$errors" -ne 0 ]; then
+  echo "❌ Workflow validation failed! All public jobs must have repository/owner gating."
+  exit 1
+else
+  echo "✅ All public workflows are successfully gated."
+  exit 0
+fi

--- a/.github/scripts/validate-workflow-gating.sh
+++ b/.github/scripts/validate-workflow-gating.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 workflows=$(find .github/workflows -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) ! -name "mirror-*")
 
 # Determine which yq binary to use.
+YQ_BIN="yq"
 if ! command -v yq &> /dev/null; then
   if [ -f "/tmp/yq" ]; then
     YQ_BIN="/tmp/yq"

--- a/.github/scripts/validate-workflow-gating_test.sh
+++ b/.github/scripts/validate-workflow-gating_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Unit tests for validate-workflow-gating.sh.
+#
+# These test the pure validation logic (validate_if_condition and
+# is_single_group) by sourcing the script; the source guard in the script
+# prevents main() from running, so yq is not required here.
+#
+# Run directly: bash .github/scripts/validate-workflow-gating_test.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/validate-workflow-gating.sh"
+
+# Sourcing the script enables `set -e`; disable it so every assertion runs even
+# after an expected failure.
+set +e
+
+pass=0
+fail=0
+
+GATE_SQ="github.repository == 'nginx/kubernetes-ingress'"
+GATE_DQ='github.repository == "nginx/kubernetes-ingress"'
+
+# assert_if <pass|fail> <description> <condition>
+assert_if() {
+  local want="$1" desc="$2" cond="$3" got
+  if validate_if_condition "test-job" "$cond" >/dev/null 2>&1; then
+    got="pass"
+  else
+    got="fail"
+  fi
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL [validate_if_condition] $desc (want=$want got=$got): '$cond'"
+  fi
+}
+
+# assert_group <pass|fail> <description> <string>
+assert_group() {
+  local want="$1" desc="$2" str="$3" got
+  if is_single_group "$str" >/dev/null 2>&1; then
+    got="pass"
+  else
+    got="fail"
+  fi
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL [is_single_group] $desc (want=$want got=$got): '$str'"
+  fi
+}
+
+# --- validate_if_condition: valid gates ---------------------------------------
+assert_if pass "bare gate, single quotes" "$GATE_SQ"
+assert_if pass "bare gate, double quotes" "$GATE_DQ"
+assert_if pass "gate with simple parenthesised tail" "$GATE_SQ && (!cancelled())"
+assert_if pass "gate with nested single group" "$GATE_SQ && (inputs.force && (github.ref_name == 'main' || startsWith(github.ref_name, 'release-')))"
+assert_if pass "leading/trailing/extra whitespace normalized" "   $GATE_SQ    &&   (!cancelled())   "
+assert_if pass "embedded newline normalized" "$GATE_SQ &&
+(!cancelled())"
+
+# --- validate_if_condition: invalid gates -------------------------------------
+assert_if fail "empty condition" ""
+assert_if fail "whitespace-only condition" "   "
+assert_if fail "no gate at all" "!cancelled()"
+assert_if fail "gate not first" "foo && $GATE_SQ"
+assert_if fail "mismatched quotes" "github.repository == 'nginx/kubernetes-ingress\""
+assert_if fail "wrong repository" "github.repository == 'nginx/other-repo'"
+assert_if fail "top-level || bypass" "$GATE_SQ && (a) || (b)"
+assert_if fail "two separate groups" "$GATE_SQ && (a) && (b)"
+assert_if fail "unparenthesised tail" "$GATE_SQ && a"
+assert_if fail "unparenthesised tail with ||" "$GATE_SQ && a || b"
+
+# --- is_single_group ----------------------------------------------------------
+assert_group pass "single group" "(a)"
+assert_group pass "nested groups" "(a && (b || c))"
+assert_group pass "double-wrapped" "((a))"
+assert_group fail "two top-level groups with ||" "(a) || (b)"
+assert_group fail "adjacent groups" "(a)(b)"
+assert_group fail "unbalanced open" "(a"
+assert_group fail "unbalanced close" "a)"
+assert_group fail "no parentheses" "a"
+assert_group fail "empty string" ""
+
+echo "passed=$pass failed=$fail"
+[ "$fail" -eq 0 ]

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -62,6 +62,7 @@ permissions:
 jobs:
   binaries:
     name: Build Binaries
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
@@ -204,6 +205,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( inputs.image-matrix-oss ) }}
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/build-oss.yml
     with:
       platforms: ${{ matrix.platforms }}
@@ -232,6 +234,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( inputs.image-matrix-plus ) }}
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/build-plus.yml
     with:
       platforms: ${{ matrix.platforms }}
@@ -259,6 +262,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( inputs.image-matrix-nap ) }}
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/build-plus.yml
     with:
       platforms: ${{ matrix.platforms }}

--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   checks:
     name: Checks and variables
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     outputs:
       docker_md5: ${{ steps.vars.outputs.docker_md5 }}
@@ -44,6 +45,7 @@ jobs:
 
   build-oss:
     name: Build OSS base images
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     needs: checks
     permissions:
@@ -127,6 +129,7 @@ jobs:
 
   build-plus:
     name: Build Plus base images
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     needs: checks
     permissions:
@@ -230,6 +233,7 @@ jobs:
 
   build-plus-nap:
     name: Build Plus NAP base images
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     needs: checks
     permissions:

--- a/.github/workflows/build-oss.yml
+++ b/.github/workflows/build-oss.yml
@@ -54,6 +54,7 @@ permissions:
 jobs:
   build:
     name: "OSS ${{ inputs.image }} ${{inputs.platforms }}"
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ${{ inputs.runner }}
     permissions:
       contents: read # for docker/build-push-action to read repo content

--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -64,6 +64,7 @@ jobs:
       contents: read # for docker/build-push-action to read repo content
       id-token: write # for OIDC login to AWS
       pull-requests: write # for scout report
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-single-image.yml
+++ b/.github/workflows/build-single-image.yml
@@ -42,6 +42,7 @@ jobs:
     permissions:
       contents: read # for docker/build-push-action to read repo content
       id-token: write # for login to GCP
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   build:
     name: Build test image
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-ubi-dependency.yml
+++ b/.github/workflows/build-ubi-dependency.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   build-binaries:
     name: Build Binary Container Image
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       packages: write

--- a/.github/workflows/cache-update.yml
+++ b/.github/workflows/cache-update.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   checks:
     name: Checks and variables
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     outputs:
       go_code_md5: ${{ steps.vars.outputs.go_code_md5 }}
@@ -44,6 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.checks.outputs.image_matrix_oss ) }}
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/build-oss.yml
     with:
       platforms: ${{ matrix.platforms }}
@@ -69,6 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.checks.outputs.image_matrix_plus ) }}
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/build-plus.yml
     with:
       platforms: ${{ matrix.platforms }}
@@ -93,6 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.checks.outputs.image_matrix_nap ) }}
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/build-plus.yml
     with:
       platforms: ${{ matrix.platforms }}

--- a/.github/workflows/certify-ubi-image.yml
+++ b/.github/workflows/certify-ubi-image.yml
@@ -33,6 +33,7 @@ permissions:
 jobs:
   certify-ubi-images:
     name: Certify OpenShift UBI images
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -16,9 +16,11 @@ jobs:
     runs-on: ubuntu-24.04
     name: Cherry pick into release branch
     if: |
+      github.repository == 'nginx/kubernetes-ingress' && (
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '/cherry-pick to') &&
       (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
+      )
     steps:
       - name: Check PR is merged
         id: pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ permissions:
 jobs:
   checks:
     name: Checks and variables
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -207,9 +208,11 @@ jobs:
       contents: read
     needs: checks
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       inputs.force ||
       needs.checks.outputs.run_tests == 'true' &&
       needs.checks.outputs.binary_cache_hit != 'true'
+      )
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -243,6 +246,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -330,9 +334,11 @@ jobs:
       contents: read
     needs: checks
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       inputs.force ||
       needs.checks.outputs.run_tests == 'true' &&
       needs.checks.outputs.binary_cache_hit != 'true'
+      )
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -362,9 +368,11 @@ jobs:
       contents: read
     needs: checks
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       inputs.force ||
       needs.checks.outputs.run_tests == 'true' &&
       needs.checks.outputs.binary_cache_hit != 'true'
+      )
     env:
       GOPROXY: ${{ needs.checks.outputs.go_proxy }}
     steps:
@@ -385,6 +393,7 @@ jobs:
   build-artifacts:
     name: Build Artifacts
     needs: [checks, unit-tests]
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/build-artifacts.yml
     with:
       force: ${{ needs.checks.outputs.docker_build == 'true' }}
@@ -422,14 +431,18 @@ jobs:
       dry_run: false
     secrets: inherit
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       needs.checks.outputs.forked_workflow == 'false' &&
       (needs.checks.outputs.run_tests == 'true' ||
       needs.checks.outputs.docker_build == 'true')
 
+      )
   package-tests:
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       needs.checks.outputs.run_tests == 'true' ||
       needs.checks.outputs.docker_build == 'true'
+      )
     name: Package Tests
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -510,8 +523,10 @@ jobs:
 
   helm-tests:
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       needs.checks.outputs.run_tests == 'true' ||
       needs.checks.outputs.docker_build == 'true'
+      )
     name: Helm Tests ${{ matrix.base-os }}
     runs-on: ubuntu-24.04
     needs: [checks, build-artifacts]
@@ -698,8 +713,10 @@ jobs:
 
   setup-matrix:
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       needs.checks.outputs.run_tests == 'true' ||
       needs.checks.outputs.docker_build == 'true'
+      )
     name: Setup Matrix for Smoke Tests
     runs-on: ubuntu-24.04
     needs: [build-artifacts, checks]
@@ -782,8 +799,10 @@ jobs:
 
   smoke-tests-oss:
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       needs.checks.outputs.run_tests == 'true' ||
       needs.checks.outputs.docker_build == 'true'
+      )
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -812,8 +831,10 @@ jobs:
 
   smoke-tests-plus:
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       needs.checks.outputs.run_tests == 'true' ||
       needs.checks.outputs.docker_build == 'true'
+      )
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -842,8 +863,10 @@ jobs:
 
   smoke-tests-nap:
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       needs.checks.outputs.run_tests == 'true' ||
       needs.checks.outputs.docker_build == 'true'
+      )
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} smoke tests
     needs:
       - checks
@@ -883,11 +906,13 @@ jobs:
       dry_run: false
     secrets: inherit
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       (needs.checks.outputs.forked_workflow == 'false' &&
       needs.checks.outputs.stable_image_exists != 'true')
 
+      )
   final-results:
-    if: ${{ !cancelled() }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled())
     runs-on: ubuntu-24.04
     name: Final CI Results
     needs: [tag-stable, build-artifacts, smoke-tests-oss, smoke-tests-plus, smoke-tests-nap, package-tests, helm-tests, staticcheck, govulncheck]
@@ -944,4 +969,4 @@ jobs:
       pull-requests: write # for scout report
     uses: ./.github/workflows/image-promotion.yml
     secrets: inherit
-    if: ${{ inputs.force && (github.ref_name == 'main' || startsWith(github.ref_name, 'release-')) }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.force && (github.ref_name == 'main' || startsWith(github.ref_name, 'release-')))

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   checks:
     name: Checks and variables
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     outputs:
       docs_only: ${{ github.event.pull_request && steps.docs.outputs.docs_only == 'true' }}
@@ -46,7 +47,7 @@ jobs:
         shell: bash --noprofile --norc -o pipefail {0}
 
   analyze:
-    if: ${{ needs.checks.outputs.docs_only != 'true' }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (needs.checks.outputs.docs_only != 'true')
     needs: [checks]
     name: Analyze
     permissions:

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -33,6 +33,7 @@ permissions:
 jobs:
   create:
     name: Create release branch
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   dependency-review:
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read # for actions/checkout

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ github.event.repository.fork == false }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (github.event.repository.fork == false)
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/external-pr.yml
+++ b/.github/workflows/external-pr.yml
@@ -11,8 +11,10 @@ permissions:
 jobs:
   pr-details:
     if: >
+      github.repository == 'nginx/kubernetes-ingress' && (
       github.event.issue.pull_request &&
       github.event.comment.body == '/approve-pipeline-run'
+      )
     runs-on: ubuntu-24.04
     outputs:
         is_fork: ${{ steps.pr-info.outputs.is_fork }}
@@ -53,7 +55,9 @@ jobs:
       issues: read
       pull-requests: read
     if: >
+      github.repository == 'nginx/kubernetes-ingress' && (
       needs.pr-details.outputs.is_fork == 'true'
+      )
     runs-on: ubuntu-24.04
     steps:
       - name: Check commenter permissions

--- a/.github/workflows/f5-cla.yml
+++ b/.github/workflows/f5-cla.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   f5-cla:
     name: F5 CLA
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       actions: write

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   checks:
     name: Checks and variables
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04-amd64
     permissions:
       contents: read
@@ -118,6 +119,7 @@ jobs:
 
   govulncheck:
     name: Run govulncheck
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04-amd64
     permissions:
       contents: read
@@ -173,6 +175,7 @@ jobs:
   build-artifacts:
     name: Build Artifacts
     needs: [checks]
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/build-artifacts.yml
     with:
       force: true
@@ -205,6 +208,7 @@ jobs:
     permissions:
       contents: read # To checkout repository
       id-token: write # To sign into Google Container Registry
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/retag-images.yml
     with:
       source_tag: ${{ needs.checks.outputs.build_tag }}
@@ -230,11 +234,11 @@ jobs:
       target_tag: ${{ github.ref_name == github.event.repository.default_branch && 'edge' || needs.checks.outputs.additional_tag }}
       dry_run: false
     secrets: inherit
-    if: ${{ !cancelled() && !failure() }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && !failure())
 
   release-oss:
     # pushes edge images to docker hub
-    if: ${{ !cancelled() && !failure() && github.ref_name == github.event.repository.default_branch }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && !failure() && github.ref_name == github.event.repository.default_branch)
     name: Release Docker OSS
     needs: [checks, build-artifacts]
     uses: ./.github/workflows/oss-release.yml
@@ -256,7 +260,7 @@ jobs:
 
   release-plus:
     # pushes plus edge images to nginx registry
-    if: ${{ !cancelled() && !failure() && github.ref_name == github.event.repository.default_branch }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && !failure() && github.ref_name == github.event.repository.default_branch)
     name: Release Docker Plus
     needs: [checks, build-artifacts]
     uses: ./.github/workflows/plus-release.yml
@@ -276,7 +280,7 @@ jobs:
     secrets: inherit
 
   publish-helm-chart:
-    if: ${{ !cancelled() && !failure() && github.ref_name == github.event.repository.default_branch }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && !failure() && github.ref_name == github.event.repository.default_branch)
     name: Publish Helm Chart
     needs: [checks]
     uses: ./.github/workflows/publish-helm.yml
@@ -293,7 +297,7 @@ jobs:
     secrets: inherit
 
   certify-openshift-images:
-    if: ${{ !cancelled() && !failure() && github.ref_name == github.event.repository.default_branch }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && !failure() && github.ref_name == github.event.repository.default_branch)
     name: Certify OpenShift UBI images
     runs-on: ubuntu-24.04
     permissions:
@@ -339,7 +343,7 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    if: ${{ !cancelled() && !failure() }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && !failure())
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.checks.outputs.image_matrix_oss ) }}
@@ -457,7 +461,7 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    if: ${{ !cancelled() && !failure() }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && !failure())
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.checks.outputs.image_matrix_plus ) }}
@@ -575,7 +579,7 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    if: ${{ !cancelled() && !failure() }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && !failure())
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.checks.outputs.image_matrix_nap ) }}
@@ -694,6 +698,7 @@ jobs:
 
   update-release-draft:
     name: Update Release Draft
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     needs: [checks]
     permissions:

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   comment:
     name: Issue comment
-    if: ${{ !github.event.issue.pull_request }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!github.event.issue.pull_request)
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # for actions/labeler to add labels
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -21,6 +21,7 @@ jobs:
 
   format:
     name: Format
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
@@ -38,6 +39,7 @@ jobs:
 
   lint:
     name: Lint
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -65,6 +67,7 @@ jobs:
 
   actionlint:
     name: Actionlint
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
@@ -74,8 +77,13 @@ jobs:
         with:
           actionlint_flags: -shellcheck ""
 
+      - name: Validate Workflow Gating
+        run: |
+          .github/scripts/validate-workflow-gating.sh
+
   chart-lint:
     name: Chart Lint
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
@@ -91,6 +99,7 @@ jobs:
 
   markdown-lint:
     name: Markdown Lint
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -73,6 +73,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Check yq
+        run: |
+          yq --version
+
       - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           actionlint_flags: -shellcheck ""

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Validate Workflow Gating
         run: |
-          .github/scripts/validate-workflow-gating.sh
+          bash .github/scripts/validate-workflow-gating.sh
 
   chart-lint:
     name: Chart Lint

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -81,6 +81,10 @@ jobs:
         with:
           actionlint_flags: -shellcheck ""
 
+      - name: Test Workflow Gating Script
+        run: |
+          bash .github/scripts/validate-workflow-gating_test.sh
+
       - name: Validate Workflow Gating
         run: |
           bash .github/scripts/validate-workflow-gating.sh

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -73,21 +73,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Check yq
-        run: |
-          yq --version
-
       - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           actionlint_flags: -shellcheck ""
-
-      - name: Test Workflow Gating Script
-        run: |
-          bash .github/scripts/validate-workflow-gating_test.sh
-
-      - name: Validate Workflow Gating
-        run: |
-          bash .github/scripts/validate-workflow-gating.sh
 
   chart-lint:
     name: Chart Lint

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   scan:
     name: Mend
-    if: ${{ github.event.repository.fork == false }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (github.event.repository.fork == false)
     uses: nginx/compliance-rules/.github/workflows/mend.yml@543d32464b56e6a695939f41ba8009cbb10e413a # v0.3.3
     secrets: inherit
     with:

--- a/.github/workflows/oss-release.yml
+++ b/.github/workflows/oss-release.yml
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.gcr_release_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.gcr_release_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -132,7 +132,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.ecr_public_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.ecr_public_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -202,7 +202,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.dockerhub_public_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.dockerhub_public_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -282,7 +282,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.quay_public_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.quay_public_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -354,7 +354,7 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    if: ${{ inputs.github_public_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.github_public_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/patch-image.yml
+++ b/.github/workflows/patch-image.yml
@@ -38,6 +38,7 @@ permissions:
 jobs:
   patch-image:
     name: Patch image
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04-amd64
     permissions:
       contents: read

--- a/.github/workflows/plus-release-lts.yml
+++ b/.github/workflows/plus-release-lts.yml
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.gcr_release_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.gcr_release_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -114,7 +114,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.nginx_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.nginx_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/plus-release.yml
+++ b/.github/workflows/plus-release.yml
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.gcr_release_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.gcr_release_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -132,7 +132,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.nginx_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.nginx_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -203,7 +203,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.gcr_mktpl_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.gcr_mktpl_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -268,7 +268,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.ecr_mktpl_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.ecr_mktpl_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -338,7 +338,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.az_mktpl_registry }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (inputs.az_mktpl_registry)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -68,6 +68,7 @@ permissions:
 jobs:
   publish-helm:
     name: Package and Publish Helm Chart
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ${{ inputs.runner }}
     permissions:
       contents: write # for pushing to Helm Charts repository

--- a/.github/workflows/pull-nap-images.yml
+++ b/.github/workflows/pull-nap-images.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   checks:
     name: Checks and variables
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -78,6 +79,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -125,6 +127,7 @@ jobs:
 
   helm-tests:
     name: Helm Tests ${{ matrix.base-os }}
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     needs: [checks]
     strategy:
@@ -247,6 +250,7 @@ jobs:
 
   setup-regression-matrix:
     name: Setup Matrix for Smoke Tests
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     needs: [checks]
     permissions:
@@ -273,6 +277,7 @@ jobs:
 
   regression-tests:
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} ${{ matrix.k8s }} regression tests
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     needs: [checks, setup-regression-matrix]
     strategy:
@@ -383,6 +388,7 @@ jobs:
     permissions:
       contents: read # To checkout repository
       id-token: write # To sign into Google Container Registry
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/retag-images.yml
     with:
       source_tag: ${{ needs.checks.outputs.stable_tag }}
@@ -394,6 +400,7 @@ jobs:
     # pushes nightly images to docker hub
     name: Release Docker OSS
     needs: [checks, regression-tests]
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/oss-release.yml
     with:
       gcr_release_registry: false
@@ -415,6 +422,7 @@ jobs:
     # pushes plus nightly images to nginx registry
     name: Release Docker Plus
     needs: [checks, regression-tests]
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/plus-release.yml
     with:
       nginx_registry: true

--- a/.github/workflows/release-lts.yml
+++ b/.github/workflows/release-lts.yml
@@ -40,6 +40,7 @@ permissions:
 jobs:
   variables:
     name: Set Variables
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04-amd64
     permissions:
       contents: read
@@ -82,7 +83,7 @@ jobs:
           cat $GITHUB_OUTPUT
 
   build-artifacts:
-    if: ${{ !cancelled() && !failure() && !inputs.dry_run && !contains(inputs.skip_step, 'build-artifacts') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && !failure() && !inputs.dry_run && !contains(inputs.skip_step, 'build-artifacts'))
     name: Build Artifacts
     needs: [variables]
     uses: ./.github/workflows/build-artifacts.yml
@@ -116,7 +117,7 @@ jobs:
     name: Create Tag on release branch in NIC repo
     runs-on: ubuntu-24.04
     needs: [build-artifacts]
-    if: ${{ !cancelled() && (needs.build-artifacts.result == 'success' || (needs.build-artifacts.result == 'skipped' && inputs.dry_run)) }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && (needs.build-artifacts.result == 'success' || (needs.build-artifacts.result == 'skipped' && inputs.dry_run)))
     permissions:
       contents: write
     steps:
@@ -149,7 +150,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   mend:
-    if: ${{ ! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'mend') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'mend'))
     name: Run Mend workflow
     uses: ./.github/workflows/mend.yml
     needs: [tag]
@@ -158,7 +159,7 @@ jobs:
     secrets: inherit
 
   release-plus-gcr-nginx:
-    if: ${{ !cancelled() && (needs.build-artifacts.result == 'success' || (needs.build-artifacts.result == 'skipped' && inputs.dry_run)) && !contains(inputs.skip_step, 'release-plus') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && (needs.build-artifacts.result == 'success' || (needs.build-artifacts.result == 'skipped' && inputs.dry_run)) && !contains(inputs.skip_step, 'release-plus'))
     name: Release Docker Plus
     needs: [variables, build-artifacts]
     uses: ./.github/workflows/plus-release-lts.yml
@@ -181,7 +182,7 @@ jobs:
     secrets: inherit
 
   publish-helm-chart:
-    if: ${{ ! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'publish-helm-chart') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'publish-helm-chart'))
     name: Publish Helm Chart
     uses: ./.github/workflows/publish-helm.yml
     with:
@@ -198,6 +199,7 @@ jobs:
 
   binaries:
     name: Process Binaries
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04-amd64
     needs: [variables, build-artifacts]
     permissions:
@@ -238,7 +240,7 @@ jobs:
 
   # Upload packages, sboms & checksums to release storage
   azure-upload:
-    if: ${{ ! cancelled() && ! failure() && ! contains(inputs.skip_step, 'azure-upload') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (! cancelled() && ! failure() && ! contains(inputs.skip_step, 'azure-upload'))
     name: Upload packages to Azure
     runs-on: ubuntu-24.04-amd64
     needs: [variables, binaries]
@@ -305,16 +307,18 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [binaries, release-plus-gcr-nginx, publish-helm-chart]
     if: >-
+      github.repository == 'nginx/kubernetes-ingress' && (
       cancelled() == false &&
       needs.binaries.result == 'success' &&
       (needs.release-plus-gcr-nginx.result == 'success' || contains(inputs.skip_step, 'release-plus')) &&
       (needs.publish-helm-chart.result == 'success' || contains(inputs.skip_step, 'publish-helm-chart'))
+      )
     steps:
       - run: echo "All prerequisites met"
 
   github-release:
     needs: [variables, release-gate]
-    if: ${{ !cancelled() && needs.release-gate.result == 'success' && !contains(inputs.skip_step, 'github-release') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && needs.release-gate.result == 'success' && !contains(inputs.skip_step, 'github-release'))
     name: Publish release to GitHub
     runs-on: ubuntu-24.04-amd64
     permissions:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -57,6 +57,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Parse versions
@@ -169,6 +170,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Parse versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ permissions:
 jobs:
   variables:
     name: Set Variables
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04-amd64
     permissions:
       contents: read
@@ -94,7 +95,7 @@ jobs:
           cat $GITHUB_OUTPUT
 
   build-artifacts:
-    if: ${{ !cancelled() && !failure() && !inputs.dry_run && !contains(inputs.skip_step, 'build-artifacts') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && !failure() && !inputs.dry_run && !contains(inputs.skip_step, 'build-artifacts'))
     name: Build Artifacts
     needs: [variables]
     uses: ./.github/workflows/build-artifacts.yml
@@ -128,7 +129,7 @@ jobs:
     name: Create Tag on release branch in NIC repo
     runs-on: ubuntu-24.04
     needs: [build-artifacts]
-    if: ${{ !cancelled() && (needs.build-artifacts.result == 'success' || (needs.build-artifacts.result == 'skipped' && inputs.dry_run)) }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && (needs.build-artifacts.result == 'success' || (needs.build-artifacts.result == 'skipped' && inputs.dry_run)))
     permissions:
       contents: write
     steps:
@@ -161,7 +162,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   mend:
-    if: ${{ ! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'mend') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'mend'))
     name: Run Mend workflow
     uses: ./.github/workflows/mend.yml
     needs: [tag]
@@ -170,7 +171,7 @@ jobs:
     secrets: inherit
 
   release-oss:
-    if: ${{ !cancelled() && (needs.build-artifacts.result == 'success' || (needs.build-artifacts.result == 'skipped' && inputs.dry_run)) && !contains(inputs.skip_step, 'release-oss') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && (needs.build-artifacts.result == 'success' || (needs.build-artifacts.result == 'skipped' && inputs.dry_run)) && !contains(inputs.skip_step, 'release-oss'))
     name: Release Docker OSS
     needs: [variables, build-artifacts]
     uses: ./.github/workflows/oss-release.yml
@@ -199,7 +200,7 @@ jobs:
     secrets: inherit
 
   release-plus-gcr-nginx:
-    if: ${{ !cancelled() && (needs.build-artifacts.result == 'success' || (needs.build-artifacts.result == 'skipped' && inputs.dry_run)) && !contains(inputs.skip_step, 'release-plus') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (!cancelled() && (needs.build-artifacts.result == 'success' || (needs.build-artifacts.result == 'skipped' && inputs.dry_run)) && !contains(inputs.skip_step, 'release-plus'))
     name: Release Docker Plus
     needs: [variables, build-artifacts]
     uses: ./.github/workflows/plus-release.yml
@@ -309,7 +310,7 @@ jobs:
   #   secrets: inherit
 
   publish-helm-chart:
-    if: ${{ ! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'publish-helm-chart') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'publish-helm-chart'))
     name: Publish Helm Chart
     uses: ./.github/workflows/publish-helm.yml
     with:
@@ -325,7 +326,7 @@ jobs:
     secrets: inherit
 
   certify-openshift-images:
-    if: ${{ ! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'certify-openshift-images') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'certify-openshift-images'))
     name: Certify OpenShift UBI images
     runs-on: ubuntu-24.04
     permissions:
@@ -366,7 +367,7 @@ jobs:
           preflight_version: 1.19.1 # renovate: datasource=github-releases depName=preflight packageName=redhat-openshift-ecosystem/openshift-preflight
 
   operator:
-    if: ${{ ! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'operator') && !contains(inputs.skip_step, 'publish-helm-chart') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'operator') && !contains(inputs.skip_step, 'publish-helm-chart'))
     name: Trigger PR for Operator
     runs-on: ubuntu-24.04
     needs: [variables,publish-helm-chart]
@@ -554,6 +555,7 @@ jobs:
 
   binaries:
     name: Process Binaries
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04-amd64
     needs: [variables, build-artifacts]
     permissions:
@@ -594,7 +596,7 @@ jobs:
 
   # Upload packages, sboms & checksums to release storage
   azure-upload:
-    if: ${{ ! cancelled() && ! failure() && ! contains(inputs.skip_step, 'azure-upload') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (! cancelled() && ! failure() && ! contains(inputs.skip_step, 'azure-upload'))
     name: Upload packages to Azure
     runs-on: ubuntu-24.04-amd64
     needs: [variables, binaries]
@@ -657,7 +659,7 @@ jobs:
             done
 
   github-release:
-    if: ${{ ! cancelled() && ! failure() && ! contains(inputs.skip_step, 'github-release') }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (! cancelled() && ! failure() && ! contains(inputs.skip_step, 'github-release'))
     name: Publish release to GitHub
     runs-on: ubuntu-24.04-amd64
     needs: [variables, binaries, release-oss, release-plus-gcr-nginx]

--- a/.github/workflows/renovate-build.yml
+++ b/.github/workflows/renovate-build.yml
@@ -23,7 +23,7 @@ jobs:
       generate: ${{ steps.filter.outputs.generate }}
     permissions:
       pull-requests: read
-    if: ${{ github.actor == 'renovate[bot]' }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (github.actor == 'renovate[bot]')
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    if: ${{ needs.check.outputs.generate == 'true' }}
+    if: github.repository == 'nginx/kubernetes-ingress' && (needs.check.outputs.generate == 'true')
     steps:
       - name: Azure login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0

--- a/.github/workflows/retag-images.yml
+++ b/.github/workflows/retag-images.yml
@@ -34,6 +34,7 @@ permissions:
 jobs:
   copy-to-gcr-dev-registry:
     name: Re-tag images in GCR Dev Registry
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,6 +17,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -49,6 +49,7 @@ jobs:
     permissions:
       contents: read # for docker/build-push-action to read repo content
       id-token: write # for OIDC login to GCR
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository

--- a/.github/workflows/single-image-regression.yml
+++ b/.github/workflows/single-image-regression.yml
@@ -65,6 +65,7 @@ permissions:
 jobs:
   checks:
     name: Run regression
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       issues: write # for actions/stale to close stale issues
       pull-requests: write # for actions/stale to close stale PRs
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   variables:
     name: Set variables for workflow
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     outputs:
       tag: ${{ steps.kic.outputs.tag }}
@@ -74,6 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJSON( needs.variables.outputs.matrix ) }}
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/patch-image.yml
     with:
       platforms: ${{ matrix.platforms }}
@@ -90,6 +92,7 @@ jobs:
   release-oss-internal:
     name: "Publish Docker OSS ${{ needs.variables.outputs.tag }}-${{ needs.variables.outputs.date }} to internal release Registries"
     needs: [variables, patch-images]
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/oss-release.yml
     with:
       gcr_release_registry: true
@@ -118,6 +121,7 @@ jobs:
           - "${{ needs.variables.outputs.short_tag }}"
           - "${{ needs.variables.outputs.tag }}-${{ needs.variables.outputs.date }}"
           - "latest"
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/oss-release.yml
     with:
       gcr_release_registry: false
@@ -146,6 +150,7 @@ jobs:
           - "${{ needs.variables.outputs.short_tag }}"
           - "${{ needs.variables.outputs.tag }}-${{ needs.variables.outputs.date }}"
           - "latest"
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/plus-release.yml
     with:
       nginx_registry: true
@@ -165,6 +170,7 @@ jobs:
   release-plus-internal:
     name: Publish Docker Plus ${{ needs.variables.outputs.tag }}-${{ needs.variables.outputs.date }} to internal release Registries
     needs: [variables, patch-images]
+    if: github.repository == 'nginx/kubernetes-ingress'
     uses: ./.github/workflows/plus-release.yml
     with:
       nginx_registry: false
@@ -183,6 +189,7 @@ jobs:
 
   certify-openshift-images:
     name: Certify OpenShift UBI images
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -222,7 +229,7 @@ jobs:
 
   patch-images-lts:
     name: Patch Images LTS
-    if: needs.variables.outputs.lts_release_matrix != '[]'
+    if: github.repository == 'nginx/kubernetes-ingress' && (needs.variables.outputs.lts_release_matrix != '[]')
     needs: [variables]
     strategy:
       fail-fast: false
@@ -243,7 +250,7 @@ jobs:
 
   release-plus-external-lts:
     name: Publish Docker Plus ${{ matrix.tag }}-${{ needs.variables.outputs.date }} to external release Registries
-    if: needs.variables.outputs.lts_release_matrix != '[]'
+    if: github.repository == 'nginx/kubernetes-ingress' && (needs.variables.outputs.lts_release_matrix != '[]')
     needs: [variables, patch-images-lts]
     strategy:
       fail-fast: false
@@ -264,7 +271,7 @@ jobs:
 
   release-plus-internal-lts:
     name: Publish Docker Plus ${{ matrix.tag }}-${{ needs.variables.outputs.date }} to internal release Registries
-    if: needs.variables.outputs.lts_release_matrix != '[]'
+    if: github.repository == 'nginx/kubernetes-ingress' && (needs.variables.outputs.lts_release_matrix != '[]')
     needs: [variables, patch-images-lts]
     strategy:
       fail-fast: false

--- a/.github/workflows/update-docker-sha.yml
+++ b/.github/workflows/update-docker-sha.yml
@@ -28,6 +28,7 @@ jobs:
   vars:
     permissions:
       contents: read
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     outputs:
       source_branch: ${{ steps.vars.outputs.source_branch }}
@@ -46,6 +47,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     needs: [vars]
     steps:

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   variables:
     name: Set variables
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -50,6 +51,7 @@ jobs:
 
   update-release-draft:
     name: Update Release Draft
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     needs: [variables]
     permissions:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -29,6 +29,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,25 @@ repos:
         require_serial: true
         pass_filenames: false
 
+      - id: test-workflow-gating
+        name: test workflow gating script
+        description: Runs unit tests for the workflow repository-gating validator.
+        entry: .github/scripts/validate-workflow-gating_test.sh
+        language: script
+        files: ^\.github/scripts/validate-workflow-gating(_test)?\.sh$
+        pass_filenames: false
+        require_serial: true
+
+      - id: validate-workflow-gating
+        name: validate workflow gating
+        description: Ensures every non-mirror workflow job is gated to the nginx/kubernetes-ingress repository.
+        entry: .github/scripts/validate-workflow-gating.sh
+        language: golang
+        additional_dependencies: ["github.com/mikefarah/yq/v4@v4.44.6"]
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false
+        require_serial: true
+
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2
     hooks:


### PR DESCRIPTION
## Proposed changes

Introduce repository gating to all public workflow jobs to prevent them from triggering when synced/pushed to internal downstream mirror repos. Also, add an automated yq-based validator to the actionlint check to enforce this gating policy for all future workflow additions.

### Why?

In any other mirror of this, we might want to run slightly different CI workflows. If we edit the current workflow files, keeping the mirror branches track this repository becomes incredibly painful due to the merge conflicts.

Each mirror workflow should be in their own file, so merges remain clean, but that means we need to make sure that the original workflows do not run where they shouldn't need to.

### Will this be an issue if people forget to add the gate to new jobs?

No, there's a linter that will yell at us.

## Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
