### PR TITLE
add missing build dependency to make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,14 +187,14 @@ build-goreleaser: ## Build Ingress Controller binary using GoReleaser
 ###### NIC + NGINX OSS Images (built from scratch) ######
 
 .PHONY: alpine-image
-alpine-image: ## Build OSS Alpine-based image
+alpine-image: build ## Build OSS Alpine-based image
 	$(DOCKER_CMD) \
 		--build-arg BUILD_OS=alpine \
 		--build-arg NGINX_OSS_VERSION=$(NGINX_OSS_VERSION) \
 		--build-arg AGENT_V3_VERSION=$(AGENT_V3_VERSION)
 
 .PHONY: debian-image
-debian-image: ## Build OSS Debian-based image
+debian-image: build ## Build OSS Debian-based image
 	$(DOCKER_CMD) \
 		--build-arg BUILD_OS=debian \
 		--build-arg NGINX_OSS_VERSION=$(NGINX_OSS_VERSION) \


### PR DESCRIPTION
### Proposed changes

Adds back the `build` dependency to the alpine and debian image builds in Makefile.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
