### PR TITLE
Reload NGINX for non-TLS secret updates regardless of -ssl-dynamic-reload (#10390) 

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1888,13 +1888,24 @@ func (lbc *LoadBalancerController) handleSecretUpdate(secret *api_v1.Secret, res
 
 	resourceExes := lbc.createExtendedResources(resources)
 
-	warnings, addOrUpdateErr = lbc.configurator.AddOrUpdateResources(resourceExes, !lbc.configurator.DynamicSSLReloadEnabled())
+	reloadIfUnchanged := shouldForceReloadOnSecretUpdate(secret.Type, lbc.configurator.DynamicSSLReloadEnabled())
+	warnings, addOrUpdateErr = lbc.configurator.AddOrUpdateResources(resourceExes, reloadIfUnchanged)
 	if addOrUpdateErr != nil {
 		nl.Errorf(lbc.Logger, "Error when updating Secret %v: %v", secretNsName, addOrUpdateErr)
 		lbc.recorder.Eventf(lbc.metadata.pod, api_v1.EventTypeWarning, nl.EventReasonUpdatedWithError, "%v was updated, but not applied: %v", secretNsName, addOrUpdateErr)
 	}
 
 	lbc.updateResourcesStatusAndEvents(resources, warnings, addOrUpdateErr)
+}
+
+// shouldForceReloadOnSecretUpdate reports whether NGINX must be reloaded on a secret
+// update even if the rendered config bytes are unchanged. The -ssl-dynamic-reload
+// optimization only applies to TLS server secrets (kubernetes.io/tls), whose
+// ssl_certificate / ssl_certificate_key directives read the file at request time via
+// a variable path. Any non-TLS secret type is parsed at config-load time and would
+// otherwise remain stale until an unrelated event triggers a reload.
+func shouldForceReloadOnSecretUpdate(secretType api_v1.SecretType, dynamicSSLReloadEnabled bool) bool {
+	return secretType != api_v1.SecretTypeTLS || !dynamicSSLReloadEnabled
 }
 
 func (lbc *LoadBalancerController) validationTLSSpecialSecret(secret *api_v1.Secret, secretName string, secretList *[]string) error {

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -3752,6 +3752,100 @@ func TestGenerateSecretNSName(t *testing.T) {
 	}
 }
 
+func TestShouldForceReloadOnSecretUpdate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name                    string
+		secretType              api_v1.SecretType
+		dynamicSSLReloadEnabled bool
+		expected                bool
+	}{
+		{
+			name:                    "TLS server secret with dynamic SSL reload enabled skips forced reload",
+			secretType:              api_v1.SecretTypeTLS,
+			dynamicSSLReloadEnabled: true,
+			expected:                false,
+		},
+		{
+			name:                    "TLS server secret with dynamic SSL reload disabled forces reload",
+			secretType:              api_v1.SecretTypeTLS,
+			dynamicSSLReloadEnabled: false,
+			expected:                true,
+		},
+		{
+			name:                    "CA secret forces reload even when dynamic SSL reload is enabled",
+			secretType:              secrets.SecretTypeCA,
+			dynamicSSLReloadEnabled: true,
+			expected:                true,
+		},
+		{
+			name:                    "JWK secret forces reload even when dynamic SSL reload is enabled",
+			secretType:              secrets.SecretTypeJWK,
+			dynamicSSLReloadEnabled: true,
+			expected:                true,
+		},
+		{
+			name:                    "Htpasswd secret forces reload even when dynamic SSL reload is enabled",
+			secretType:              secrets.SecretTypeHtpasswd,
+			dynamicSSLReloadEnabled: true,
+			expected:                true,
+		},
+		{
+			name:                    "OIDC secret forces reload even when dynamic SSL reload is enabled",
+			secretType:              secrets.SecretTypeOIDC,
+			dynamicSSLReloadEnabled: true,
+			expected:                true,
+		},
+		{
+			name:                    "APIKey secret forces reload even when dynamic SSL reload is enabled",
+			secretType:              secrets.SecretTypeAPIKey,
+			dynamicSSLReloadEnabled: true,
+			expected:                true,
+		},
+		{
+			name:                    "CA secret forces reload when dynamic SSL reload is disabled",
+			secretType:              secrets.SecretTypeCA,
+			dynamicSSLReloadEnabled: false,
+			expected:                true,
+		},
+		{
+			name:                    "JWK secret forces reload when dynamic SSL reload is disabled",
+			secretType:              secrets.SecretTypeJWK,
+			dynamicSSLReloadEnabled: false,
+			expected:                true,
+		},
+		{
+			name:                    "Htpasswd secret forces reload when dynamic SSL reload is disabled",
+			secretType:              secrets.SecretTypeHtpasswd,
+			dynamicSSLReloadEnabled: false,
+			expected:                true,
+		},
+		{
+			name:                    "OIDC secret forces reload when dynamic SSL reload is disabled",
+			secretType:              secrets.SecretTypeOIDC,
+			dynamicSSLReloadEnabled: false,
+			expected:                true,
+		},
+		{
+			name:                    "APIKey secret forces reload when dynamic SSL reload is disabled",
+			secretType:              secrets.SecretTypeAPIKey,
+			dynamicSSLReloadEnabled: false,
+			expected:                true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldForceReloadOnSecretUpdate(tc.secretType, tc.dynamicSSLReloadEnabled)
+			if got != tc.expected {
+				t.Fatalf("shouldForceReloadOnSecretUpdate(%q, %v) = %v, want %v",
+					tc.secretType, tc.dynamicSSLReloadEnabled, got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestCreateVirtualServerExWithZoneSync(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
cherry pick https://github.com/nginx/kubernetes-ingress/pull/10390

* Reload NGINX for non-TLS secret updates regardless of -ssl-dynamic-reload

The -ssl-dynamic-reload optimization only applies to ssl_certificate / ssl_certificate_key, which read the file at request time via a variable path. All other secret types (nginx.org/ca, /jwk, /htpasswd, /oidc, /apikey) are parsed by NGINX at config-load time and need a reload to pick up rotated content. Scope the optimization to kubernetes.io/tls secrets so rotations of the other types no longer no-op.

Fixes #10039

* Extract shouldForceReloadOnSecretUpdate and add regression test

Address review feedback on #10390:
- Extract the reloadIfUnchanged boolean into a package-level pure helper so the behavior can be unit-tested and future refactors can't silently regress it back to !DynamicSSLReloadEnabled().
- Replace the hard-coded list of non-TLS secret types in the comment with a type-agnostic explanation of why non-TLS secrets need a reload.
- Add TestShouldForceReloadOnSecretUpdate covering TLS with dynamic reload on/off and every currently-supported non-TLS secret type (CA, JWK, Htpasswd, OIDC, APIKey) with dynamic reload enabled.

* Cover non-TLS secret types with dynamic SSL reload disabled

Address review feedback on #10390: add table rows for CA, JWK, Htpasswd, OIDC and APIKey with dynamicSSLReloadEnabled=false to complete the truth table for shouldForceReloadOnSecretUpdate.

---------


(cherry picked from commit 2a19bd3987eeed8e32bb8e267d236f0064058536)