### PR TITLE
Add support for v1 WAF CRDs in NIC

### DIFF
--- a/cmd/nginx-ingress/flags.go
+++ b/cmd/nginx-ingress/flags.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -448,28 +450,20 @@ func mustValidateFlags(ctx context.Context) {
 		nl.Fatal(l, "NGINX App Protect Dos memory support is for NGINX Plus and App Protect Dos is enable")
 	}
 
-	if *plmStorageURL != "" {
-		if !*nginxPlus {
-			nl.Fatal(l, "plm-storage-url requires -nginx-plus")
-		}
-		if !*appProtect {
-			nl.Fatal(l, "plm-storage-url requires -enable-app-protect")
-		}
-		if !strings.HasPrefix(*plmStorageURL, "http://") && !strings.HasPrefix(*plmStorageURL, "https://") {
-			nl.Fatalf(l, "plm-storage-url must start with http:// or https://; got %q", *plmStorageURL)
-		}
-		for name, val := range map[string]string{
-			"plm-storage-credentials-secret": *plmStorageCredentialsSecret,
-			"plm-storage-ca-secret":          *plmStorageCASecret,
-			"plm-storage-client-ssl-secret":  *plmStorageClientSSLSecret,
-		} {
-			if err := validatePLMSecretRef(name, val); err != nil {
-				nl.Fatal(l, err.Error())
-			}
-		}
-		if *plmStorageInsecureSkipVerify {
-			nl.Warn(l, "plm-storage-insecure-skip-verify is enabled; TLS verification of the PLM SeaweedFS filer will be skipped. This is for dev/test only.")
-		}
+	warn, err := validatePLMFlags(
+		*plmStorageURL,
+		*plmStorageCredentialsSecret,
+		*plmStorageCASecret,
+		*plmStorageClientSSLSecret,
+		*plmStorageInsecureSkipVerify,
+		*nginxPlus,
+		*appProtect,
+	)
+	if err != nil {
+		nl.Fatal(l, err.Error())
+	}
+	if warn != "" {
+		nl.Warn(l, warn)
 	}
 
 	if *enableInternalRoutes && *spireAgentAddress == "" {
@@ -546,26 +540,102 @@ func validateLogFormat(logFormat string) error {
 	return fmt.Errorf("invalid log format: %v", logFormat)
 }
 
-// validatePLMSecretRef checks that a --plm-storage-*-secret value is either empty
-// or in the format [namespace/]name, where namespace and name are non-empty strings.
+// validatePLMSecretRef checks that a --plm-storage-*-secret value is either
+// empty or in the form "[namespace/]name" where each component is a valid
+// DNS-1123 subdomain.
 func validatePLMSecretRef(flagName, value string) error {
 	if value == "" {
 		return nil
 	}
+	var namespace, name string
 	parts := strings.Split(value, "/")
 	switch len(parts) {
 	case 1:
-		if parts[0] == "" {
-			return fmt.Errorf("%s: name must not be empty", flagName)
-		}
+		name = parts[0]
 	case 2:
-		if parts[0] == "" || parts[1] == "" {
-			return fmt.Errorf("%s: namespace and name must not be empty in %q", flagName, value)
+		namespace, name = parts[0], parts[1]
+		if namespace == "" {
+			return fmt.Errorf("%s: namespace must not be empty when '/' separator is present, got %q", flagName, value)
 		}
 	default:
 		return fmt.Errorf("%s: expected [namespace/]name, got %q", flagName, value)
 	}
+	if name == "" {
+		return fmt.Errorf("%s: name must not be empty in %q", flagName, value)
+	}
+	if namespace != "" {
+		if errs := validation.IsDNS1123Subdomain(namespace); len(errs) > 0 {
+			return fmt.Errorf("%s: invalid namespace %q: %s", flagName, namespace, strings.Join(errs, "; "))
+		}
+	}
+	if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
+		return fmt.Errorf("%s: invalid name %q: %s", flagName, name, strings.Join(errs, "; "))
+	}
 	return nil
+}
+
+// validatePLMStorageURL parses the --plm-storage-url value and
+// returns an error if it is not a valid URL with a scheme and host.
+func validatePLMStorageURL(rawURL string) error {
+	if rawURL == "" {
+		return errors.New("plm-storage-url: must not be empty")
+	}
+	if strings.ContainsAny(rawURL, " \t\r\n") {
+		return fmt.Errorf("plm-storage-url: must not contain whitespace or control characters, got %q", rawURL)
+	}
+	if !strings.Contains(rawURL, "://") {
+		return fmt.Errorf("plm-storage-url: scheme is required (http:// or https://), got %q", rawURL)
+	}
+	if err := internalValidation.ValidateURI(rawURL); err != nil {
+		return fmt.Errorf("plm-storage-url: %w", err)
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("plm-storage-url: %w", err)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("plm-storage-url: host must not be empty in %q", rawURL)
+	}
+	return nil
+}
+
+// The URL flag is the master switch. If it is empty, any auxiliary PLM flag
+// being set is treated as a fatal misconfiguration
+func validatePLMFlags(rawURL, credentialsSecret, caSecret, clientSSLSecret string, insecureSkipVerify, nginxPlus, appProtect bool) (warn string, err error) {
+	auxSecrets := []struct{ name, val string }{
+		{"plm-storage-credentials-secret", credentialsSecret},
+		{"plm-storage-ca-secret", caSecret},
+		{"plm-storage-client-ssl-secret", clientSSLSecret},
+	}
+	if rawURL == "" {
+		for _, sec := range auxSecrets {
+			if sec.val != "" {
+				return "", fmt.Errorf("%s is set but plm-storage-url is not; PLM auxiliary flags require plm-storage-url", sec.name)
+			}
+		}
+		if insecureSkipVerify {
+			return "", errors.New("plm-storage-insecure-skip-verify is set but plm-storage-url is not; PLM auxiliary flags require plm-storage-url")
+		}
+		return "", nil
+	}
+	if !nginxPlus {
+		return "", errors.New("plm-storage-url requires -nginx-plus")
+	}
+	if !appProtect {
+		return "", errors.New("plm-storage-url requires -enable-app-protect")
+	}
+	if err := validatePLMStorageURL(rawURL); err != nil {
+		return "", err
+	}
+	for _, sec := range auxSecrets {
+		if err := validatePLMSecretRef(sec.name, sec.val); err != nil {
+			return "", err
+		}
+	}
+	if insecureSkipVerify {
+		return "plm-storage-insecure-skip-verify is enabled; TLS verification of the PLM SeaweedFS filer will be skipped. This is for dev/test only.", nil
+	}
+	return "", nil
 }
 
 // parseNginxStatusAllowCIDRs converts a comma separated CIDR/IP address string into an array of CIDR/IP addresses.

--- a/cmd/nginx-ingress/flags.go
+++ b/cmd/nginx-ingress/flags.go
@@ -81,6 +81,29 @@ var (
 
 	appProtectIPIntelligence = flag.Bool("enable-app-protect-ip-intelligence", false, "Enable App Protect IP Intelligence. Requires -nginx-plus and -enable-app-protect.")
 
+	plmStorageURL = flag.String("plm-storage-url", "",
+		`SeaweedFS S3 endpoint URL for the F5 WAF Policy Controller (PLM). When non-empty,
+enables the PLM integration: NIC watches the appprotect.f5.com/v1 CRDs installed by the PLM
+Helm chart instead of the legacy v1beta1 CRDs. Empty (default) disables PLM.
+Must be http:// or https://. Requires -nginx-plus and -enable-app-protect.`)
+
+	plmStorageCredentialsSecret = flag.String("plm-storage-credentials-secret", "",
+		`Kubernetes Secret holding the S3 admin key for the PLM SeaweedFS filer under the
+seaweedfs_admin_secret key. Format: [namespace/]name. When only "name" is given, the Secret
+is resolved in NIC's own namespace. Requires -plm-storage-url.`)
+
+	plmStorageCASecret = flag.String("plm-storage-ca-secret", "",
+		`Kubernetes Secret containing a ca.crt for verifying the PLM SeaweedFS server
+certificate. Format: [namespace/]name. Optional. Requires -plm-storage-url.`)
+
+	plmStorageClientSSLSecret = flag.String("plm-storage-client-ssl-secret", "",
+		`Kubernetes Secret containing tls.crt and tls.key for mTLS to the PLM SeaweedFS
+filer. Format: [namespace/]name. Optional. Requires -plm-storage-url.`)
+
+	plmStorageInsecureSkipVerify = flag.Bool("plm-storage-insecure-skip-verify", false,
+		`Disable TLS verification of the PLM SeaweedFS server certificate. For dev/test only.
+NIC prints a startup warning when set. Requires -plm-storage-url.`)
+
 	agent              = flag.Bool("agent", false, "Enable NGINX Agent")
 	agentInstanceGroup = flag.String("agent-instance-group", "nginx-ingress-controller", "Grouping used to associate NGINX Ingress Controller instances")
 
@@ -425,6 +448,30 @@ func mustValidateFlags(ctx context.Context) {
 		nl.Fatal(l, "NGINX App Protect Dos memory support is for NGINX Plus and App Protect Dos is enable")
 	}
 
+	if *plmStorageURL != "" {
+		if !*nginxPlus {
+			nl.Fatal(l, "plm-storage-url requires -nginx-plus")
+		}
+		if !*appProtect {
+			nl.Fatal(l, "plm-storage-url requires -enable-app-protect")
+		}
+		if !strings.HasPrefix(*plmStorageURL, "http://") && !strings.HasPrefix(*plmStorageURL, "https://") {
+			nl.Fatalf(l, "plm-storage-url must start with http:// or https://; got %q", *plmStorageURL)
+		}
+		for name, val := range map[string]string{
+			"plm-storage-credentials-secret": *plmStorageCredentialsSecret,
+			"plm-storage-ca-secret":          *plmStorageCASecret,
+			"plm-storage-client-ssl-secret":  *plmStorageClientSSLSecret,
+		} {
+			if err := validatePLMSecretRef(name, val); err != nil {
+				nl.Fatal(l, err.Error())
+			}
+		}
+		if *plmStorageInsecureSkipVerify {
+			nl.Warn(l, "plm-storage-insecure-skip-verify is enabled; TLS verification of the PLM SeaweedFS filer will be skipped. This is for dev/test only.")
+		}
+	}
+
 	if *enableInternalRoutes && *spireAgentAddress == "" {
 		nl.Fatal(l, "enable-internal-routes flag requires spire-agent-address")
 	}
@@ -497,6 +544,28 @@ func validateLogFormat(logFormat string) error {
 		return nil
 	}
 	return fmt.Errorf("invalid log format: %v", logFormat)
+}
+
+// validatePLMSecretRef checks that a --plm-storage-*-secret value is either empty
+// or in the format [namespace/]name, where namespace and name are non-empty strings.
+func validatePLMSecretRef(flagName, value string) error {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, "/")
+	switch len(parts) {
+	case 1:
+		if parts[0] == "" {
+			return fmt.Errorf("%s: name must not be empty", flagName)
+		}
+	case 2:
+		if parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("%s: namespace and name must not be empty in %q", flagName, value)
+		}
+	default:
+		return fmt.Errorf("%s: expected [namespace/]name, got %q", flagName, value)
+	}
+	return nil
 }
 
 // parseNginxStatusAllowCIDRs converts a comma separated CIDR/IP address string into an array of CIDR/IP addresses.

