### PR TITLE
chore: update markdownlint2 and action

### DIFF
--- a/.github/skills/nic-debugging/SKILL.md
+++ b/.github/skills/nic-debugging/SKILL.md
@@ -12,6 +12,7 @@ description: 'Debugging and troubleshooting patterns for NIC. Use when diagnosin
 **Symptom:** Controller logs show "reload failed" or NGINX returns error status.
 
 **Diagnosis:**
+
 1. Check controller logs for the generated config that failed
 2. Look for `nginx -t` output in logs — shows exact syntax error and line number
 3. Common causes:
@@ -21,6 +22,7 @@ description: 'Debugging and troubleshooting patterns for NIC. Use when diagnosin
    - Invalid upstream when no endpoints available
 
 **Fix pattern:**
+
 - Find the template or config generation code that produced the bad directive
 - Add validation to reject the input earlier, OR fix the template guard
 - Verify with `make test` — snapshot tests catch most template output issues
@@ -30,6 +32,7 @@ description: 'Debugging and troubleshooting patterns for NIC. Use when diagnosin
 **Symptom:** User applies VirtualServer/Policy but NGINX config doesn't change.
 
 **Diagnosis:**
+
 1. Check CRD status: `kubectl get vs <name> -o yaml` — look at `.status.message`
 2. Check controller logs for sync errors on that resource
 3. Common causes:
@@ -43,6 +46,7 @@ description: 'Debugging and troubleshooting patterns for NIC. Use when diagnosin
 **Symptom:** Pod restarts, panic in logs.
 
 **Diagnosis:**
+
 1. Check logs for the panic stack trace
 2. Common causes:
    - Nil pointer on optional CRD field (forgot `*bool`/`*int` check)
@@ -55,6 +59,7 @@ description: 'Debugging and troubleshooting patterns for NIC. Use when diagnosin
 **Symptom:** `make test` fails with snapshot mismatch.
 
 **Diagnosis:**
+
 1. This means template output changed — could be intentional or regression
 2. Review the diff shown in test output
 3. If change is intentional: `make test-update-snaps` to regenerate

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
+      - uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
         with:
           config: .markdownlint-cli2.yaml
           globs: "**/*.md"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -17,6 +17,3 @@ noBanner: true
 ignores:
   - ".github/**"
   - "docs/**" # Ignore developer docs folder
-
-# Fix any fixable errors
-fix: true

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -17,3 +17,9 @@ noBanner: true
 ignores:
   - ".github/**"
   - "docs/**" # Ignore developer docs folder
+  - "vendor/**" # Ignore vendor folder
+  - "**/venv/**"
+  - ".local/**"
+
+# Fix any fixable errors
+fix: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,9 +100,10 @@ repos:
         args: ["--schemafile", "charts/nginx-ingress/values.schema.json"]
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.23.0
+    rev: v0.23.1
     hooks:
       - id: markdownlint-cli2
+        args: [--fix]
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,9 @@ repos:
     rev: v0.23.1
     hooks:
       - id: markdownlint-cli2
-        args: [--fix]
+        args: [ "**/*.md", "--fix" ]
+        pass_filenames: false
+        always_run: true
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12


### PR DESCRIPTION

### Proposed changes

There's a renovate PR open https://github.com/nginx/kubernetes-ingress/pull/10493 that only updates the version used in pre-commit, but there's not one for the github action. This one bundles both.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
