### PR TITLE
Tests/improve e2e failure reporting

### DIFF
--- a/.github/actions/smoke-tests/action.yaml
+++ b/.github/actions/smoke-tests/action.yaml
@@ -42,6 +42,9 @@ outputs:
   test-results-path:
     description: Test results full path
     value: ${{ steps.k8s.outputs.test_output_path }}
+  test-junit-path:
+    description: Test JUnit XML full path
+    value: ${{ steps.k8s.outputs.test_junit_path }}
 
 runs:
   using: composite
@@ -59,12 +62,16 @@ runs:
         cluster_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${{ github.run_id }}-control-plane)
         test_name=tests-nginx-${{ inputs.image-type }}-${name}.html
         test_output_path=${{ github.workspace }}/tests/${test_name}
+        test_junit_name=junit-nginx-${{ inputs.image-type }}-${name}.xml
+        test_junit_path=${{ github.workspace }}/tests/${test_junit_name}
         echo "cluster_ip=${cluster_ip}" >> $GITHUB_OUTPUT
         echo "test_name=${test_name}" >> $GITHUB_OUTPUT
         echo "test_output_path=${test_output_path}" >> $GITHUB_OUTPUT
+        echo "test_junit_path=${test_junit_path}" >> $GITHUB_OUTPUT
         echo "Output:"
         echo "  cluster_ip=${cluster_ip}"
         echo "  test_output_path=${test_output_path}"
+        echo "  test_junit_path=${test_junit_path}"
       shell: bash
 
     - name: Setup Kubeconfig
@@ -76,6 +83,7 @@ runs:
       id: smoke-tests
       run: |
         touch ${{ steps.k8s.outputs.test_output_path }}
+        touch ${{ steps.k8s.outputs.test_junit_path }}
         docker run --rm \
         --name test-runner-${{ github.run_id }} \
         --network=kind \
@@ -88,6 +96,7 @@ runs:
         -v ${{ github.workspace }}/config:/workspace/config \
         -v ${{ github.workspace }}/pyproject.toml:/workspace/pyproject.toml \
         -v ${{ steps.k8s.outputs.test_output_path }}:${{ steps.k8s.outputs.test_output_path }} \
+        -v ${{ steps.k8s.outputs.test_junit_path }}:${{ steps.k8s.outputs.test_junit_path }} \
         -v ~/.kube/kind/config:/root/.kube/config ${{ inputs.test-image }} \
         --docker-registry-user=oauth2accesstoken \
         --docker-registry-token=${{ inputs.registry-token }} \
@@ -98,6 +107,7 @@ runs:
         --service=nodeport --node-ip=${{ steps.k8s.outputs.cluster_ip }} \
         --html=${{ steps.k8s.outputs.test_output_path }} \
         --self-contained-html \
+        --junitxml=${{ steps.k8s.outputs.test_junit_path }} \
         --durations=10 \
         -rfE \
         --show-ic-logs=yes \

--- a/.github/actions/smoke-tests/action.yaml
+++ b/.github/actions/smoke-tests/action.yaml
@@ -99,6 +99,7 @@ runs:
         --html=${{ steps.k8s.outputs.test_output_path }} \
         --self-contained-html \
         --durations=10 \