--- a/cmd/nginx-ingress/flags_test.go
+++ b/cmd/nginx-ingress/flags_test.go
@@ -196,6 +196,10 @@ func TestValidatePLMSecretRef(t *testing.T) {
 		{name: "leading slash rejected", value: "/seaweed-auth", wantErr: true},
 		{name: "double slash rejected", value: "plm/foo/bar", wantErr: true},
 		{name: "just slash rejected", value: "/", wantErr: true},
+		{name: "uppercase name rejected (non DNS-1123)", value: "plm/Foo", wantErr: true},
+		{name: "uppercase namespace rejected (non DNS-1123)", value: "PLM/seaweed-auth", wantErr: true},
+		{name: "whitespace in value rejected", value: "plm/foo bar", wantErr: true},
+		{name: "underscore in name rejected", value: "plm/foo_bar", wantErr: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -206,6 +210,197 @@ func TestValidatePLMSecretRef(t *testing.T) {
 			}
 			if !tc.wantErr && err != nil {
 				t.Errorf("validatePLMSecretRef(%q) unexpected error: %v", tc.value, err)
+			}
+		})
+	}
+}
+
+func TestValidatePLMStorageURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "http host", value: "http://seaweed.plm.svc.cluster.local:8333", wantErr: false},
+		{name: "https host", value: "https://seaweed.plm.svc.cluster.local:8333/", wantErr: false},
+		{name: "http with path", value: "http://seaweed:8333/bucket", wantErr: false},
+
+		{name: "empty rejected", value: "", wantErr: true},
+		{name: "scheme only rejected", value: "http://", wantErr: true},
+		{name: "wrong scheme rejected", value: "ftp://seaweed:8333", wantErr: true},
+		{name: "no scheme rejected", value: "seaweed:8333", wantErr: true},
+		{name: "s3 scheme rejected", value: "s3://bucket/key", wantErr: true},
+		{name: "userinfo rejected", value: "http://user:pass@evil/", wantErr: true},
+		{name: "trailing space rejected", value: "http://seaweed:8333 ", wantErr: true},
+		{name: "embedded CRLF rejected", value: "http://foo\r\nbar", wantErr: true},
+		{name: "embedded tab rejected", value: "http://seaweed\t:8333", wantErr: true},
+		{name: "ipv6 rejected", value: "http://[::1]:8333", wantErr: true},
+		{name: "port out of range rejected", value: "http://seaweed:70000", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validatePLMStorageURL(tc.value)
+			if tc.wantErr && err == nil {
+				t.Errorf("validatePLMStorageURL(%q) expected error, got nil", tc.value)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validatePLMStorageURL(%q) unexpected error: %v", tc.value, err)
+			}
+		})
+	}
+}
+
+func TestValidatePLMFlags(t *testing.T) {
+	t.Parallel()
+	const goodURL = "http://seaweed.plm.svc.cluster.local:8333"
+
+	tests := []struct {
+		name               string
+		url                string
+		credentialsSecret  string
+		caSecret           string
+		clientSSLSecret    string
+		insecureSkipVerify bool
+		nginxPlus          bool
+		appProtect         bool
+		wantErr            bool
+		wantErrContains    string
+		wantWarn           bool
+	}{
+		{
+			name:      "URL empty and no aux flags is a no-op",
+			url:       "",
+			nginxPlus: false, // even without prereqs, empty URL means no PLM
+		},
+		{
+			name:              "URL empty but credentials-secret set fails",
+			url:               "",
+			credentialsSecret: "plm/seaweed-auth",
+			wantErr:           true,
+			wantErrContains:   "plm-storage-credentials-secret is set but plm-storage-url is not",
+		},
+		{
+			name:            "URL empty but ca-secret set fails",
+			url:             "",
+			caSecret:        "plm/plm-ca",
+			wantErr:         true,
+			wantErrContains: "plm-storage-ca-secret is set but plm-storage-url is not",
+		},
+		{
+			name:            "URL empty but client-ssl-secret set fails",
+			url:             "",
+			clientSSLSecret: "plm/plm-client",
+			wantErr:         true,
+			wantErrContains: "plm-storage-client-ssl-secret is set but plm-storage-url is not",
+		},
+		{
+			name:               "URL empty but insecure-skip-verify set fails",
+			url:                "",
+			insecureSkipVerify: true,
+			wantErr:            true,
+			wantErrContains:    "plm-storage-insecure-skip-verify is set but plm-storage-url is not",
+		},
+		{
+			name:            "URL set without nginx-plus fails",
+			url:             goodURL,
+			nginxPlus:       false,
+			appProtect:      true,
+			wantErr:         true,
+			wantErrContains: "nginx-plus",
+		},
+		{
+			name:            "URL set without app-protect fails",
+			url:             goodURL,
+			nginxPlus:       true,
+			appProtect:      false,
+			wantErr:         true,
+			wantErrContains: "enable-app-protect",
+		},
+		{
+			name:            "malformed URL fails",
+			url:             "not-a-url",
+			nginxPlus:       true,
+			appProtect:      true,
+			wantErr:         true,
+			wantErrContains: "plm-storage-url",
+		},
+		{
+			name:              "invalid credentials secret ref fails",
+			url:               goodURL,
+			credentialsSecret: "PLM/Foo",
+			nginxPlus:         true,
+			appProtect:        true,
+			wantErr:           true,
+			wantErrContains:   "plm-storage-credentials-secret",
+		},
+		{
+			name:            "invalid ca secret ref fails",
+			url:             goodURL,
+			caSecret:        "plm/",
+			nginxPlus:       true,
+			appProtect:      true,
+			wantErr:         true,
+			wantErrContains: "plm-storage-ca-secret",
+		},
+		{
+			name:            "invalid client-ssl secret ref fails",
+			url:             goodURL,
+			clientSSLSecret: "/bad",
+			nginxPlus:       true,
+			appProtect:      true,
+			wantErr:         true,
+			wantErrContains: "plm-storage-client-ssl-secret",
+		},
+		{
+			name:              "valid config with all secrets is accepted",
+			url:               goodURL,
+			credentialsSecret: "plm/seaweed-auth",
+			caSecret:          "plm/plm-ca",
+			clientSSLSecret:   "plm/plm-client",
+			nginxPlus:         true,
+			appProtect:        true,
+		},
+		{
+			name:               "insecure-skip-verify emits warning",
+			url:                goodURL,
+			credentialsSecret:  "plm/seaweed-auth",
+			insecureSkipVerify: true,
+			nginxPlus:          true,
+			appProtect:         true,
+			wantWarn:           true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			warn, err := validatePLMFlags(
+				tc.url,
+				tc.credentialsSecret,
+				tc.caSecret,
+				tc.clientSSLSecret,
+				tc.insecureSkipVerify,
+				tc.nginxPlus,
+				tc.appProtect,
+			)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("validatePLMFlags: expected error, got nil")
+				}
+				if tc.wantErrContains != "" && !strings.Contains(err.Error(), tc.wantErrContains) {
+					t.Errorf("validatePLMFlags: error %q does not contain %q", err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validatePLMFlags: unexpected error: %v", err)
+			}
+			if tc.wantWarn && warn == "" {
+				t.Errorf("validatePLMFlags: expected a warning, got empty string")
+			}
+			if !tc.wantWarn && warn != "" {
+				t.Errorf("validatePLMFlags: unexpected warning: %q", warn)
 			}
 		})
 	}

--- a/cmd/nginx-ingress/flags_test.go
+++ b/cmd/nginx-ingress/flags_test.go
@@ -181,3 +181,32 @@ func TestValidateLogFormat(t *testing.T) {
 		}
 	}
 }
+
+func TestValidatePLMSecretRef(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "empty is accepted", value: "", wantErr: false},
+		{name: "bare name", value: "seaweed-auth", wantErr: false},
+		{name: "namespace/name", value: "plm/seaweed-auth", wantErr: false},
+		{name: "trailing slash rejected", value: "plm/", wantErr: true},
+		{name: "leading slash rejected", value: "/seaweed-auth", wantErr: true},
+		{name: "double slash rejected", value: "plm/foo/bar", wantErr: true},
+		{name: "just slash rejected", value: "/", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validatePLMSecretRef("plm-storage-credentials-secret", tc.value)
+			if tc.wantErr && err == nil {
+				t.Errorf("validatePLMSecretRef(%q) expected error, got nil", tc.value)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validatePLMSecretRef(%q) unexpected error: %v", tc.value, err)
+			}
+		})
+	}
+}

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -630,15 +630,16 @@ func getAppProtectVersionInfo(ctx context.Context) string {
 // selectAppProtectAPIVersion configures the appprotect package to watch the
 // v1 CRDs installed by the WAF Policy Controller (PLM) chart when the
 // operator sets --plm-storage-url, and the legacy v1beta1 CRDs otherwise.
-
 func selectAppProtectAPIVersion(ctx context.Context, plmEnabled bool, recorder record.EventRecorder, pod *api_v1.Pod) {
 	l := nl.LoggerFromContext(ctx)
 	version := appprotect.SelectAPIVersion(plmEnabled)
+	// SelectAPIVersion only returns APIVersionV1 or APIVersionV1beta1, both
+	// accepted by SetAPIVersion
 	if err := appprotect.SetAPIVersion(version); err != nil {
 		nl.Fatalf(l, "Invalid %s API version %q: %v", appprotect.APIGroup, version, err)
 	}
 	nl.Infof(l, "Using %s/%s CRDs", appprotect.APIGroup, version)
-	recorder.Eventf(pod, api_v1.EventTypeNormal, "AppProtectAPIVersionSelected",
+	recorder.Eventf(pod, api_v1.EventTypeNormal, nl.EventReasonAppProtectAPIVersionSelected,
 		"Using %s/%s CRDs", appprotect.APIGroup, version)
 }
 

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nginx/kubernetes-ingress/internal/configs/version2"
 	"github.com/nginx/kubernetes-ingress/internal/healthcheck"
 	"github.com/nginx/kubernetes-ingress/internal/k8s"
+	"github.com/nginx/kubernetes-ingress/internal/k8s/appprotect"
 	"github.com/nginx/kubernetes-ingress/internal/k8s/secrets"
 	license_reporting "github.com/nginx/kubernetes-ingress/internal/license_reporting"
 	"github.com/nginx/kubernetes-ingress/internal/metadata"
@@ -151,6 +152,8 @@ func main() {
 			appProtectV5 = true
 			appProtectBundlePath = appProtectv5BundleFolder
 		}
+
+		selectAppProtectAPIVersion(ctx, *plmStorageURL != "", eventRecorder, pod)
 	}
 
 	var agentVersion string
@@ -622,6 +625,21 @@ func getAppProtectVersionInfo(ctx context.Context) string {
 	version := strings.TrimSpace(string(v))
 	nl.Infof(l, "Using AppProtect Version %s", version)
 	return version
+}
+
+// selectAppProtectAPIVersion configures the appprotect package to watch the
+// v1 CRDs installed by the WAF Policy Controller (PLM) chart when the
+// operator sets --plm-storage-url, and the legacy v1beta1 CRDs otherwise.
+
+func selectAppProtectAPIVersion(ctx context.Context, plmEnabled bool, recorder record.EventRecorder, pod *api_v1.Pod) {
+	l := nl.LoggerFromContext(ctx)
+	version := appprotect.SelectAPIVersion(plmEnabled)
+	if err := appprotect.SetAPIVersion(version); err != nil {
+		nl.Fatalf(l, "Invalid %s API version %q: %v", appprotect.APIGroup, version, err)
+	}
+	nl.Infof(l, "Using %s/%s CRDs", appprotect.APIGroup, version)
+	recorder.Eventf(pod, api_v1.EventTypeNormal, "AppProtectAPIVersionSelected",
+		"Using %s/%s CRDs", appprotect.APIGroup, version)
 }
 
 func getAgentVersionInfo(nginxManager nginx.Manager) string {

--- a/internal/k8s/appprotect/app_protect_configuration.go
+++ b/internal/k8s/appprotect/app_protect_configuration.go
@@ -25,46 +25,101 @@ const (
 	invalidTimestampErrorMsg = "invalid timestamp"
 )
 
+// APIGroup is the API group of the App Protect CRDs.
+const APIGroup = "appprotect.f5.com"
+
+// APIVersion identifies the version of the appprotect.f5.com CRDs NIC watches.
+// Values: APIVersionV1beta1 (default, legacy) and APIVersionV1 (introduced by
+// the WAF Policy Controller / PLM).
+type APIVersion string
+
+const (
+	// APIVersionV1beta1 is the legacy version of the appprotect.f5.com CRDs
+	// shipped with NIC's Helm chart.
+	APIVersionV1beta1 APIVersion = "v1beta1"
+	// APIVersionV1 is the version of the appprotect.f5.com CRDs installed by
+	// the WAF Policy Controller (PLM) chart.
+	APIVersionV1 APIVersion = "v1"
+)
+
 var (
-	// PolicyGVR is the group version resource of the appprotect policy
+	// PolicyGVR is the group version resource of the appprotect policy.
+	// The Version field is mutated once at startup by SetAPIVersion.
 	PolicyGVR = schema.GroupVersionResource{
-		Group:    "appprotect.f5.com",
-		Version:  "v1beta1",
+		Group:    APIGroup,
+		Version:  string(APIVersionV1beta1),
 		Resource: "appolicies",
 	}
-	// PolicyGVK is the group version kind of the appprotect policy
+	// PolicyGVK is the group version kind of the appprotect policy.
+	// The Version field is mutated once at startup by SetAPIVersion.
 	PolicyGVK = schema.GroupVersionKind{
-		Group:   "appprotect.f5.com",
-		Version: "v1beta1",
+		Group:   APIGroup,
+		Version: string(APIVersionV1beta1),
 		Kind:    "APPolicy",
 	}
 
-	// LogConfGVR is the group version resource of the appprotect policy
+	// LogConfGVR is the group version resource of the appprotect log
+	// configuration. The Version field is mutated once at startup by
+	// SetAPIVersion.
 	LogConfGVR = schema.GroupVersionResource{
-		Group:    "appprotect.f5.com",
-		Version:  "v1beta1",
+		Group:    APIGroup,
+		Version:  string(APIVersionV1beta1),
 		Resource: "aplogconfs",
 	}
-	// LogConfGVK is the group version kind of the appprotect policy
+	// LogConfGVK is the group version kind of the appprotect log
+	// configuration. The Version field is mutated once at startup by
+	// SetAPIVersion.
 	LogConfGVK = schema.GroupVersionKind{
-		Group:   "appprotect.f5.com",
-		Version: "v1beta1",
+		Group:   APIGroup,
+		Version: string(APIVersionV1beta1),
 		Kind:    "APLogConf",
 	}
 
-	// UserSigGVR is the group version resource of the appprotect policy
+	// UserSigGVR is the group version resource of the appprotect user
+	// signature. The Version field is mutated once at startup by
+	// SetAPIVersion.
 	UserSigGVR = schema.GroupVersionResource{
-		Group:    "appprotect.f5.com",
-		Version:  "v1beta1",
+		Group:    APIGroup,
+		Version:  string(APIVersionV1beta1),
 		Resource: "apusersigs",
 	}
-	// UserSigGVK is the group version kind of the appprotect policy
+	// UserSigGVK is the group version kind of the appprotect user
+	// signature. The Version field is mutated once at startup by
+	// SetAPIVersion.
 	UserSigGVK = schema.GroupVersionKind{
-		Group:   "appprotect.f5.com",
-		Version: "v1beta1",
+		Group:   APIGroup,
+		Version: string(APIVersionV1beta1),
 		Kind:    "APUserSig",
 	}
 )
+
+// SelectAPIVersion returns the appprotect.f5.com CRD version NIC should
+// watch, based on whether the operator has opted in to the WAF Policy
+// Controller (PLM) integration.
+func SelectAPIVersion(plmEnabled bool) APIVersion {
+	if plmEnabled {
+		return APIVersionV1
+	}
+	return APIVersionV1beta1
+}
+
+// SetAPIVersion switches the package-level PolicyGVR / LogConfGVR /
+// UserSigGVR (and matching GVK values) to point at the given version.
+func SetAPIVersion(version APIVersion) error {
+	switch version {
+	case APIVersionV1, APIVersionV1beta1:
+	default:
+		return fmt.Errorf("unsupported %s API version %q", APIGroup, version)
+	}
+	v := string(version)
+	PolicyGVR.Version = v
+	PolicyGVK.Version = v
+	LogConfGVR.Version = v
+	LogConfGVK.Version = v
+	UserSigGVR.Version = v
+	UserSigGVK.Version = v
+	return nil
+}
 
 // UserSigChange holds resources that are affected by changes in UserSigs
 type UserSigChange struct {

--- a/internal/k8s/appprotect/app_protect_configuration_test.go
+++ b/internal/k8s/appprotect/app_protect_configuration_test.go
@@ -1198,3 +1198,97 @@ func TestGetAppProtectResource(t *testing.T) {
 		}
 	}
 }
+
+// resetAPIVersionForTesting restores the package-level GVR/GVK vars to their
+// default v1beta1 values.
+func resetAPIVersionForTesting(t *testing.T) {
+	t.Helper()
+	if err := SetAPIVersion(APIVersionV1beta1); err != nil {
+		t.Fatalf("resetAPIVersionForTesting: %v", err)
+	}
+}
+
+func TestSelectAPIVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		plmEnabled  bool
+		wantVersion APIVersion
+	}{
+		{
+			name:        "PLM disabled selects v1beta1 (default)",
+			plmEnabled:  false,
+			wantVersion: APIVersionV1beta1,
+		},
+		{
+			name:        "PLM enabled selects v1",
+			plmEnabled:  true,
+			wantVersion: APIVersionV1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := SelectAPIVersion(tc.plmEnabled); got != tc.wantVersion {
+				t.Errorf("SelectAPIVersion(%v) = %q, want %q", tc.plmEnabled, got, tc.wantVersion)
+			}
+		})
+	}
+}
+
+func TestSetAPIVersion(t *testing.T) {
+	defer resetAPIVersionForTesting(t)
+
+	tests := []struct {
+		name       string
+		version    APIVersion
+		wantErr    bool
+		wantOnGVRs string // expected Version on all GVRs / GVKs after the call
+	}{
+		{
+			name:       "v1",
+			version:    APIVersionV1,
+			wantOnGVRs: "v1",
+		},
+		{
+			name:       "v1beta1",
+			version:    APIVersionV1beta1,
+			wantOnGVRs: "v1beta1",
+		},
+		{
+			name:    "unsupported version rejected",
+			version: APIVersion("v2alpha1"),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := SetAPIVersion(tc.version)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("SetAPIVersion(%q) expected an error, got nil", tc.version)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SetAPIVersion(%q) unexpected error: %v", tc.version, err)
+			}
+			for _, got := range []struct {
+				name string
+				v    string
+			}{
+				{"PolicyGVR", PolicyGVR.Version},
+				{"PolicyGVK", PolicyGVK.Version},
+				{"LogConfGVR", LogConfGVR.Version},
+				{"LogConfGVK", LogConfGVK.Version},
+				{"UserSigGVR", UserSigGVR.Version},
+				{"UserSigGVK", UserSigGVK.Version},
+			} {
+				if got.v != tc.wantOnGVRs {
+					t.Errorf("%s.Version = %q, want %q", got.name, got.v, tc.wantOnGVRs)
+				}
+			}
+		})
+	}
+}

--- a/internal/logger/events.go
+++ b/internal/logger/events.go
@@ -1,29 +1,30 @@
 package log
 
 const (
-	EventReasonAddedOrUpdated            = "AddedOrUpdated"            //nolint:revive
-	EventReasonAddedOrUpdatedWithError   = "AddedOrUpdatedWithError"   //nolint:revive
-	EventReasonAddedOrUpdatedWithWarning = "AddedOrUpdatedWithWarning" //nolint:revive
-	EventReasonBadConfig                 = "BadConfig"                 //nolint:revive
-	EventReasonCreateDNSEndpoint         = "CreateDNSEndpoint"         //nolint:revive
-	EventReasonCreateCertificate         = "CreateCertificate"         //nolint:revive
-	EventReasonDeleteCertificate         = "DeleteCertificate"         //nolint:revive
-	EventReasonIgnored                   = "Ignored"                   //nolint:revive
-	EventReasonInvalidValue              = "InvalidValue"              //nolint:revive
-	EventReasonLicenseExpiry             = "LicenseExpiry"             //nolint:revive
-	EventReasonNoIngressMasterFound      = "NoIngressMasterFound"      //nolint:revive
-	EventReasonNoVirtualServerFound      = "NoVirtualServerFound"      //nolint:revive
-	EventReasonRejected                  = "Rejected"                  //nolint:revive
-	EventReasonRejectedWithError         = "RejectedWithError"         //nolint:revive
-	EventReasonSecretDeleted             = "SecretDeleted"             //nolint:revive
-	EventReasonSecretUpdated             = "SecretUpdated"             //nolint:revive
-	EventReasonUpdated                   = "Updated"                   //nolint:revive
-	EventReasonUpdatedWithError          = "UpdatedWithError"          //nolint:revive
-	EventReasonUpdateCertificate         = "UpdateCertificate"         //nolint:revive
-	EventReasonUpdateDNSEndpoint         = "UpdateDNSEndpoint"         //nolint:revive
-	EventReasonUpdatePodLabel            = "UpdatePodLabel"            //nolint:revive
-	EventReasonUsageGraceEnding          = "UsageGraceEnding"          //nolint:revive
-	EventReasonServiceFailedToCreate     = "ServiceFailedToCreate"     //nolint:revive
-	EventReasonInvalidConfiguration      = "InvalidConfiguration"      //nolint:revive
-	EventReasonBundleFetchFailed         = "BundleFetchFailed"         //nolint:revive
+	EventReasonAddedOrUpdated               = "AddedOrUpdated"               //nolint:revive
+	EventReasonAddedOrUpdatedWithError      = "AddedOrUpdatedWithError"      //nolint:revive
+	EventReasonAddedOrUpdatedWithWarning    = "AddedOrUpdatedWithWarning"    //nolint:revive
+	EventReasonBadConfig                    = "BadConfig"                    //nolint:revive
+	EventReasonCreateDNSEndpoint            = "CreateDNSEndpoint"            //nolint:revive
+	EventReasonCreateCertificate            = "CreateCertificate"            //nolint:revive
+	EventReasonDeleteCertificate            = "DeleteCertificate"            //nolint:revive
+	EventReasonIgnored                      = "Ignored"                      //nolint:revive
+	EventReasonInvalidValue                 = "InvalidValue"                 //nolint:revive
+	EventReasonLicenseExpiry                = "LicenseExpiry"                //nolint:revive
+	EventReasonNoIngressMasterFound         = "NoIngressMasterFound"         //nolint:revive
+	EventReasonNoVirtualServerFound         = "NoVirtualServerFound"         //nolint:revive
+	EventReasonRejected                     = "Rejected"                     //nolint:revive
+	EventReasonRejectedWithError            = "RejectedWithError"            //nolint:revive
+	EventReasonSecretDeleted                = "SecretDeleted"                //nolint:revive
+	EventReasonSecretUpdated                = "SecretUpdated"                //nolint:revive
+	EventReasonUpdated                      = "Updated"                      //nolint:revive
+	EventReasonUpdatedWithError             = "UpdatedWithError"             //nolint:revive
+	EventReasonUpdateCertificate            = "UpdateCertificate"            //nolint:revive
+	EventReasonUpdateDNSEndpoint            = "UpdateDNSEndpoint"            //nolint:revive
+	EventReasonUpdatePodLabel               = "UpdatePodLabel"               //nolint:revive
+	EventReasonUsageGraceEnding             = "UsageGraceEnding"             //nolint:revive
+	EventReasonServiceFailedToCreate        = "ServiceFailedToCreate"        //nolint:revive
+	EventReasonInvalidConfiguration         = "InvalidConfiguration"         //nolint:revive
+	EventReasonBundleFetchFailed            = "BundleFetchFailed"            //nolint:revive
+	EventReasonAppProtectAPIVersionSelected = "AppProtectAPIVersionSelected" //nolint:revive
 )


### PR DESCRIPTION
### Proposed changes

- Adds support for v1 WAF CRDs installed by F5 WAF Policy Controller
- Adds a new cli arg `-plm-storage-url` which acts as a toggle for PLM (and switch to v1 api). `-plm-storage-url` points to SeaweedFS S3 endpoint URL for the F5 WAF Policy Controller. 
- Adds other PLM specific CLI args

```
 make build
go version go1.26.5 darwin/arm64
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=5.6.0-SNAPSHOT -X main.telemetryEndpoint=oss.edge.df.f5.com:443" -o nginx-ingress-amd64  github.com/nginx/kubernetes-ingress/cmd/nginx-ingress
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
