### PR TITLE
Fix conditional for nodePort in controller-service.yaml

### DIFF
--- a/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/nginx-ingress/templates/controller-service.yaml
@@ -54,7 +54,7 @@ spec:
     targetPort: {{ .Values.controller.service.httpPort.targetPort }}
     protocol: TCP
     name: {{ .Values.controller.service.httpPort.name }}
-  {{- if or (eq .Values.controller.service.type "LoadBalancer") (eq .Values.controller.service.type "NodePort") }}
+  {{- if and (or (eq .Values.controller.service.type "LoadBalancer") (eq .Values.controller.service.type "NodePort")) (not (empty .Values.controller.service.httpPort.nodePort)) }}
     nodePort: {{ .Values.controller.service.httpPort.nodePort }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### Proposed changes

Avoid setting an explicit empty value for nodePort when not using nodePorts, which causes issues with systems that compare the manifest with the live values (where a nodePort will be injected). Fixes #9054.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