+        -rfE \
         --show-ic-logs=yes \
         --plus-jwt=${{ inputs.plus-jwt }} \
         -m ${{ inputs.marker != '' && inputs.marker || '""' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,7 +814,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      checks: write
     uses: ./.github/workflows/setup-smoke.yml
     secrets: inherit
     with:
@@ -847,7 +846,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      checks: write
     uses: ./.github/workflows/setup-smoke.yml
     secrets: inherit
     with:
@@ -880,7 +878,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      checks: write
     uses: ./.github/workflows/setup-smoke.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,6 +814,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      checks: write
     uses: ./.github/workflows/setup-smoke.yml
     secrets: inherit
     with:
@@ -846,6 +847,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      checks: write
     uses: ./.github/workflows/setup-smoke.yml
     secrets: inherit
     with:
@@ -878,6 +880,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      checks: write
     uses: ./.github/workflows/setup-smoke.yml
     secrets: inherit
     with:

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -49,7 +49,6 @@ jobs:
     permissions:
       contents: read # for ./.github/actions/build-push-retry
       id-token: write # for OIDC login to GCR
-      checks: write # for publish-unit-test-result-action
     if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
@@ -247,15 +246,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.smoke-tests.outputs.test-results-name }}
-          path: ${{ steps.smoke-tests.outputs.test-results-path }}
-        if: ${{ !cancelled() && steps.stable_exists.outputs.exists != 'true' }}
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
-        with:
-          files: ${{ steps.smoke-tests.outputs.test-junit-path }}
-          check_name: "Smoke Test Results (${{ inputs.image }})"
-          comment_mode: "off"
+          path: |
+            ${{ steps.smoke-tests.outputs.test-results-path }}
+            ${{ steps.smoke-tests.outputs.test-junit-path }}
         if: ${{ !cancelled() && steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Clean up secrets

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -50,7 +50,6 @@ jobs:
       contents: read # for ./.github/actions/build-push-retry
       id-token: write # for OIDC login to GCR
       checks: write # for publish-unit-test-result-action
-      pull-requests: write # for publish-unit-test-result-action
     if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:
@@ -256,6 +255,7 @@ jobs:
         with:
           junit_files: ${{ steps.smoke-tests.outputs.test-junit-path }}
           check_name: "Smoke Test Results (${{ inputs.image }})"
+          comment_mode: off
         if: ${{ !cancelled() && steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Clean up secrets

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -250,7 +250,7 @@ jobs:
         if: ${{ !cancelled() && steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@170e2a5f632e3a890fc252195f4e0c4e12c1d8c0 # v2.18.0
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           junit_files: ${{ steps.smoke-tests.outputs.test-junit-path }}
           check_name: "Smoke Test Results (${{ inputs.image }})"

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -249,6 +249,13 @@ jobs:
           path: ${{ steps.smoke-tests.outputs.test-results-path }}
         if: ${{ !cancelled() && steps.stable_exists.outputs.exists != 'true' }}
 
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@170e2a5f632e3a890fc252195f4e0c4e12c1d8c0 # v2.18.0
+        with:
+          junit_files: ${{ steps.smoke-tests.outputs.test-junit-path }}
+          check_name: "Smoke Test Results (${{ inputs.image }})"
+        if: ${{ !cancelled() && steps.stable_exists.outputs.exists != 'true' }}
+
       - name: Clean up secrets
         run: |
           rm -f nginx-repo.crt nginx-repo.key rhel_license

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -253,9 +253,9 @@ jobs:
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
-          junit_files: ${{ steps.smoke-tests.outputs.test-junit-path }}
+          files: ${{ steps.smoke-tests.outputs.test-junit-path }}
           check_name: "Smoke Test Results (${{ inputs.image }})"
-          comment_mode: off
+          comment_mode: "off"
         if: ${{ !cancelled() && steps.stable_exists.outputs.exists != 'true' }}
 
       - name: Clean up secrets

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -49,6 +49,8 @@ jobs:
     permissions:
       contents: read # for ./.github/actions/build-push-retry
       id-token: write # for OIDC login to GCR
+      checks: write # for publish-unit-test-result-action
+      pull-requests: write # for publish-unit-test-result-action
     if: github.repository == 'nginx/kubernetes-ingress'
     runs-on: ubuntu-24.04
     steps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,3 +254,28 @@ def pytest_runtest_makereport(item) -> None:
     if rep.when == "call" and item.config.getoption("--skip-fixture-teardown") == "yes":
         print("\n===================== WARNING =====================")
         print("Make sure to remove resources from this test run manually using kubectl utility\n")
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config) -> None:
+    """Write failed test summary table to GITHUB_STEP_SUMMARY if running in GitHub Actions."""
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_file or exitstatus == 0:
+        return
+
+    failed_reports = terminalreporter.stats.get("failed", [])
+    if not failed_reports:
+        return
+
+    try:
+        with open(summary_file, "a", encoding="utf-8") as f:
+            f.write("\n### ❌ Failed Tests Summary\n\n")
+            f.write("| Test Case | Failure Summary |\n")
+            f.write("| --- | --- |\n")
+            for rep in failed_reports:
+                nodeid = rep.nodeid
+                summary = str(rep.longrepr).strip().splitlines()[-1] if rep.longrepr else "Test failed"
+                summary_clean = summary.replace("|", "\\|")
+                f.write(f"| `{nodeid}` | `{summary_clean}` |\n")
+            f.write("\n")
+    except Exception as e:
+        print(f"Failed to write to GITHUB_STEP_SUMMARY: {e}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,6 +232,11 @@ def pytest_runtest_makereport(item) -> None:
     outcome = yield
     rep = outcome.get_result()
 
+    if rep.failed:
+        file_path, line_no, _ = rep.location
+        summary = str(rep.longrepr).strip().splitlines()[-1] if rep.longrepr else "Test failed"
+        print(f"\n::error file={file_path},line={line_no + 1},title=Test Failed: {item.nodeid}::{summary}")
+
     # we only look at actual failing test calls, not setup/teardown
     if rep.when == "call" and rep.failed and item.config.getoption("--show-ic-logs") == "yes":
         pod_namespace = item.funcargs["ingress_controller_prerequisites"].namespace

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,7 +241,7 @@ def pytest_runtest_makereport(item) -> None:
     if rep.when == "call" and rep.failed and item.config.getoption("--show-ic-logs") == "yes":
         pod_namespace = item.funcargs["ingress_controller_prerequisites"].namespace
         pod_name = get_first_pod_name(item.funcargs["kube_apis"].v1, pod_namespace)
-        print("\n===================== IC Logs Start =====================")
+        print("\n::group::NGINX Ingress Controller Pod Logs")
         count = 0
         while (not are_all_pods_in_ready_state(item.funcargs["kube_apis"].v1, pod_namespace)) and count < 10:
             count += 1
@@ -249,7 +249,7 @@ def pytest_runtest_makereport(item) -> None:
         pod = item.funcargs["kube_apis"].v1.read_namespaced_pod(pod_name, pod_namespace)
         container_name = pod.spec.containers[0].name
         print(item.funcargs["kube_apis"].v1.read_namespaced_pod_log(pod_name, pod_namespace, container=container_name))
-        print("\n===================== IC Logs End =====================")
+        print("::endgroup::")
 
     if rep.when == "call" and item.config.getoption("--skip-fixture-teardown") == "yes":
         print("\n===================== WARNING =====================")


### PR DESCRIPTION
# Proposed changes


## 1. GitHub Actions Error Annotations (`::error::`)

- **File**: [`tests/conftest.py`](file:///Users/g.javorszky/Projects/NIC/kubernetes-ingress/tests/conftest.py#L235-L238)
- **Commit Message**: `ci(testing): add GitHub Actions error annotations for test failures`
- **Summary**: Emits `::error::` workflow command strings during pytest failures to automatically create red error banners on the GitHub Actions PR summary & PR checks UI.

---

## 2. Collapsible NGINX IC Pod Logs (`::group::`)
- **File**: [`tests/conftest.py`](file:///Users/g.javorszky/Projects/NIC/kubernetes-ingress/tests/conftest.py#L244-L252)
- **Commit Message**: `ci(testing): collapse NGINX Ingress Controller logs in GitHub Actions output`
- **Summary**: Wraps container log dumps in `::group::NGINX Ingress Controller Pod Logs` and `::endgroup::`, hiding thousands of log lines inside a collapsible accordion in GitHub Actions UI.

---

## 3. GitHub Step Summary Table (`$GITHUB_STEP_SUMMARY`)
- **File**: [`tests/conftest.py`](file:///Users/g.javorszky/Projects/NIC/kubernetes-ingress/tests/conftest.py#L258-L281)
- **Commit Message**: `ci(testing): write failed test summary to GITHUB_STEP_SUMMARY`
- **Summary**: Added `pytest_terminal_summary` hook that appends a Markdown summary table of all failed test cases and failure reasons to `$GITHUB_STEP_SUMMARY`.

---

## 4. Expand Pytest Short Summary (`-rfE`)
- **File**: [`.github/actions/smoke-tests/action.yaml`](file:///Users/g.javorszky/Projects/NIC/kubernetes-ingress/.github/actions/smoke-tests/action.yaml#L110)
- **Commit Message**: `ci(testing): expand pytest short test summary info with failure details`
- **Summary**: Added `-rfE` flag to pytest options so pytest's `short test summary info` prints the exception/assertion error message alongside the test ID.

---

## 5. JUnit XML Reporting & Native Test Results Tab
- **Files**:
  - [`.github/actions/smoke-tests/action.yaml`](file:///Users/g.javorszky/Projects/NIC/kubernetes-ingress/.github/actions/smoke-tests/action.yaml)
  - [`.github/workflows/setup-smoke.yml`](file:///Users/g.javorszky/Projects/NIC/kubernetes-ingress/.github/workflows/setup-smoke.yml#L252-L257)
- **Commit Message**: `ci(testing): enable JUnit XML generation and publish test results`
- **Summary**: Configured `--junitxml` export in pytest and added `EnricoMi/publish-unit-test-result-action` to render an interactive "Tests" tab in GitHub Actions.


# Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
