### PR TITLE
test: tolerate connection drops during NGINX reloads in reload-sensitive e2e tests

### DIFF
--- a/tests/suite/FLAKY_RELOAD_REQUESTS.md
+++ b/tests/suite/FLAKY_RELOAD_REQUESTS.md
@@ -39,26 +39,40 @@ Do not wrap the whole test in `@pytest.mark.flaky` -- that reruns the entire
 expensive test and can mask real regressions. Instead, make the specific request
 resilient.
 
-Use the shared helper in `suite/utils/resources_utils.py`:
+Use one of the shared helpers in `suite/utils/resources_utils.py`, all of which
+catch `requests.exceptions.ConnectionError` while retrying:
 
-```python
-from suite.utils.resources_utils import retry_get_until_body_contains
+- `retry_get_until_body_contains(req_url, host, expected_body)` -- poll until a
+  substring appears in the body.
+- `retry_get_until_status_code(req_url, host, expected_status, session=..., **kwargs)`
+  -- poll until a status code matches; supports an SNI/client-cert `session` and
+  extra `requests.get` kwargs (`cert`, `verify`, `allow_redirects`, ...).
+- `retry_get(req_url, host, **kwargs)` -- guard a single request whose assertion
+  cannot be expressed as "body contains X" or "status == Y" (e.g. asserting a
+  substring is absent, or an arbitrary status); retries only on `ConnectionError`.
 
-resp = retry_get_until_body_contains(req_url, ingress_host, expected_body)
-assert expected_body in resp.text
-assert resp.status_code == 200
-```
+The shared helpers `wait_and_assert_status_code` (`suite/utils/custom_assertions.py`)
+and `send_malicious_request_with_retry` (`suite/utils/ap_resources_utils.py`) also
+tolerate `ConnectionError`, so their many callers are covered automatically.
+
+    ```python
+    from suite.utils.resources_utils import retry_get_until_body_contains
+
+    resp = retry_get_until_body_contains(req_url, ingress_host, expected_body)
+    assert expected_body in resp.text
+    assert resp.status_code == 200
+    ```
 
 Replace hand-rolled loops like:
 
-```python
-resp = requests.get(url, headers={"host": host}, verify=False)
-retry = 0
-while expected not in resp.text and retry <= 60:
-    resp = requests.get(url, headers={"host": host}, verify=False)  # can raise ConnectionError
-    retry += 1
-    wait_before_test(1)
-```
+    ```python
+    resp = requests.get(url, headers={"host": host}, verify=False)
+    retry = 0
+    while expected not in resp.text and retry <= 60:
+        resp = requests.get(url, headers={"host": host}, verify=False)  # can raise ConnectionError
+        retry += 1
+        wait_before_test(1)
+    ```
 
 with a single `retry_get_until_body_contains(...)` call.
 
@@ -66,10 +80,18 @@ If a test needs a method/headers/body the helper doesn't cover, replicate its
 core guarantee: catch `requests.exceptions.ConnectionError` inside the retry loop
 and continue, rather than letting it propagate.
 
+Note: `requests.exceptions.SSLError` is a *subclass* of `ConnectionError`. When a
+test relies on catching `SSLError` (e.g. mTLS client-cert tests), keep the
+`except SSLError` handler **before** any `except ConnectionError` handler so the
+SSL case is not swallowed.
+
 ## Reference implementation
 
 See `test_app_protect_watch_namespace_label.py` and the
 `retry_get_until_body_contains` helper in `suite/utils/resources_utils.py`.
+For status-based and single-request variants, see `retry_get_until_status_code`
+and `retry_get` in the same file, and the mTLS tests (`test_ingress_mtls*.py`)
+for the SSLError-ordering pattern.
 
 ## Checklist for the AI applying this
 

--- a/tests/suite/FLAKY_RELOAD_REQUESTS.md
+++ b/tests/suite/FLAKY_RELOAD_REQUESTS.md
@@ -1,0 +1,83 @@
+# Fixing flaky e2e tests: connection drops during NGINX reloads
+
+## Symptom
+
+A test intermittently fails with:
+
+    requests.exceptions.ConnectionError:
+      ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
+
+Often accompanied in the IC logs by an access-log line with status `000`, and
+around a config change (Ingress/Policy/namespace-label update) that triggers an
+NGINX reload. With App Protect, the WAF "soft reset" recycles workers and can
+take several seconds, widening the window where in-flight connections are closed.
+
+## Root cause
+
+The test sends an HTTP request that lands exactly while NGINX is reloading and
+recycling worker processes. NGINX closes the connection, `requests` raises an
+uncaught `ConnectionError`, and the test crashes instead of retrying. This is a
+timing race, not a product bug -- a dropped connection during a reload is
+expected and should be retried (the same way `ensure_response_from_backend` and
+`wait_for_reload` already tolerate transients).
+
+## When this pattern applies
+
+Apply the fix to any e2e test that BOTH:
+
+1. Mutates config that causes a reload (apply/patch/delete of Ingress, VS/VSR,
+   TransportServer, Policy, ConfigMap, or namespace label/watch changes), AND
+2. Sends traffic (`requests.get/post/...`) shortly after, while a reload may be
+   in progress -- especially inside a body/status polling loop.
+
+Do NOT apply it to tests that only send traffic against already-stable config
+and never reload mid-traffic (e.g. `test_app_protect_watch_namespace.py`).
+
+## The fix
+
+Do not wrap the whole test in `@pytest.mark.flaky` -- that reruns the entire
+expensive test and can mask real regressions. Instead, make the specific request
+resilient.
+
+Use the shared helper in `suite/utils/resources_utils.py`:
+
+```python
+from suite.utils.resources_utils import retry_get_until_body_contains
+
+resp = retry_get_until_body_contains(req_url, ingress_host, expected_body)
+assert expected_body in resp.text
+assert resp.status_code == 200
+```
+
+Replace hand-rolled loops like:
+
+```python
+resp = requests.get(url, headers={"host": host}, verify=False)
+retry = 0
+while expected not in resp.text and retry <= 60:
+    resp = requests.get(url, headers={"host": host}, verify=False)  # can raise ConnectionError
+    retry += 1
+    wait_before_test(1)
+```
+
+with a single `retry_get_until_body_contains(...)` call.
+
+If a test needs a method/headers/body the helper doesn't cover, replicate its
+core guarantee: catch `requests.exceptions.ConnectionError` inside the retry loop
+and continue, rather than letting it propagate.
+
+## Reference implementation
+
+See `test_app_protect_watch_namespace_label.py` and the
+`retry_get_until_body_contains` helper in `suite/utils/resources_utils.py`.
+
+## Checklist for the AI applying this
+
+- [ ] Confirm the test reloads config AND sends traffic that could overlap it.
+- [ ] Replace unguarded `requests.*` retry loops with `retry_get_until_body_contains`
+      (or add `except requests.exceptions.ConnectionError: continue` to the loop).
+- [ ] Guard single pre-loop requests that immediately follow a config change too.
+- [ ] Preserve existing assertions and the ~60s retry budget.
+- [ ] Remove the now-unused `import requests` if no other usage remains in the file.
+- [ ] Do NOT add `@pytest.mark.flaky`.
+- [ ] Test-only change: no product code, codegen, or snapshot updates.

--- a/tests/suite/test_app_protect_integration.py
+++ b/tests/suite/test_app_protect_integration.py
@@ -1,5 +1,4 @@
 import pytest
