### PR TITLE
feat: add additional controller Services to the Helm chart

### DIFF
--- a/charts/nginx-ingress/templates/controller-additional-services.yaml
+++ b/charts/nginx-ingress/templates/controller-additional-services.yaml
@@ -1,0 +1,69 @@
+{{- range $name, $service := .Values.controller.service.additionalServices }}
+{{- if eq $name (include "nginx-ingress.controller.service.name" $) }}
+{{- fail (printf "additional Service name %q must not match the primary controller Service name" $name) }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "nginx-ingress.labels" $ | nindent 4 }}
+    {{- with $service.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- if or (eq $service.type "LoadBalancer") (eq $service.type "NodePort") }}
+  {{- with $service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if eq $service.type "LoadBalancer" }}
+  {{- if hasKey $service "allocateLoadBalancerNodePorts" }}
+  allocateLoadBalancerNodePorts: {{ $service.allocateLoadBalancerNodePorts }}
+  {{- end }}
+  {{- with $service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with $service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
+  {{- with $service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  type: {{ $service.type }}
+  {{- with $service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with $service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    {{- toYaml $service.ports | nindent 4 }}
+  selector:
+    {{- include "nginx-ingress.selectorLabels" $ | nindent 4 }}
+  {{- if and $service.sessionAffinity $service.sessionAffinity.enable }}
+  {{- $sessionAffinityType := default "ClientIP" $service.sessionAffinity.type }}
+  sessionAffinity: {{ $sessionAffinityType }}
+  {{- if eq $sessionAffinityType "ClientIP" }}
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ default 3600 $service.sessionAffinity.timeoutSeconds }}
+  {{- end }}
+  {{- end }}
+  {{- with $service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/nginx-ingress/values.schema.json
+++ b/charts/nginx-ingress/values.schema.json
@@ -1592,6 +1592,126 @@
                 "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServicePort"
               }
             },
+            "additionalServices": {
+              "type": "object",
+              "default": {},
+              "title": "Additional Services that expose the Ingress Controller pods",
+              "propertyNames": {
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              },
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "type",
+                  "ports"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "title": "The Service type",
+                    "enum": [
+                      "ClusterIP",
+                      "NodePort",
+                      "LoadBalancer"
+                    ]
+                  },
+                  "annotations": {
+                    "default": {},
+                    "title": "The Service annotations",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+                  },
+                  "extraLabels": {
+                    "default": {},
+                    "title": "The extra Service labels",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                  },
+                  "clusterIP": {
+                    "default": "",
+                    "title": "The Service clusterIP",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/clusterIP"
+                  },
+                  "externalTrafficPolicy": {
+                    "default": "",
+                    "title": "The Service externalTrafficPolicy",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/externalTrafficPolicy"
+                  },
+                  "loadBalancerIP": {
+                    "default": "",
+                    "title": "The Service loadBalancerIP",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/loadBalancerIP"
+                  },
+                  "loadBalancerClass": {
+                    "default": "",
+                    "title": "The Service loadBalancerClass",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/loadBalancerClass"
+                  },
+                  "externalIPs": {
+                    "default": [],
+                    "title": "The Service externalIPs",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/externalIPs"
+                  },
+                  "loadBalancerSourceRanges": {
+                    "default": [],
+                    "title": "The Service loadBalancerSourceRanges",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/loadBalancerSourceRanges"
+                  },
+                  "allocateLoadBalancerNodePorts": {
+                    "default": true,
+                    "title": "Allocate NodePorts for the LoadBalancer Service",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/allocateLoadBalancerNodePorts"
+                  },
+                  "ipFamilyPolicy": {
+                    "default": "",
+                    "title": "The Service ipFamilyPolicy",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/ipFamilyPolicy"
+                  },
+                  "ipFamilies": {
+                    "default": [],
+                    "title": "The Service ipFamilies",
+                    "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/ipFamilies"
+                  },
+                  "ports": {
+                    "type": "array",
+                    "title": "The Service ports",
+                    "minItems": 1,
+                    "items": {
+                      "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.36.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServicePort"
+                    }
+                  },
+                  "sessionAffinity": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The sessionAffinity Schema",
+                    "additionalProperties": false,
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "default": false,
+                        "title": "Enable session affinity"
+                      },
+                      "type": {
+                        "type": "string",
+                        "default": "ClientIP",
+                        "title": "Session affinity type",
+                        "enum": [
+                          "ClientIP"
+                        ]
+                      },
+                      "timeoutSeconds": {
+                        "type": "integer",
+                        "default": 3600,
+                        "title": "Session affinity timeout in seconds",
+                        "minimum": 1,
+                        "maximum": 86400
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "sessionAffinity": {
               "type": "object",
               "default": {},

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -580,6 +580,25 @@ controller:
     ## A list of custom ports to expose through the Ingress Controller service. Follows the conventional Kubernetes yaml syntax for service ports.
     customPorts: []
 
+    ## Additional Services that expose the Ingress Controller pods independently from the primary Service.
+    ## This is useful when different listeners require separate LoadBalancer IPs, annotations, or source ranges.
+    ## Each name is used as the exact Service name and must be unique in the release namespace.
+    ## The controller can report status from only one Service; additional Services do not change controller.reportIngressStatus.externalService.
+    additionalServices: {}
+    # nginx-ingress-redis:
+    #   type: LoadBalancer
+    #   annotations: {}
+    #   extraLabels: {}
+    #   loadBalancerIP: ""
+    #   loadBalancerClass: ""
+    #   externalTrafficPolicy: Local
+    #   loadBalancerSourceRanges: []
+    #   ports:
+    #   - name: redis
+    #     port: 6379
+    #     targetPort: 6379
+    #     protocol: TCP
+
     ## Session affinity configuration for the Ingress Controller service, ensures requests from the same client IP go to the same pod
     sessionAffinity:
       ## Enable session affinity. Valid values: None, ClientIP

--- a/charts/tests/__snapshots__/helmunit_test.snap
+++ b/charts/tests/__snapshots__/helmunit_test.snap
@@ -1,4 +1,72 @@
 
+[TestHelmNICTemplate/additionalServices - 1]
+/-/-/-/
+# Source: nginx-ingress/templates/controller-additional-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-ingress-dns
+  namespace: default
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/instance: shared-controller
+    app.kubernetes.io/name: custom-nginx-ingress
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  clusterIP: 10.96.0.53
+  type: ClusterIP
+  ports:
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: 5353
+  selector:
+    app.kubernetes.io/instance: shared-controller
+    app.kubernetes.io/name: custom-nginx-ingress
+  externalIPs:
+    - 192.0.2.53
+/-/-/-/
+# Source: nginx-ingress/templates/controller-additional-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-ingress-redis
+  namespace: default
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/instance: shared-controller
+    app.kubernetes.io/name: custom-nginx-ingress
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/traffic: redis
+  annotations:
+    example.com/exposure: database
+spec:
+  externalTrafficPolicy: Local
+  allocateLoadBalancerNodePorts: false
+  loadBalancerIP: 10.0.0.11
+  loadBalancerClass: example.com/internal
+  loadBalancerSourceRanges:
+    - 10.0.0.0/8
+  type: LoadBalancer
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv4
+  ports:
+    - name: redis
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+  selector:
+    app.kubernetes.io/instance: shared-controller
+    app.kubernetes.io/name: custom-nginx-ingress
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 1800
+---
+
 [TestHelmNICTemplate/allowEmptyIngressHost - 1]
 /-/-/-/
 # Source: nginx-ingress/templates/controller-serviceaccount.yaml

--- a/charts/tests/helmunit_test.go
+++ b/charts/tests/helmunit_test.go
@@ -27,9 +27,10 @@ func TestHelmNICTemplate(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		valuesFile  string
-		releaseName string
-		namespace   string
+		valuesFile    string
+		releaseName   string
+		namespace     string
+		templateFiles []string
 	}{
 		"default values file": {
 			valuesFile:  "",
@@ -196,6 +197,12 @@ func TestHelmNICTemplate(t *testing.T) {
 			releaseName: "loadbalancerclass",
 			namespace:   "default",
 		},
+		"additionalServices": {
+			valuesFile:    "testdata/additional-services.yaml",
+			releaseName:   "additional-services",
+			namespace:     "default",
+			templateFiles: []string{"templates/controller-additional-services.yaml"},
+		},
 		"listConfigurations": {
 			valuesFile:  "testdata/list-configurations.yaml",
 			releaseName: "list-configs",
@@ -224,7 +231,7 @@ func TestHelmNICTemplate(t *testing.T) {
 				options.ValuesFiles = []string{tc.valuesFile}
 			}
 
-			output := helm.RenderTemplate(t, options, helmChartPath, tc.releaseName, make([]string, 0))
+			output := helm.RenderTemplate(t, options, helmChartPath, tc.releaseName, tc.templateFiles)
 
 			snaps.MatchSnapshot(t, output)
 			t.Log(output)
@@ -265,6 +272,30 @@ func TestHelmNICTemplateNegative(t *testing.T) {
 			releaseName:       "global-config-empty-name",
 			namespace:         "default",
 			expectedErrorMsgs: []string{"globalConfiguration.customName namespace and name parts cannot be empty (e.g., \"my-namespace/my-global-config\")"},
+		},
+		"additionalServiceWithoutPorts": {
+			valuesFile:        "testdata/additional-service-without-ports.yaml",
+			releaseName:       "additional-service-without-ports",
+			namespace:         "default",
+			expectedErrorMsgs: []string{"missing property 'ports'"},
+		},
+		"additionalServiceExternalName": {
+			valuesFile:        "testdata/additional-service-external-name.yaml",
+			releaseName:       "additional-service-external-name",
+			namespace:         "default",
+			expectedErrorMsgs: []string{"value must be one of 'ClusterIP', 'NodePort', 'LoadBalancer'"},
+		},
+		"additionalServiceEmptyPorts": {
+			valuesFile:        "testdata/additional-service-empty-ports.yaml",
+			releaseName:       "additional-service-empty-ports",
+			namespace:         "default",
+			expectedErrorMsgs: []string{"minItems: got 0, want 1"},
+		},
+		"additionalServiceNameCollision": {
+			valuesFile:        "testdata/additional-service-name-collision.yaml",
+			releaseName:       "additional-service-name-collision",
+			namespace:         "default",
+			expectedErrorMsgs: []string{"additional Service name \"duplicate-service\" must not match the primary controller Service name"},
 		},
 	}
 

--- a/charts/tests/testdata/additional-service-empty-ports.yaml
+++ b/charts/tests/testdata/additional-service-empty-ports.yaml
@@ -1,0 +1,6 @@
+controller:
+  service:
+    additionalServices:
+      invalid-empty-ports:
+        type: LoadBalancer
+        ports: []

--- a/charts/tests/testdata/additional-service-external-name.yaml
+++ b/charts/tests/testdata/additional-service-external-name.yaml
@@ -1,0 +1,9 @@
+controller:
+  service:
+    additionalServices:
+      invalid-external-name:
+        type: ExternalName
+        ports:
+          - name: redis
+            port: 6379
+            targetPort: 6379

--- a/charts/tests/testdata/additional-service-name-collision.yaml
+++ b/charts/tests/testdata/additional-service-name-collision.yaml
@@ -1,0 +1,10 @@
+serviceNameOverride: duplicate-service
+controller:
+  service:
+    additionalServices:
+      duplicate-service:
+        type: LoadBalancer
+        ports:
+          - name: redis
+            port: 6379
+            targetPort: 6379

--- a/charts/tests/testdata/additional-service-without-ports.yaml
+++ b/charts/tests/testdata/additional-service-without-ports.yaml
@@ -1,0 +1,5 @@
+controller:
+  service:
+    additionalServices:
+      invalid-service:
+        type: LoadBalancer

--- a/charts/tests/testdata/additional-services.yaml
+++ b/charts/tests/testdata/additional-services.yaml
@@ -1,0 +1,41 @@
+controller:
+  selectorLabels:
+    app.kubernetes.io/name: custom-nginx-ingress
+    app.kubernetes.io/instance: shared-controller
+  service:
+    create: false
+    additionalServices:
+      nginx-ingress-redis:
+        type: LoadBalancer
+        annotations:
+          example.com/exposure: database
+        extraLabels:
+          app.kubernetes.io/traffic: redis
+        loadBalancerIP: 10.0.0.11
+        loadBalancerClass: example.com/internal
+        externalTrafficPolicy: Local
+        allocateLoadBalancerNodePorts: false
+        loadBalancerSourceRanges:
+          - 10.0.0.0/8
+        ipFamilyPolicy: SingleStack
+        ipFamilies:
+          - IPv4
+        ports:
+          - name: redis
+            port: 6379
+            targetPort: 6379
+            protocol: TCP
+        sessionAffinity:
+          enable: true
+          type: ClientIP
+          timeoutSeconds: 1800
+      nginx-ingress-dns:
+        type: ClusterIP
+        clusterIP: 10.96.0.53
+        externalIPs:
+          - 192.0.2.53
+        ports:
+          - name: dns-udp
+            port: 53
+            targetPort: 5353
+            protocol: UDP


### PR DESCRIPTION
### Proposed changes

This PR adds `controller.service.additionalServices` to the Helm chart so one NGINX Ingress Controller workload can be exposed through multiple independently configured Kubernetes Services.

The map key is the exact Service name. Each additional Service:

- always selects the controller pods using `nginx-ingress.selectorLabels`;
- can configure its own type, ports, annotations, labels, LoadBalancer settings, traffic policy, IP families, external IPs, and session affinity;
- is rendered independently from `controller.service.create`, allowing installations that only use explicitly defined Services;
- rejects `ExternalName`, missing/empty ports, invalid names, and collisions with the primary controller Service.

The default is an empty map, so existing chart output is unchanged. Status reporting remains intentionally unchanged: `controller.reportIngressStatus.externalService` still identifies a single Service.

Fixes #10476

### Validation

- `make secrets && make test` (Linux, Go 1.26.5, Helm 3.21.2)
- `helm lint charts/nginx-ingress`
- `golangci-lint run --new-from-rev HEAD`
- pre-commit YAML, JSON, JSON Schema, formatting, and security hooks

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork