### PR TITLE
Add build-push-retry action to Docker build workflows

### DIFF
--- a/.github/actions/build-push-retry/action.yaml
+++ b/.github/actions/build-push-retry/action.yaml
@@ -1,0 +1,177 @@
+name: Build and Push with Retry
+description: Wraps docker/build-push-action with retry logic for transient push/auth failures
+
+inputs:
+  file:
+    description: Path to the Dockerfile
+    required: true
+  context:
+    description: Build context
+    default: "."
+  tags:
+    description: Image tags (newline-separated)
+    required: true
+  labels:
+    description: Image labels
+    required: false
+  annotations:
+    description: Image annotations
+    required: false
+  platforms:
+    description: Target platforms (e.g. linux/amd64,linux/arm64)
+    required: false
+  target:
+    description: Dockerfile build target
+    required: false
+  build-args:
+    description: Build arguments (newline-separated)
+    required: false
+  secret-files:
+    description: Secret files (newline-separated key=path pairs)
+    required: false
+  cache-from:
+    description: Cache sources
+    required: false
+  cache-to:
+    description: Cache destinations
+    required: false
+  push:
+    description: Push image to registry
+    default: "true"
+  load:
+    description: Load image into local Docker daemon
+    default: "false"
+  pull:
+    description: Always pull base images
+    default: "true"
+  no-cache:
+    description: Disable build cache
+    default: "false"
+  sbom:
+    description: Generate SBOM attestation
+    required: false
+  provenance:
+    description: Generate provenance attestation
+    required: false
+  max-attempts:
+    description: Maximum number of push attempts (1-3)
+    default: "3"
+  retry-wait-seconds:
+    description: Seconds to wait between retries
+    default: "15"
+
+outputs:
+  digest:
+    description: Image digest from successful push
+    value: ${{ steps.attempt1.outputs.digest || steps.attempt2.outputs.digest || steps.attempt3.outputs.digest }}
+  metadata:
+    description: Build result metadata
+    value: ${{ steps.attempt1.outputs.metadata || steps.attempt2.outputs.metadata || steps.attempt3.outputs.metadata }}
+  imageid:
+    description: Image ID
+    value: ${{ steps.attempt1.outputs.imageid || steps.attempt2.outputs.imageid || steps.attempt3.outputs.imageid }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build and Push (attempt 1)
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      id: attempt1
+      continue-on-error: true
+      with:
+        file: ${{ inputs.file }}
+        context: ${{ inputs.context }}
+        tags: ${{ inputs.tags }}
+        labels: ${{ inputs.labels }}
+        annotations: ${{ inputs.annotations }}
+        platforms: ${{ inputs.platforms }}
+        target: ${{ inputs.target }}
+        build-args: ${{ inputs.build-args }}
+        secret-files: ${{ inputs.secret-files }}
+        cache-from: ${{ inputs.cache-from }}
+        cache-to: ${{ inputs.cache-to }}
+        push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
+        pull: ${{ inputs.pull }}
+        no-cache: ${{ inputs.no-cache }}
+        sbom: ${{ inputs.sbom }}
+        provenance: ${{ inputs.provenance }}
+
+    - name: Wait before retry 1
+      if: steps.attempt1.outcome == 'failure' && inputs.max-attempts >= 2
+      shell: bash
+      env:
+        RETRY_WAIT: ${{ inputs.retry-wait-seconds }}
+      run: |
+        echo "::warning::Build/push attempt 1 failed. Retrying in ${RETRY_WAIT}s..."
+        sleep "${RETRY_WAIT}"
+
+    - name: Build and Push (attempt 2)
+      if: steps.attempt1.outcome == 'failure' && inputs.max-attempts >= 2
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      id: attempt2
+      continue-on-error: true
+      with:
+        file: ${{ inputs.file }}
+        context: ${{ inputs.context }}
+        tags: ${{ inputs.tags }}
+        labels: ${{ inputs.labels }}
+        annotations: ${{ inputs.annotations }}
+        platforms: ${{ inputs.platforms }}
+        target: ${{ inputs.target }}
+        build-args: ${{ inputs.build-args }}
+        secret-files: ${{ inputs.secret-files }}
+        cache-from: ${{ inputs.cache-from }}
+        push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
+        pull: ${{ inputs.pull }}
+        no-cache: ${{ inputs.no-cache }}
+        sbom: ${{ inputs.sbom }}
+        provenance: ${{ inputs.provenance }}
+
+    - name: Wait before retry 2
+      if: steps.attempt1.outcome == 'failure' && steps.attempt2.outcome == 'failure' && inputs.max-attempts >= 3
+      shell: bash
+      env:
+        RETRY_WAIT: ${{ inputs.retry-wait-seconds }}
+      run: |
+        echo "::warning::Build/push attempt 2 failed. Retrying in ${RETRY_WAIT}s..."
+        sleep "${RETRY_WAIT}"
+
+    - name: Build and Push (attempt 3)
+      if: steps.attempt1.outcome == 'failure' && steps.attempt2.outcome == 'failure' && inputs.max-attempts >= 3
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      id: attempt3
+      continue-on-error: true
+      with:
+        file: ${{ inputs.file }}
+        context: ${{ inputs.context }}
+        tags: ${{ inputs.tags }}
+        labels: ${{ inputs.labels }}
+        annotations: ${{ inputs.annotations }}
+        platforms: ${{ inputs.platforms }}
+        target: ${{ inputs.target }}
+        build-args: ${{ inputs.build-args }}
+        secret-files: ${{ inputs.secret-files }}
+        cache-from: ${{ inputs.cache-from }}
+        push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
+        pull: ${{ inputs.pull }}
+        no-cache: ${{ inputs.no-cache }}
+        sbom: ${{ inputs.sbom }}
+        provenance: ${{ inputs.provenance }}
+
+    - name: Fail if all attempts failed
+      if: steps.attempt1.outcome == 'failure' && (inputs.max-attempts < 2 || steps.attempt2.outcome == 'failure') && (inputs.max-attempts < 3 || steps.attempt3.outcome == 'failure')
+      shell: bash
+      env:
+        MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+      run: |
+        if ! [[ "${MAX_ATTEMPTS}" =~ ^[0-9]+$ ]]; then
+          echo "::error::max-attempts must be a positive integer, got: ${MAX_ATTEMPTS}"
+          exit 1
+        fi
+        attempts="${MAX_ATTEMPTS}"
+        if [ "${attempts}" -gt 3 ]; then attempts=3; fi
+        echo "::error::All ${attempts} build/push attempts failed"
+        exit 1

--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -112,7 +112,7 @@ jobs:
             type=raw,value=${{ needs.checks.outputs.docker_md5 }},enable=${{ needs.checks.outputs.docker_md5 != '' }}
 
       - name: Build Base Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: build/Dockerfile
           context: "."
@@ -208,7 +208,7 @@ jobs:
             type=raw,value=${{ needs.checks.outputs.docker_md5 }},enable=${{ needs.checks.outputs.docker_md5 != '' }}
 
       - name: Build Base Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: build/Dockerfile
           context: "."
@@ -319,7 +319,7 @@ jobs:
             type=raw,value=${{ needs.checks.outputs.docker_md5 }},enable=${{ needs.checks.outputs.docker_md5 != '' }}
 
       - name: Build Base Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: build/Dockerfile
           context: "."

--- a/.github/workflows/build-oss.yml
+++ b/.github/workflows/build-oss.yml
@@ -183,7 +183,7 @@ jobs:
         if: ${{ steps.images_exist.outputs.base_exists != 'true' || steps.images_exist.outputs.target_exists != 'true' }}
 
       - name: Build Base Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: build/Dockerfile
           context: "."
@@ -215,7 +215,7 @@ jobs:
         if: ${{ steps.images_exist.outputs.base_exists != 'true' || steps.images_exist.outputs.target_exists != 'true' }}
 
       - name: Build Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         id: build-push
         with:
           file: build/Dockerfile

--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -206,7 +206,7 @@ jobs:
         if: ${{ steps.images_exist.outputs.base_exists != 'true' || steps.images_exist.outputs.target_exists != 'true' }}
 
       - name: Build Base Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: build/Dockerfile
           context: "."
@@ -243,7 +243,7 @@ jobs:
         if: ${{ steps.images_exist.outputs.base_exists != 'true' || steps.images_exist.outputs.target_exists != 'true' }}
 
       - name: Build Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         id: build-push
         with:
           file: build/Dockerfile

--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -68,7 +68,7 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Build Test-Runner Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: tests/Dockerfile
           context: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,7 +617,7 @@ jobs:
         if: ${{ needs.checks.outputs.forked_workflow == 'true' }}
 
       - name: Build Docker Image ${{ matrix.base-os }}
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: build/Dockerfile
           context: "."
@@ -772,7 +772,7 @@ jobs:
         if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
 
       - name: Build Test-Runner Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: tests/Dockerfile
           context: "."

--- a/.github/workflows/patch-image.yml
+++ b/.github/workflows/patch-image.yml
@@ -89,7 +89,7 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Apply OS patches to Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: build/Dockerfile
           context: "."

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -47,7 +47,7 @@ permissions:
 jobs:
   setup-smoke:
     permissions:
-      contents: read # for docker/build-push-action to read repo content
+      contents: read # for ./.github/actions/build-push-retry
       id-token: write # for OIDC login to GCR
     if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
@@ -163,7 +163,7 @@ jobs:
         if: ${{ inputs.authenticated  }}
 
       - name: Build Pytest-Runner Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: tests/Dockerfile
           context: "."
@@ -175,7 +175,7 @@ jobs:
         if: ${{ ( !inputs.authenticated || steps.check-image.outcome == 'failure' )  }}
 
       - name: Build ${{ inputs.image }} Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: build/Dockerfile
           context: "."

--- a/.github/workflows/single-image-regression.yml
+++ b/.github/workflows/single-image-regression.yml
@@ -124,7 +124,7 @@ jobs:
         continue-on-error: true
 
       - name: Build Test-Runner Container
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: ./.github/actions/build-push-retry
         with:
           file: tests/Dockerfile
           context: "."


### PR DESCRIPTION
* Add build-push-retry action to Docker build workflows

* Update action.yaml to clarify max-attempts input and handle error messages for build/push attempts

* Enhance retry logic in build-push-retry action to use environment variables for wait times and validate max-attempts input

---------

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to
that issue here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