-import requests
 import yaml
 from settings import CRDS, TEST_DATA
 from suite.utils.ap_resources_utils import (
@@ -28,6 +27,7 @@ from suite.utils.resources_utils import (
     get_pod_name_that_contains,
     get_pods_amount,
     get_test_file_name,
+    retry_get,
     scale_deployment,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -209,7 +209,7 @@ class TestAppProtect:
         ensure_response_from_backend(appprotect_setup.req_url, ingress_host, check404=True)
 
         print("----------------------- Send request ----------------------")
-        response = requests.get(appprotect_setup.req_url + "/<script>", headers={"host": ingress_host}, verify=False)
+        response = retry_get(appprotect_setup.req_url + "/<script>", ingress_host, verify=False)
         print(response.text)
         delete_items_from_yaml(kube_apis, src_ing_yaml, test_namespace)
         assert_invalid_responses(response)
@@ -233,7 +233,7 @@ class TestAppProtect:
         wait_before_test(5)
 
         print("----------------------- Send request ----------------------")
-        response = requests.get(appprotect_setup.req_url + "/<script>", headers={"host": ingress_host}, verify=False)
+        response = retry_get(appprotect_setup.req_url + "/<script>", ingress_host, verify=False)
         print(response.text)
         delete_items_from_yaml(kube_apis, src_ing_yaml, test_namespace)
         assert_valid_responses(response)
@@ -260,7 +260,7 @@ class TestAppProtect:
         ensure_response_from_backend(appprotect_setup.req_url, ingress_host, check404=True)
 
         print("----------------------- Send request ----------------------")
-        response = requests.get(appprotect_setup.req_url + "/<script>", headers={"host": ingress_host}, verify=False)
+        response = retry_get(appprotect_setup.req_url + "/<script>", ingress_host, verify=False)
         print(response.text)
         delete_items_from_yaml(kube_apis, src_ing_yaml, test_namespace)
         assert_invalid_responses(response)
@@ -288,7 +288,7 @@ class TestAppProtect:
 
         print("----------------------- Send request ----------------------")
         wait_before_test(5)
-        response = requests.get(appprotect_setup.req_url + "/<script>", headers={"host": ingress_host}, verify=False)
+        response = retry_get(appprotect_setup.req_url + "/<script>", ingress_host, verify=False)
         print(response.text)
         delete_items_from_yaml(kube_apis, src_ing_yaml, test_namespace)
         assert_valid_responses(response)
@@ -366,7 +366,7 @@ class TestAppProtect:
         ensure_response_from_backend(appprotect_setup.req_url, ingress_host, check404=True)
 
         print("----------------------- Send request ----------------------")
-        response = requests.get(appprotect_setup.req_url + "/<script>", headers={"host": ingress_host}, verify=False)
+        response = retry_get(appprotect_setup.req_url + "/<script>", ingress_host, verify=False)
         print(response.text)
         syslog_pod = get_pod_name_that_contains(kube_apis.v1, test_namespace, "syslog-")
         syslog2_pod = get_pod_name_that_contains(kube_apis.v1, test_namespace, "syslog2")
@@ -434,9 +434,9 @@ class TestAppProtect:
         wait_before_test(120)
         ensure_response_from_backend(appprotect_setup.req_url, ingress_host, check404=True)
         print("----------------------- Send request ----------------------")
-        response1 = requests.get(appprotect_setup.req_url, headers={"host": ingress_host}, verify=False, data="kic")
+        response1 = retry_get(appprotect_setup.req_url, ingress_host, verify=False, data="kic")
         print(response1.text)
-        response2 = requests.get(appprotect_setup.req_url + "/<script>", headers={"host": ingress_host}, verify=False)
+        response2 = retry_get(appprotect_setup.req_url + "/<script>", ingress_host, verify=False)
         print(response2.text)
         reload_ms = get_last_reload_time(appprotect_setup.metrics_url, "nginx")
         print(f"last reload duration: {reload_ms} ms")

--- a/tests/suite/test_app_protect_waf_bundle_source_vs.py
+++ b/tests/suite/test_app_protect_waf_bundle_source_vs.py
@@ -1,5 +1,4 @@
 import pytest
-import requests
 from settings import TEST_DATA
 from suite.utils.ap_resources_utils import (
     assert_waf_blocked,
@@ -14,7 +13,7 @@ from suite.utils.bundle_source_utils import (
 )
 from suite.utils.custom_resources_utils import read_custom_resource, wait_for_resource_status
 from suite.utils.policy_resources_utils import delete_policy
-from suite.utils.resources_utils import wait_before_test
+from suite.utils.resources_utils import retry_get, wait_before_test
 from suite.utils.vs_vsr_resources_utils import (
     create_virtual_server_from_yaml,
     delete_virtual_server,
@@ -208,9 +207,10 @@ class TestWAFBundleSourceFailureVS:
         # WAF is inactive so a malicious request should NOT be blocked with
         # the rejection page. The VS may return a 500 or the backend's response
         # depending on how the NGINX config was generated.
-        response = requests.get(
+        # Tolerate a connection dropped by an NGINX reload; retry the single request.
+        response = retry_get(
             virtual_server_setup.backend_1_url + "</script>",
-            headers={"host": virtual_server_setup.vs_host},
+            virtual_server_setup.vs_host,
         )
         assert "The requested URL was rejected" not in response.text
 

--- a/tests/suite/test_app_protect_waf_policies.py
+++ b/tests/suite/test_app_protect_waf_policies.py
@@ -1,5 +1,4 @@
 import pytest
-import requests
 from settings import TEST_DATA
 from suite.utils.ap_resources_utils import (
     create_ap_logconf_from_yaml,
@@ -17,6 +16,7 @@ from suite.utils.resources_utils import (
     create_items_from_yaml,
     get_file_contents,
     get_pod_name_that_contains,
+    retry_get,
     wait_before_test,
 )
 from suite.utils.vs_vsr_resources_utils import (
@@ -197,16 +197,16 @@ class TestAppProtectWAFPolicyVS:
         wait_before_test(120)
 
         print("----------------------- Send request with embedded malicious script----------------------")
-        response1 = requests.get(
+        response1 = retry_get(
             virtual_server_setup.backend_1_url + "</script>",
-            headers={"host": virtual_server_setup.vs_host},
+            virtual_server_setup.vs_host,
         )
         print(response1.text)
 
         print("----------------------- Send request with blocked keyword in UDS----------------------")
-        response2 = requests.get(
+        response2 = retry_get(
             virtual_server_setup.backend_1_url,
-            headers={"host": virtual_server_setup.vs_host},
+            virtual_server_setup.vs_host,
             data="kic",
         )
         print(response2.text)
@@ -268,16 +268,16 @@ class TestAppProtectWAFPolicyVS:
         wait_before_test(120)
 
         print("----------------------- Send request with embedded malicious script----------------------")
-        response1 = requests.get(
+        response1 = retry_get(
             virtual_server_setup.backend_1_url + "</script>",
-            headers={"host": virtual_server_setup.vs_host},
+            virtual_server_setup.vs_host,
         )
         print(response1.text)
 
         print("----------------------- Send request with blocked keyword in UDS----------------------")
-        response2 = requests.get(
+        response2 = retry_get(
             virtual_server_setup.backend_1_url,
-            headers={"host": virtual_server_setup.vs_host},
+            virtual_server_setup.vs_host,
             data="kic",
         )
         print(response2.text)
@@ -333,9 +333,9 @@ class TestAppProtectWAFPolicyVS:
         wait_before_test(120)
 
         print("----------------------- Send request with embedded malicious script----------------------")
-        response = requests.get(
+        response = retry_get(
             virtual_server_setup.backend_1_url + "</script>",
-            headers={"host": virtual_server_setup.vs_host},
+            virtual_server_setup.vs_host,
         )
         print(response.text)
         syslog_pod = get_pod_name_that_contains(kube_apis.v1, test_namespace, "syslog")
@@ -449,9 +449,9 @@ class TestAppProtectWAFPolicyVSR:
         ap_crd_info = read_ap_custom_resource(kube_apis.custom_objects, test_namespace, "appolicies", ap_policy_uds)
         assert_ap_crd_info(ap_crd_info, ap_policy_uds)
         wait_before_test(120)
-        response = requests.get(
+        response = retry_get(
             f'{req_url}{v_s_route_setup.route_m.paths[0]}+"</script>"',
-            headers={"host": v_s_route_setup.vs_host},
+            v_s_route_setup.vs_host,
         )
         print(response.text)
         delete_policy(kube_apis.custom_objects, "waf-policy", v_s_route_setup.route_m.namespace)
@@ -546,9 +546,9 @@ class TestAppProtectWAFPolicyVSRSelector:
         ap_crd_info = read_ap_custom_resource(kube_apis.custom_objects, test_namespace, "appolicies", ap_policy_uds)
         assert_ap_crd_info(ap_crd_info, ap_policy_uds)
         wait_before_test(120)
-        response = requests.get(
+        response = retry_get(
             f'{req_url}{v_s_route_selector_setup.route_m.paths[0]}+"</script>"',
-            headers={"host": v_s_route_selector_setup.vs_host},
+            v_s_route_selector_setup.vs_host,
         )
         print(response.text)
         delete_policy(kube_apis.custom_objects, "waf-policy", v_s_route_selector_setup.route_m.namespace)

--- a/tests/suite/test_app_protect_watch_namespace_label.py
+++ b/tests/suite/test_app_protect_watch_namespace_label.py
@@ -1,7 +1,6 @@
 import time
 
 import pytest
-import requests
 from settings import TEST_DATA
 from suite.utils.ap_resources_utils import (
     create_ap_logconf_from_yaml,
@@ -20,6 +19,7 @@ from suite.utils.resources_utils import (
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
     patch_namespace_with_label,
+    retry_get_until_body_contains,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -156,8 +156,8 @@ class TestAppProtectWatchNamespaceLabelEnabled:
         ensure_response_from_backend(backend_setup.req_url, backend_setup.ingress_host, check404=True)
 
         print("----------------------- Send request ----------------------")
-        resp = requests.get(
-            f"{backend_setup.req_url}/test.bat", headers={"host": backend_setup.ingress_host}, verify=False
+        resp = retry_get_until_body_contains(
+            f"{backend_setup.req_url}/test.bat", backend_setup.ingress_host, valid_resp_body
         )
 
         print(resp.text)
@@ -176,17 +176,9 @@ class TestAppProtectWatchNamespaceLabelEnabled:
         ensure_response_from_backend(backend_setup.req_url, backend_setup.ingress_host, check404=True)
 
         print("----------------------- Send request ----------------------")
-        resp = requests.get(
-            f"{backend_setup.req_url}/test.bat", headers={"host": backend_setup.ingress_host}, verify=False
+        resp = retry_get_until_body_contains(
+            f"{backend_setup.req_url}/test.bat", backend_setup.ingress_host, invalid_resp_body
         )
-        retry = 0
-        while invalid_resp_body not in resp.text and retry <= 60:
-            resp = requests.get(
-                f"{backend_setup.req_url}/test.bat", headers={"host": backend_setup.ingress_host}, verify=False
-            )
-            retry += 1
-            wait_before_test(1)
-            print(f"Policy not yet enforced, retrying... #{retry}")
 
         assert invalid_resp_body in resp.text
         assert resp.status_code == 200
@@ -202,17 +194,9 @@ class TestAppProtectWatchNamespaceLabelEnabled:
         ensure_response_from_backend(backend_setup.req_url, backend_setup.ingress_host, check404=True)
 
         print("----------------------- Send request ----------------------")
-        resp = requests.get(
-            f"{backend_setup.req_url}/test.bat", headers={"host": backend_setup.ingress_host}, verify=False
+        resp = retry_get_until_body_contains(
+            f"{backend_setup.req_url}/test.bat", backend_setup.ingress_host, valid_resp_body
         )
-        retry = 0
-        while valid_resp_body not in resp.text and retry <= 60:
-            resp = requests.get(
-                f"{backend_setup.req_url}/test.bat", headers={"host": backend_setup.ingress_host}, verify=False
-            )
-            retry += 1
-            wait_before_test(1)
-            print(f"Policy not yet removed, retrying... #{retry}")
 
         assert valid_resp_body in resp.text
         assert resp.status_code == 200

--- a/tests/suite/test_dos.py
+++ b/tests/suite/test_dos.py
@@ -3,7 +3,6 @@ import subprocess
 from datetime import datetime
 
 import pytest
-import requests
 from settings import TEST_DATA
 from suite.utils.custom_resources_utils import (
     create_dos_logconf_from_yaml,
@@ -37,6 +36,7 @@ from suite.utils.resources_utils import (
     get_test_file_name,
     nginx_reload,
     replace_configmap_from_yaml,
+    retry_get,
     scale_deployment,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -243,7 +243,7 @@ class TestDos:
 
         print("----------------------- Send request ----------------------")
         wait_before_test(5)
-        response = requests.get(dos_setup.req_url, headers={"host": "dos.example.com"}, verify=False)
+        response = retry_get(dos_setup.req_url, "dos.example.com", verify=False)
         print(response.text)
 
         print(f"log_loc {log_loc} syslog_pod {syslog_pod} namespace {ingress_controller_prerequisites.namespace}")
@@ -283,8 +283,11 @@ class TestDos:
 
         print("----------------------- Send request to check allowlist ----------------------")
         wait_before_test(5)
-        response = requests.get(
-            dos_setup.req_url, headers={"host": "dos.example.com", "X-Forwarded-For": "10.10.10.10"}, verify=False
+        response = retry_get(
+            dos_setup.req_url,
+            None,
+            headers={"host": "dos.example.com", "X-Forwarded-For": "10.10.10.10"},
+            verify=False,
         )
         print(response.text)
 

--- a/tests/suite/test_ingress_mtls.py
+++ b/tests/suite/test_ingress_mtls.py
@@ -2,9 +2,14 @@ from unittest import mock
 
 import pytest
 import requests
-from settings import TEST_DATA
+from settings import RECONFIGURATION_DELAY, TEST_DATA
 from suite.utils.policy_resources_utils import create_policy_from_yaml, delete_policy
-from suite.utils.resources_utils import create_secret_from_yaml, delete_secret, wait_before_test
+from suite.utils.resources_utils import (
+    create_secret_from_yaml,
+    delete_secret,
+    retry_get_until_status_code,
+    wait_before_test,
+)
 from suite.utils.ssl_utils import create_sni_session
 from suite.utils.vs_vsr_resources_utils import (
     delete_and_create_vs_from_yaml,
@@ -146,19 +151,18 @@ class TestIngressMtlsPolicyVS:
             virtual_server_setup.namespace,
         )
         wait_before_test()
-        resp = mock.Mock()
-        counter = 0
-
-        while resp.status_code != expected_code and counter < 10:
-            resp = session.get(
-                virtual_server_setup.backend_1_url_ssl,
-                cert=(crt, key),
-                headers={"host": virtual_server_setup.vs_host},
-                allow_redirects=False,
-                verify=False,
-            )
-            wait_before_test()
-            counter += 1
+        # Tolerate connections dropped by an NGINX reload during the policy swap.
+        resp = retry_get_until_status_code(
+            virtual_server_setup.backend_1_url_ssl,
+            virtual_server_setup.vs_host,
+            expected_code,
+            retries=10,
+            wait_seconds=RECONFIGURATION_DELAY,
+            session=session,
+            cert=(crt, key),
+            allow_redirects=False,
+            verify=False,
+        )
 
         vs_res = read_vs(kube_apis.custom_objects, test_namespace, virtual_server_setup.vs_name)
         teardown_policy(kube_apis, test_namespace, tls_secret, pol_name, mtls_secret)
@@ -239,6 +243,12 @@ class TestIngressMtlsPolicyVS:
                 resp = mock.Mock()
                 resp.status_code = "None"
                 resp.text = "None"
+            except requests.exceptions.ConnectionError as e:
+                # NGINX reload recycled workers and dropped the connection; retry.
+                # Note: SSLError subclasses ConnectionError, so this must come after it.
+                print(f"Connection dropped during reload: {e}")
+                wait_before_test()
+                counter += 1
 
         teardown_policy(kube_apis, test_namespace, tls_secret, pol_name, mtls_secret)
 
@@ -313,20 +323,18 @@ class TestIngressMtlsPolicyVS:
             virtual_server_setup.namespace,
         )
         wait_before_test()
-        resp = mock.Mock()
-        resp.status_code == 502
-        counter = 0
-
-        while resp.status_code != expected_code and counter < 10:
-            resp = session.get(
-                virtual_server_setup.backend_1_url_ssl,
-                cert=(crt_not_revoked, key_not_revoked),
-                headers={"host": virtual_server_setup.vs_host},
-                allow_redirects=False,
-                verify=False,
-            )
-            wait_before_test()
-            counter += 1
+        # Tolerate connections dropped by an NGINX reload during the VS recreate.
+        resp = retry_get_until_status_code(
+            virtual_server_setup.backend_1_url_ssl,
+            virtual_server_setup.vs_host,
+            expected_code,
+            retries=10,
+            wait_seconds=RECONFIGURATION_DELAY,
+            session=session,
+            cert=(crt_not_revoked, key_not_revoked),
+            allow_redirects=False,
+            verify=False,
+        )
 
         vs_res = read_vs(kube_apis.custom_objects, test_namespace, virtual_server_setup.vs_name)
         teardown_policy(kube_apis, test_namespace, tls_secret, pol_name, mtls_secret)
@@ -405,6 +413,12 @@ class TestIngressMtlsPolicyVS:
                 resp = mock.Mock()
                 resp.status_code = "None"
                 resp.text = "None"
+            except requests.exceptions.ConnectionError as e:
+                # NGINX reload recycled workers and dropped the connection; retry.
+                # Note: SSLError subclasses ConnectionError, so this must come after it.
+                print(f"Connection dropped during reload: {e}")
+                wait_before_test()
+                counter += 1
 
         teardown_policy(kube_apis, test_namespace, tls_secret, pol_name, mtls_secret)
 

--- a/tests/suite/test_ingress_mtls_ingress.py
+++ b/tests/suite/test_ingress_mtls_ingress.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 import requests
-from settings import TEST_DATA
+from settings import RECONFIGURATION_DELAY, TEST_DATA
 from suite.utils.custom_resources_utils import read_custom_resource
 from suite.utils.policy_resources_utils import (
     apply_and_wait_for_valid_policy,
@@ -17,6 +17,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    retry_get_until_status_code,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -152,6 +153,12 @@ class TestIngressMTLSPoliciesIngress:
                     resp.status_code = "None"
                     resp.text = "None"
                     break
+                except requests.exceptions.ConnectionError as e:
+                    # NGINX reload recycled workers and dropped the connection; retry.
+                    # Note: SSLError subclasses ConnectionError, so this must come after it.
+                    print(f"Connection dropped during reload: {e}")
+                    wait_before_test()
+                    counter += 1
 
             assert (
                 resp.status_code == expected_code
@@ -229,18 +236,17 @@ class TestIngressMTLSPoliciesIngress:
                 counter += 1
 
             session = create_sni_session()
-            resp = mock.Mock()
-            resp.status_code = 404
-            counter = 0
-            while resp.status_code != 500 and counter < 30:
-                resp = session.get(
-                    request_url,
-                    headers={"host": ingress_host},
-                    allow_redirects=False,
-                    verify=False,
-                )
-                wait_before_test()
-                counter += 1
+            # Tolerate connections dropped by an NGINX reload after the ingress/policy apply.
+            resp = retry_get_until_status_code(
+                request_url,
+                ingress_host,
+                500,
+                retries=30,
+                wait_seconds=RECONFIGURATION_DELAY,
+                session=session,
+                allow_redirects=False,
+                verify=False,
+            )
 
             assert resp.status_code == 500, f"Expected 500 for invalid policy, got {resp.status_code}"
             assert (
@@ -299,20 +305,18 @@ class TestIngressMTLSPoliciesIngress:
             )
 
             session = create_sni_session()
-            resp = mock.Mock()
-            resp.status_code = 502
-            counter = 0
-
-            while resp.status_code != 200 and counter < 10:
-                resp = session.get(
-                    request_url,
-                    cert=(intermediate_crt, intermediate_key),
-                    headers={"host": ingress_host},
-                    allow_redirects=False,
-                    verify=False,
-                )
-                wait_before_test()
-                counter += 1
+            # Tolerate connections dropped by an NGINX reload after the ingress/policy apply.
+            resp = retry_get_until_status_code(
+                request_url,
+                ingress_host,
+                200,
+                retries=10,
+                wait_seconds=RECONFIGURATION_DELAY,
+                session=session,
+                cert=(intermediate_crt, intermediate_key),
+                allow_redirects=False,
+                verify=False,
+            )
 
             assert (
                 resp.status_code == 200
@@ -332,20 +336,18 @@ class TestIngressMTLSPoliciesIngress:
             print("Wait for NGINX reload after policy swap")
             wait_before_test()
 
-            resp = mock.Mock()
-            resp.status_code = 200
-            counter = 0
-
-            while resp.status_code != 400 and counter < 10:
-                resp = session.get(
-                    request_url,
-                    cert=(intermediate_crt, intermediate_key),
-                    headers={"host": ingress_host},
-                    allow_redirects=False,
-                    verify=False,
-                )
-                wait_before_test()
-                counter += 1
+            # Tolerate connections dropped by the NGINX reload after the policy swap.
+            resp = retry_get_until_status_code(
+                request_url,
+                ingress_host,
+                400,
+                retries=10,
+                wait_seconds=RECONFIGURATION_DELAY,
+                session=session,
+                cert=(intermediate_crt, intermediate_key),
+                allow_redirects=False,
+                verify=False,
+            )
 
             assert (
                 resp.status_code == 400
@@ -408,19 +410,17 @@ class TestIngressMTLSPoliciesIngress:
             )
 
             session = create_sni_session()
-            resp = mock.Mock()
-            resp.status_code = 404
-            counter = 0
-
-            while resp.status_code != 500 and counter < 30:
-                resp = session.get(
-                    request_url,
-                    headers={"host": ingress_host},
-                    allow_redirects=False,
-                    verify=False,
-                )
-                wait_before_test()
-                counter += 1
+            # Tolerate connections dropped by an NGINX reload after the ingress/policy apply.
+            resp = retry_get_until_status_code(
+                request_url,
+                ingress_host,
+                500,
+                retries=30,
+                wait_seconds=RECONFIGURATION_DELAY,
+                session=session,
+                allow_redirects=False,
+                verify=False,
+            )
 
             assert (
                 resp.status_code == 500

--- a/tests/suite/test_ingress_mtls_mergeable_ingress.py
+++ b/tests/suite/test_ingress_mtls_mergeable_ingress.py
@@ -1,7 +1,5 @@
-from unittest import mock
-
 import pytest
-from settings import TEST_DATA
+from settings import RECONFIGURATION_DELAY, TEST_DATA
 from suite.utils.custom_resources_utils import read_custom_resource
 from suite.utils.policy_resources_utils import apply_and_wait_for_valid_policy, delete_policy
 from suite.utils.resources_utils import (
@@ -12,7 +10,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
-    wait_before_test,
+    retry_get_until_status_code,
     wait_until_all_pods_are_ready,
 )
 from suite.utils.ssl_utils import create_sni_session
@@ -82,20 +80,18 @@ class TestIngressMTLSMergeableIngress:
             policy_info = read_custom_resource(kube_apis.custom_objects, test_namespace, "policies", pol_name)
             session = create_sni_session()
 
-            # No cert gives 400 meaning the policy is enforced at the master server block level
-            resp = mock.Mock()
-            resp.status_code = 502
-            counter = 0
-
-            while resp.status_code != 400 and counter < 10:
-                resp = session.get(
-                    request_url,
-                    headers={"host": ingress_host},
-                    allow_redirects=False,
-                    verify=False,
-                )
-                wait_before_test()
-                counter += 1
+            # No cert gives 400 meaning the policy is enforced at the master server block level.
+            # Tolerate connections dropped by an NGINX reload after the ingress/policy apply.
+            resp = retry_get_until_status_code(
+                request_url,
+                ingress_host,
+                400,
+                retries=10,
+                wait_seconds=RECONFIGURATION_DELAY,
+                session=session,
+                allow_redirects=False,
+                verify=False,
+            )
 
             assert resp.status_code == 400, (
                 f"Expected 400 with no client cert on mergeable master, "
@@ -105,10 +101,14 @@ class TestIngressMTLSMergeableIngress:
                 "No required SSL certificate was sent" in resp.text
             ), f"Expected SSL error message in response body, got: {resp.text}"
             # Valid cert gives 200 which confirms the merged Ingress routes correctly
-            resp = session.get(
+            resp = retry_get_until_status_code(
                 request_url,
+                ingress_host,
+                200,
+                retries=10,
+                wait_seconds=RECONFIGURATION_DELAY,
+                session=session,
                 cert=(crt, key),
-                headers={"host": ingress_host},
                 allow_redirects=False,
                 verify=False,
             )
@@ -171,20 +171,18 @@ class TestIngressMTLSMergeableIngress:
             policy_info = read_custom_resource(kube_apis.custom_objects, test_namespace, "policies", pol_name)
             session = create_sni_session()
 
-            # IngressMTLS policy on a minion is rejected; config is not applied and HTTP 500 is returned
-            resp = mock.Mock()
-            resp.status_code = 200
-            counter = 0
-
-            while resp.status_code != 500 and counter < 10:
-                resp = session.get(
-                    request_url,
-                    headers={"host": ingress_host},
-                    allow_redirects=False,
-                    verify=False,
-                )
-                wait_before_test()
-                counter += 1
+            # IngressMTLS policy on a minion is rejected; config is not applied and HTTP 500 is returned.
+            # Tolerate connections dropped by an NGINX reload after the ingress/policy apply.
+            resp = retry_get_until_status_code(
+                request_url,
+                ingress_host,
+                500,
+                retries=10,
+                wait_seconds=RECONFIGURATION_DELAY,
+                session=session,
+                allow_redirects=False,
+                verify=False,
+            )
 
             assert resp.status_code == 500, (
                 f"Expected 500 (IngressMTLS on minion should be rejected), "

--- a/tests/suite/test_virtual_server_dos.py
+++ b/tests/suite/test_virtual_server_dos.py
@@ -3,7 +3,6 @@ import subprocess
 from datetime import datetime
 
 import pytest
-import requests
 from settings import TEST_DATA
 from suite.utils.custom_assertions import wait_and_assert_status_code
 from suite.utils.custom_resources_utils import (
@@ -29,6 +28,7 @@ from suite.utils.resources_utils import (
     get_vs_nginx_template_conf,
     nginx_reload,
     replace_configmap_from_yaml,
+    retry_get,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -205,9 +205,7 @@ class TestDos:
         print("----------------------- Send request ----------------------")
         ensure_response_from_backend(virtual_server_setup_dos.backend_1_url, virtual_server_setup_dos.vs_host)
 
-        response = requests.get(
-            virtual_server_setup_dos.backend_1_url, headers={"host": virtual_server_setup_dos.vs_host}
-        )
+        response = retry_get(virtual_server_setup_dos.backend_1_url, virtual_server_setup_dos.vs_host)
         print(response.text)
 
         wait_before_test(20)

--- a/tests/suite/test_watch_namespace_label.py
+++ b/tests/suite/test_watch_namespace_label.py
@@ -1,5 +1,5 @@
 import pytest
-from settings import TEST_DATA
+from settings import RECONFIGURATION_DELAY, TEST_DATA
 from suite.utils.resources_utils import (
     create_example_app,
     create_items_from_yaml,
@@ -135,7 +135,11 @@ class TestWatchNamespaceLabelIngress:
             ensure_response_from_backend(backend_setup.req_url, backend_setup.resource_hosts[ing])
             # Tolerate connections dropped by an NGINX reload from the namespace label change.
             resp = retry_get_until_status_code(
-                backend_setup.req_url, backend_setup.resource_hosts[ing], expected_responses[ing], retries=3
+                backend_setup.req_url,
+                backend_setup.resource_hosts[ing],
+                expected_responses[ing],
+                retries=3,
+                wait_seconds=RECONFIGURATION_DELAY,
             )
             assert (
                 resp.status_code == expected_responses[ing]
@@ -146,7 +150,13 @@ class TestWatchNamespaceLabelIngress:
         ensure_response_from_backend(backend_setup.req_url, backend_setup.resource_hosts[ing])
         ing = "foreign-ns-ingress"
         # Tolerate connections dropped by the NGINX reload from the namespace label change.
-        resp = retry_get_until_status_code(backend_setup.req_url, backend_setup.resource_hosts[ing], 200, retries=3)
+        resp = retry_get_until_status_code(
+            backend_setup.req_url,
+            backend_setup.resource_hosts[ing],
+            200,
+            retries=3,
+            wait_seconds=RECONFIGURATION_DELAY,
+        )
         assert (
             resp.status_code == 200
         ), f"Expected: 200 response code for {backend_setup.resource_hosts[ing]} after adding the correct label"
@@ -156,7 +166,11 @@ class TestWatchNamespaceLabelIngress:
         ensure_response_from_backend(backend_setup.req_url, backend_setup.resource_hosts[ing])
         # Tolerate connections dropped by the NGINX reload from the namespace label change.
         resp = retry_get_until_status_code(
-            backend_setup.req_url, backend_setup.resource_hosts[ing], expected_responses[ing], retries=3
+            backend_setup.req_url,
+            backend_setup.resource_hosts[ing],
+            expected_responses[ing],
+            retries=3,
+            wait_seconds=RECONFIGURATION_DELAY,
         )
         assert (
             resp.status_code == expected_responses[ing]
@@ -181,7 +195,11 @@ class TestWatchNamespaceLabelVS:
             ensure_response_from_backend(backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs])
             # Tolerate connections dropped by an NGINX reload from the namespace label change.
             resp = retry_get_until_status_code(
-                backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs], expected_responses[vs], retries=3
+                backend_setup_vs.req_url,
+                backend_setup_vs.resource_hosts[vs],
+                expected_responses[vs],
+                retries=3,
+                wait_seconds=RECONFIGURATION_DELAY,
             )
             assert (
                 resp.status_code == expected_responses[vs]
@@ -193,7 +211,11 @@ class TestWatchNamespaceLabelVS:
         vs = "foreign-ns-vs"
         # Tolerate connections dropped by the NGINX reload from the namespace label change.
         resp = retry_get_until_status_code(
-            backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs], 200, retries=3
+            backend_setup_vs.req_url,
+            backend_setup_vs.resource_hosts[vs],
+            200,
+            retries=3,
+            wait_seconds=RECONFIGURATION_DELAY,
         )
         assert (
             resp.status_code == 200
@@ -204,7 +226,11 @@ class TestWatchNamespaceLabelVS:
         ensure_response_from_backend(backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs])
         # Tolerate connections dropped by the NGINX reload from the namespace label change.
         resp = retry_get_until_status_code(
-            backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs], expected_responses[vs], retries=3
+            backend_setup_vs.req_url,
+            backend_setup_vs.resource_hosts[vs],
+            expected_responses[vs],
+            retries=3,
+            wait_seconds=RECONFIGURATION_DELAY,
         )
         assert (
             resp.status_code == expected_responses[vs]

--- a/tests/suite/test_watch_namespace_label.py
+++ b/tests/suite/test_watch_namespace_label.py
@@ -1,7 +1,4 @@
-from unittest import mock
-
 import pytest
-import requests
 from settings import TEST_DATA
 from suite.utils.resources_utils import (
     create_example_app,
@@ -11,7 +8,7 @@ from suite.utils.resources_utils import (
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
     patch_namespace_with_label,
-    wait_before_test,
+    retry_get_until_status_code,
     wait_until_all_pods_are_ready,
 )
 from suite.utils.vs_vsr_resources_utils import create_virtual_server_from_yaml
@@ -136,13 +133,10 @@ class TestWatchNamespaceLabelIngress:
     def test_response_codes(self, kube_apis, ingress_controller, backend_setup, expected_responses):
         for ing in ["watched-ns-ingress", "watched-ns2-ingress", "foreign-ns-ingress"]:
             ensure_response_from_backend(backend_setup.req_url, backend_setup.resource_hosts[ing])
-            resp = mock.Mock()
-            resp.status_code = "None"
-            retry = 0
-            while resp.status_code != expected_responses[ing] and retry < 3:
-                resp = requests.get(backend_setup.req_url, headers={"host": backend_setup.resource_hosts[ing]})
-                retry = retry + 1
-                wait_before_test()
+            # Tolerate connections dropped by an NGINX reload from the namespace label change.
+            resp = retry_get_until_status_code(
+                backend_setup.req_url, backend_setup.resource_hosts[ing], expected_responses[ing], retries=3
+            )
             assert (
                 resp.status_code == expected_responses[ing]
             ), f"Expected: {expected_responses[ing]} response code for {backend_setup.resource_hosts[ing]}"
@@ -150,14 +144,9 @@ class TestWatchNamespaceLabelIngress:
         # Add label to foreign-ns-ingress and show traffic being served
         patch_namespace_with_label(kube_apis.v1, "foreign-ns", "watch", f"{TEST_DATA}/common/ns-patch.yaml")
         ensure_response_from_backend(backend_setup.req_url, backend_setup.resource_hosts[ing])
-        resp = mock.Mock()
-        resp.status_code = "None"
-        retry = 0
         ing = "foreign-ns-ingress"
-        while resp.status_code != 200 and retry < 3:
-            resp = requests.get(backend_setup.req_url, headers={"host": backend_setup.resource_hosts[ing]})
-            retry = retry + 1
-            wait_before_test()
+        # Tolerate connections dropped by the NGINX reload from the namespace label change.
+        resp = retry_get_until_status_code(backend_setup.req_url, backend_setup.resource_hosts[ing], 200, retries=3)
         assert (
             resp.status_code == 200
         ), f"Expected: 200 response code for {backend_setup.resource_hosts[ing]} after adding the correct label"
@@ -165,13 +154,10 @@ class TestWatchNamespaceLabelIngress:
         # Remove label from foreign-ns-ingress and show traffic being ignored again
         patch_namespace_with_label(kube_apis.v1, "foreign-ns", "nowatch", f"{TEST_DATA}/common/ns-patch.yaml")
         ensure_response_from_backend(backend_setup.req_url, backend_setup.resource_hosts[ing])
-        resp = mock.Mock()
-        resp.status_code = "None"
-        retry = 0
-        while resp.status_code != expected_responses[ing] and retry < 3:
-            resp = requests.get(backend_setup.req_url, headers={"host": backend_setup.resource_hosts[ing]})
-            retry = retry + 1
-            wait_before_test()
+        # Tolerate connections dropped by the NGINX reload from the namespace label change.
+        resp = retry_get_until_status_code(
+            backend_setup.req_url, backend_setup.resource_hosts[ing], expected_responses[ing], retries=3
+        )
         assert (
             resp.status_code == expected_responses[ing]
         ), f"Expected: {expected_responses[ing]} response code for {backend_setup.resource_hosts[ing]} after removing the watched label"
@@ -193,13 +179,10 @@ class TestWatchNamespaceLabelVS:
     def test_response_codes(self, kube_apis, crd_ingress_controller, backend_setup_vs, expected_responses):
         for vs in ["watched-ns-vs", "watched-ns2-vs", "foreign-ns-vs"]:
             ensure_response_from_backend(backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs])
-            resp = mock.Mock()
-            resp.status_code = "None"
-            retry = 0
-            while resp.status_code != expected_responses[vs] and retry < 3:
-                resp = requests.get(backend_setup_vs.req_url, headers={"host": backend_setup_vs.resource_hosts[vs]})
-                retry = retry + 1
-                wait_before_test()
+            # Tolerate connections dropped by an NGINX reload from the namespace label change.
+            resp = retry_get_until_status_code(
+                backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs], expected_responses[vs], retries=3
+            )
             assert (
                 resp.status_code == expected_responses[vs]
             ), f"Expected: {expected_responses[vs]} response code for {backend_setup_vs.resource_hosts[vs]}"
@@ -207,14 +190,11 @@ class TestWatchNamespaceLabelVS:
         # Add label to foreign-ns-vs and show traffic being served
         patch_namespace_with_label(kube_apis.v1, "foreign-ns", "watch", f"{TEST_DATA}/common/ns-patch.yaml")
         ensure_response_from_backend(backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs])
-        resp = mock.Mock()
-        resp.status_code = "None"
-        retry = 0
         vs = "foreign-ns-vs"
-        while resp.status_code != 200 and retry < 3:
-            resp = requests.get(backend_setup_vs.req_url, headers={"host": backend_setup_vs.resource_hosts[vs]})
-            retry = retry + 1
-            wait_before_test()
+        # Tolerate connections dropped by the NGINX reload from the namespace label change.
+        resp = retry_get_until_status_code(
+            backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs], 200, retries=3
+        )
         assert (
             resp.status_code == 200
         ), f"Expected: 200 response code for {backend_setup_vs.resource_hosts[vs]} after adding the correct label"
@@ -222,13 +202,10 @@ class TestWatchNamespaceLabelVS:
         # Remove label from foreign-ns-vs and show traffic being ignored again
         patch_namespace_with_label(kube_apis.v1, "foreign-ns", "nowatch", f"{TEST_DATA}/common/ns-patch.yaml")
         ensure_response_from_backend(backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs])
-        resp = mock.Mock()
-        resp.status_code = "None"
-        retry = 0
-        while resp.status_code != expected_responses[vs] and retry < 3:
-            resp = requests.get(backend_setup_vs.req_url, headers={"host": backend_setup_vs.resource_hosts[vs]})
-            retry = retry + 1
-            wait_before_test()
+        # Tolerate connections dropped by the NGINX reload from the namespace label change.
+        resp = retry_get_until_status_code(
+            backend_setup_vs.req_url, backend_setup_vs.resource_hosts[vs], expected_responses[vs], retries=3
+        )
         assert (
             resp.status_code == expected_responses[vs]
         ), f"Expected: {expected_responses[vs]} response code for {backend_setup_vs.resource_hosts[vs]} after removing the watched label"

--- a/tests/suite/utils/ap_resources_utils.py
+++ b/tests/suite/utils/ap_resources_utils.py
@@ -267,12 +267,21 @@ def delete_ap_policy(custom_objects: CustomObjectsApi, name, namespace) -> None:
 
 
 def send_malicious_request_with_retry(url, host, retries=20, wait_seconds=3):
-    """Send a request with an embedded XSS payload, retrying until WAF blocks it."""
-    response = requests.get(url + "</script>", headers={"host": host})
+    """Send a request with an embedded XSS payload, retrying until WAF blocks it.
+
+    Tolerates ConnectionError/RemoteDisconnected caused by NGINX reloads
+    (worker recycling during App Protect reconfiguration closes connections).
+    """
+    response = None
     count = 0
-    while count < retries and "Request Rejected" not in response.text:
+    while count < retries and (response is None or "Request Rejected" not in response.text):
+        try:
+            response = requests.get(url + "</script>", headers={"host": host})
+            if "Request Rejected" in response.text:
+                break
+        except requests.exceptions.ConnectionError as e:
+            print(f"Attempt {count + 1}: connection dropped during reload ({e})")
         wait_before_test(wait_seconds)
-        response = requests.get(url + "</script>", headers={"host": host})
         count += 1
     return response
 

--- a/tests/suite/utils/ap_resources_utils.py
+++ b/tests/suite/utils/ap_resources_utils.py
@@ -3,6 +3,7 @@
 import logging
 import time
 
+import pytest
 import requests
 import yaml
 from kubernetes.client import CustomObjectsApi
@@ -273,6 +274,7 @@ def send_malicious_request_with_retry(url, host, retries=20, wait_seconds=3):
     (worker recycling during App Protect reconfiguration closes connections).
     """
     response = None
+    last_error = None
     count = 0
     while count < retries and (response is None or "Request Rejected" not in response.text):
         try:
@@ -280,9 +282,15 @@ def send_malicious_request_with_retry(url, host, retries=20, wait_seconds=3):
             if "Request Rejected" in response.text:
                 break
         except requests.exceptions.ConnectionError as e:
+            last_error = e
             print(f"Attempt {count + 1}: connection dropped during reload ({e})")
         wait_before_test(wait_seconds)
         count += 1
+    if response is None:
+        pytest.fail(
+            f"Never got a response from {url} after {retries} attempts; "
+            f"connection kept dropping during reloads. Last error: {last_error}"
+        )
     return response
 
 

--- a/tests/suite/utils/ap_resources_utils.py
+++ b/tests/suite/utils/ap_resources_utils.py
@@ -275,20 +275,19 @@ def send_malicious_request_with_retry(url, host, retries=20, wait_seconds=3):
     """
     response = None
     last_error = None
-    count = 0
-    while count < retries and (response is None or "Request Rejected" not in response.text):
+    for i in range(retries + 1):
         try:
             response = requests.get(url + "</script>", headers={"host": host})
             if "Request Rejected" in response.text:
-                break
+                return response
         except requests.exceptions.ConnectionError as e:
             last_error = e
-            print(f"Attempt {count + 1}: connection dropped during reload ({e})")
-        wait_before_test(wait_seconds)
-        count += 1
+            print(f"Attempt {i + 1}: connection dropped during reload ({e})")
+        if i < retries:
+            wait_before_test(wait_seconds)
     if response is None:
         pytest.fail(
-            f"Never got a response from {url} after {retries} attempts; "
+            f"Never got a response from {url} after {retries + 1} attempts; "
             f"connection kept dropping during reloads. Last error: {last_error}"
         )
     return response

--- a/tests/suite/utils/custom_assertions.py
+++ b/tests/suite/utils/custom_assertions.py
@@ -216,12 +216,19 @@ def wait_and_assert_status_code(code, req_url, host=None, **kwargs) -> None:
     """
     counter = 0
     headers = {} if host is None else {"host": host}
-    resp = requests.get(req_url, headers=headers, **kwargs)
-    while not resp.status_code == code and counter <= 30:
+    resp = None
+    while counter <= 30:
+        try:
+            resp = requests.get(req_url, headers=headers, **kwargs)
+            if resp.status_code == code:
+                break
+        except requests.exceptions.ConnectionError as e:
+            # NGINX reloads recycle workers and can drop in-flight connections;
+            # tolerate the transient and retry rather than failing the test.
+            print(f"Attempt {counter + 1}: connection dropped during reload ({e})")
         time.sleep(1)
         counter = counter + 1
-        resp = requests.get(req_url, headers=headers, **kwargs)
-    assert resp.status_code == code, f"After 30 seconds the status_code is still not {code}"
+    assert resp is not None and resp.status_code == code, f"After 30 seconds the status_code is still not {code}"
 
 
 def assert_grpc_entries_exist(config) -> None:

--- a/tests/suite/utils/custom_assertions.py
+++ b/tests/suite/utils/custom_assertions.py
@@ -214,11 +214,13 @@ def wait_and_assert_status_code(code, req_url, host=None, **kwargs) -> None:
     :param  kwargs: optional arguments passed to ``requests.get``
     :return:
     """
-    counter = 0
     headers = {} if host is None else {"host": host}
     resp = None
     last_error = None
-    while counter <= 30:
+    # One initial request plus up to 31 retries (~31s of polling), matching the
+    # original loop. Only sleep between attempts, never after the final one.
+    attempts = 32
+    for i in range(attempts):
         try:
             resp = requests.get(req_url, headers=headers, **kwargs)
             if resp.status_code == code:
@@ -227,12 +229,12 @@ def wait_and_assert_status_code(code, req_url, host=None, **kwargs) -> None:
             # NGINX reloads recycle workers and can drop in-flight connections;
             # tolerate the transient and retry rather than failing the test.
             last_error = e
-            print(f"Attempt {counter + 1}: connection dropped during reload ({e})")
-        time.sleep(1)
-        counter = counter + 1
+            print(f"Attempt {i + 1}: connection dropped during reload ({e})")
+        if i < attempts - 1:
+            time.sleep(1)
     if resp is None:
         pytest.fail(
-            f"Never got a response from {req_url} after 31 attempts; "
+            f"Never got a response from {req_url} after {attempts} attempts; "
             f"connection kept dropping during reloads. Last error: {last_error}"
         )
     assert resp.status_code == code, f"After 30 seconds the status_code is still not {code}"

--- a/tests/suite/utils/custom_assertions.py
+++ b/tests/suite/utils/custom_assertions.py
@@ -232,12 +232,14 @@ def wait_and_assert_status_code(code, req_url, host=None, **kwargs) -> None:
             print(f"Attempt {i + 1}: connection dropped during reload ({e})")
         if i < attempts - 1:
             time.sleep(1)
+    # Elapsed time is one 1s sleep between each pair of attempts.
+    elapsed_seconds = attempts - 1
     if resp is None:
         pytest.fail(
-            f"Never got a response from {req_url} after {attempts} attempts; "
-            f"connection kept dropping during reloads. Last error: {last_error}"
+            f"Never got a response from {req_url} after {attempts} attempts "
+            f"(~{elapsed_seconds}s); connection kept dropping during reloads. Last error: {last_error}"
         )
-    assert resp.status_code == code, f"After 30 seconds the status_code is still not {code}"
+    assert resp.status_code == code, f"After ~{elapsed_seconds}s the status_code is still not {code}"
 
 
 def assert_grpc_entries_exist(config) -> None:

--- a/tests/suite/utils/custom_assertions.py
+++ b/tests/suite/utils/custom_assertions.py
@@ -217,6 +217,7 @@ def wait_and_assert_status_code(code, req_url, host=None, **kwargs) -> None:
     counter = 0
     headers = {} if host is None else {"host": host}
     resp = None
+    last_error = None
     while counter <= 30:
         try:
             resp = requests.get(req_url, headers=headers, **kwargs)
@@ -225,10 +226,16 @@ def wait_and_assert_status_code(code, req_url, host=None, **kwargs) -> None:
         except requests.exceptions.ConnectionError as e:
             # NGINX reloads recycle workers and can drop in-flight connections;
             # tolerate the transient and retry rather than failing the test.
+            last_error = e
             print(f"Attempt {counter + 1}: connection dropped during reload ({e})")
         time.sleep(1)
         counter = counter + 1
-    assert resp is not None and resp.status_code == code, f"After 30 seconds the status_code is still not {code}"
+    if resp is None:
+        pytest.fail(
+            f"Never got a response from {req_url} after 31 attempts; "
+            f"connection kept dropping during reloads. Last error: {last_error}"
+        )
+    assert resp.status_code == code, f"After 30 seconds the status_code is still not {code}"
 
 
 def assert_grpc_entries_exist(config) -> None:

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -1974,6 +1974,66 @@ def retry_get_until_body_contains(req_url, host, expected_body, retries=60, veri
     return resp
 
 
+def retry_get_until_status_code(req_url, host, expected_status, retries=60, wait_seconds=1, session=None, **kwargs):
+    """
+    Repeatedly GET req_url until the response status code equals expected_status.
+
+    Tolerates ConnectionError/RemoteDisconnected caused by NGINX reloads
+    (worker recycling during reconfiguration closes in-flight connections).
+
+    :param req_url: url to request
+    :param host: value for the Host header (ignored if a "headers" kwarg is provided)
+    :param expected_status: status code to wait for
+    :param retries: number of retries
+    :param wait_seconds: delay between attempts (passed to wait_before_test)
+    :param session: optional requests.Session (e.g. an SNI/client-cert session); defaults to the requests module
+    :param kwargs: extra arguments passed to get (e.g. cert, verify, headers, allow_redirects)
+    :return: the final requests.Response (may not have expected_status if exhausted)
+    """
+    getter = session if session is not None else requests
+    if "headers" not in kwargs:
+        kwargs["headers"] = {} if host is None else {"host": host}
+    resp = None
+    for i in range(retries + 1):
+        try:
+            resp = getter.get(req_url, **kwargs)
+            if resp.status_code == expected_status:
+                return resp
+        except requests.exceptions.ConnectionError as e:
+            print(f"Attempt {i + 1}: connection dropped during reload ({e})")
+        wait_before_test(wait_seconds)
+    return resp
+
+
+def retry_get(req_url, host, retries=3, wait_seconds=1, session=None, **kwargs):
+    """
+    GET req_url once, retrying only when a ConnectionError is raised.
+
+    Use this to guard a single request that immediately follows a config change
+    (and therefore a possible NGINX reload) when the assertion cannot be
+    expressed as "body contains X" or "status == Y" (e.g. asserting a substring
+    is absent, or an arbitrary status). Returns the first successful response.
+
+    :param req_url: url to request
+    :param host: value for the Host header (ignored if a "headers" kwarg is provided)
+    :param retries: number of extra attempts if the connection is dropped
+    :param wait_seconds: delay between attempts (passed to wait_before_test)
+    :param session: optional requests.Session; defaults to the requests module
+    :param kwargs: extra arguments passed to get
+    :return: the requests.Response, or None if every attempt dropped the connection
+    """
+    getter = session if session is not None else requests
+    if "headers" not in kwargs:
+        kwargs["headers"] = {} if host is None else {"host": host}
+    for i in range(retries + 1):
+        try:
+            return getter.get(req_url, **kwargs)
+        except requests.exceptions.ConnectionError as e:
+            print(f"Attempt {i + 1}: connection dropped during reload ({e})")
+            wait_before_test(wait_seconds)
+    return None
+
+
 def get_service_endpoint(kube_apis, service_name, namespace) -> str:
     """
     Wait for endpoint resource to spin up.

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -1963,14 +1963,21 @@ def retry_get_until_body_contains(req_url, host, expected_body, retries=60, veri
     :return: the final requests.Response (may not contain expected_body if exhausted)
     """
     resp = None
+    last_error = None
     for i in range(retries + 1):
         try:
             resp = requests.get(req_url, headers={"host": host}, verify=verify)
             if expected_body in resp.text:
                 return resp
         except requests.exceptions.ConnectionError as e:
+            last_error = e
             print(f"Attempt {i + 1}: connection dropped during reload ({e})")
         wait_before_test(1)
+    if resp is None:
+        pytest.fail(
+            f"Never got a response from {req_url} after {retries + 1} attempts; "
+            f"connection kept dropping during reloads. Last error: {last_error}"
+        )
     return resp
 
 
@@ -1994,14 +2001,21 @@ def retry_get_until_status_code(req_url, host, expected_status, retries=60, wait
     if "headers" not in kwargs:
         kwargs["headers"] = {} if host is None else {"host": host}
     resp = None
+    last_error = None
     for i in range(retries + 1):
         try:
             resp = getter.get(req_url, **kwargs)
             if resp.status_code == expected_status:
                 return resp
         except requests.exceptions.ConnectionError as e:
+            last_error = e
             print(f"Attempt {i + 1}: connection dropped during reload ({e})")
         wait_before_test(wait_seconds)
+    if resp is None:
+        pytest.fail(
+            f"Never got a response from {req_url} after {retries + 1} attempts; "
+            f"connection kept dropping during reloads. Last error: {last_error}"
+        )
     return resp
 
 
@@ -2020,18 +2034,23 @@ def retry_get(req_url, host, retries=3, wait_seconds=1, session=None, **kwargs):
     :param wait_seconds: delay between attempts (passed to wait_before_test)
     :param session: optional requests.Session; defaults to the requests module
     :param kwargs: extra arguments passed to get
-    :return: the requests.Response, or None if every attempt dropped the connection
+    :return: the first successful requests.Response
     """
     getter = session if session is not None else requests
     if "headers" not in kwargs:
         kwargs["headers"] = {} if host is None else {"host": host}
+    last_error = None
     for i in range(retries + 1):
         try:
             return getter.get(req_url, **kwargs)
         except requests.exceptions.ConnectionError as e:
+            last_error = e
             print(f"Attempt {i + 1}: connection dropped during reload ({e})")
             wait_before_test(wait_seconds)
-    return None
+    pytest.fail(
+        f"Never got a response from {req_url} after {retries + 1} attempts; "
+        f"connection kept dropping during reloads. Last error: {last_error}"
+    )
 
 
 def get_service_endpoint(kube_apis, service_name, namespace) -> str:

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -1958,14 +1958,20 @@ def ensure_response_from_backend(req_url, host, additional_headers=None, check40
             try:
                 resp = requests.get(req_url, headers=headers, verify=False)
                 if resp.status_code != 502 and resp.status_code != 504:
-                    print(f"After {_} retries at 1 second interval, got non 502|504 response. Continue with tests...")
+                    print(
+                        f"After {_} retries at {RECONFIGURATION_DELAY} second interval, "
+                        f"got non 502|504 response. Continue with tests..."
+                    )
                     return
             except requests.exceptions.ConnectionError as e:
                 # NGINX reloads recycle workers and can drop in-flight connections; retry.
                 print(f"Connection dropped during reload: {e}")
             wait_before_test()
         _status = resp.status_code if resp is not None else "no response (connection kept dropping)"
-        pytest.fail(f"Keep getting {_status} (expected non 502|504) from {req_url} after 60 seconds. Exiting...")
+        pytest.fail(
+            f"Keep getting {_status} (expected non 502|504) from {req_url} "
+            f"after {30 * RECONFIGURATION_DELAY} seconds. Exiting..."
+        )
 
 
 def retry_get_until_body_contains(req_url, host, expected_body, retries=60, verify=False):

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -1906,6 +1906,7 @@ def ensure_response_from_backend(req_url, host, additional_headers=None, check40
 
     if sni and check404:
         session = create_sni_session()
+        resp = None
         for _ in range(60):
             try:
                 resp = session.get(
@@ -1919,33 +1920,52 @@ def ensure_response_from_backend(req_url, host, additional_headers=None, check40
                         f"After {_} retries at 1 second interval, got {resp.status_code} response. Continue with tests..."
                     )
                     return
-                time.sleep(1)
             except requests.exceptions.SSLError as e:
+                # SSLError subclasses ConnectionError, so this must come first.
                 exception = str(e)
                 print(f"SSL certificate exception: {exception}")
                 resp = mock.Mock()
                 resp.status_code = "None"
-        pytest.fail(f"Keep getting {resp.status_code} from {req_url} after 60 seconds. Exiting...")
+            except requests.exceptions.ConnectionError as e:
+                # NGINX reloads recycle workers and can drop in-flight connections; retry.
+                print(f"Connection dropped during reload: {e}")
+                resp = mock.Mock()
+                resp.status_code = "None"
+            time.sleep(1)
+        _status = resp.status_code if resp is not None else "no response (connection kept dropping)"
+        pytest.fail(f"Keep getting {_status} from {req_url} after 60 seconds. Exiting...")
 
     if check404:
+        resp = None
         for _ in range(60):
-            resp = requests.get(req_url, headers=headers, verify=False)
-            if resp.status_code != 502 and resp.status_code != 504 and resp.status_code != 404:
-                print(
-                    f"After {_} retries at 1 second interval, got {resp.status_code} response. Continue with tests..."
-                )
-                return
+            try:
+                resp = requests.get(req_url, headers=headers, verify=False)
+                if resp.status_code != 502 and resp.status_code != 504 and resp.status_code != 404:
+                    print(
+                        f"After {_} retries at 1 second interval, got {resp.status_code} response. Continue with tests..."
+                    )
+                    return
+            except requests.exceptions.ConnectionError as e:
+                # NGINX reloads recycle workers and can drop in-flight connections; retry.
+                print(f"Connection dropped during reload: {e}")
             time.sleep(1)
-        pytest.fail(f"Keep getting {resp.status_code} from {req_url} after 60 seconds. Exiting...")
+        _status = resp.status_code if resp is not None else "no response (connection kept dropping)"
+        pytest.fail(f"Keep getting {_status} from {req_url} after 60 seconds. Exiting...")
 
     else:
+        resp = None
         for _ in range(30):
-            resp = requests.get(req_url, headers=headers, verify=False)
-            if resp.status_code != 502 and resp.status_code != 504:
-                print(f"After {_} retries at 1 second interval, got non 502|504 response. Continue with tests...")
-                return
+            try:
+                resp = requests.get(req_url, headers=headers, verify=False)
+                if resp.status_code != 502 and resp.status_code != 504:
+                    print(f"After {_} retries at 1 second interval, got non 502|504 response. Continue with tests...")
+                    return
+            except requests.exceptions.ConnectionError as e:
+                # NGINX reloads recycle workers and can drop in-flight connections; retry.
+                print(f"Connection dropped during reload: {e}")
             wait_before_test()
-        pytest.fail(f"Keep getting 502|504 from {req_url} after 60 seconds. Exiting...")
+        _status = resp.status_code if resp is not None else "no response (connection kept dropping)"
+        pytest.fail(f"Keep getting {_status} (expected non 502|504) from {req_url} after 60 seconds. Exiting...")
 
 
 def retry_get_until_body_contains(req_url, host, expected_body, retries=60, verify=False):

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -1972,7 +1972,8 @@ def retry_get_until_body_contains(req_url, host, expected_body, retries=60, veri
         except requests.exceptions.ConnectionError as e:
             last_error = e
             print(f"Attempt {i + 1}: connection dropped during reload ({e})")
-        wait_before_test(1)
+        if i < retries:
+            wait_before_test(1)
     if resp is None:
         pytest.fail(
             f"Never got a response from {req_url} after {retries + 1} attempts; "
@@ -2010,7 +2011,8 @@ def retry_get_until_status_code(req_url, host, expected_status, retries=60, wait
         except requests.exceptions.ConnectionError as e:
             last_error = e
             print(f"Attempt {i + 1}: connection dropped during reload ({e})")
-        wait_before_test(wait_seconds)
+        if i < retries:
+            wait_before_test(wait_seconds)
     if resp is None:
         pytest.fail(
             f"Never got a response from {req_url} after {retries + 1} attempts; "
@@ -2046,7 +2048,8 @@ def retry_get(req_url, host, retries=3, wait_seconds=1, session=None, **kwargs):
         except requests.exceptions.ConnectionError as e:
             last_error = e
             print(f"Attempt {i + 1}: connection dropped during reload ({e})")
-            wait_before_test(wait_seconds)
+            if i < retries:
+                wait_before_test(wait_seconds)
     pytest.fail(
         f"Never got a response from {req_url} after {retries + 1} attempts; "
         f"connection kept dropping during reloads. Last error: {last_error}"

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -1948,6 +1948,32 @@ def ensure_response_from_backend(req_url, host, additional_headers=None, check40
         pytest.fail(f"Keep getting 502|504 from {req_url} after 60 seconds. Exiting...")
 
 
+def retry_get_until_body_contains(req_url, host, expected_body, retries=60, verify=False):
+    """
+    Repeatedly GET req_url until expected_body appears in the response body.
+
+    Tolerates ConnectionError/RemoteDisconnected caused by NGINX reloads
+    (worker recycling during App Protect reconfiguration closes connections).
+
+    :param req_url: url to request
+    :param host: value for the Host header
+    :param expected_body: substring expected to appear in the response body
+    :param retries: number of retries at 1 second interval
+    :param verify: passed through to requests.get for TLS verification
+    :return: the final requests.Response (may not contain expected_body if exhausted)
+    """
+    resp = None
+    for i in range(retries + 1):
+        try:
+            resp = requests.get(req_url, headers={"host": host}, verify=verify)
+            if expected_body in resp.text:
+                return resp
+        except requests.exceptions.ConnectionError as e:
+            print(f"Attempt {i + 1}: connection dropped during reload ({e})")
+        wait_before_test(1)
+    return resp
+
+
 def get_service_endpoint(kube_apis, service_name, namespace) -> str:
     """
     Wait for endpoint resource to spin up.


### PR DESCRIPTION
### Proposed changes

Try to fix flaky e2e tests by better handling nginx reloads

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingxess/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
