### PR TITLE
fix(templates): omit status_zone for default fallback server

### DIFF
--- a/internal/configs/version1/__snapshots__/template_test.snap
+++ b/internal/configs/version1/__snapshots__/template_test.snap
@@ -946,8 +946,6 @@ server {
 
     server_name _;
 
-    status_zone _;
-
     
 
     
@@ -971,8 +969,6 @@ server {
     server_tokens "off";
 
     server_name _;
-
-    status_zone _;
 
     
 
@@ -998,8 +994,6 @@ server {
 
     server_name _;
 
-    status_zone _;
-
     
 
     
@@ -1023,8 +1017,6 @@ server {
     server_tokens "off";
 
     server_name _;
-
-    status_zone _;
 
     
 
@@ -1051,8 +1043,6 @@ server {
 
     server_name _;
 
-    status_zone _;
-
     
 
     
@@ -1076,8 +1066,6 @@ server {
     server_tokens "off";
 
     server_name _;
-
-    status_zone _;
 
     
 

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -106,13 +106,16 @@ server {
 	{{- end }}
 
 	server_name {{$server.Name}};
+	{{- if $.Ingress.Name}}
 
 	status_zone {{$server.StatusZone}};
-	{{- if $.Ingress.Name}}
 	set $resource_type "ingress";
 	set $resource_name "{{$.Ingress.Name}}";
 	set $resource_namespace "{{$.Ingress.Namespace}}";
 	set $service "-";
+	{{- else if ne $server.StatusZone "_" }}
+
+	status_zone {{$server.StatusZone}};
 	{{- end}}
 
 	{{- with $server.EgressMTLS }}

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -2056,6 +2056,9 @@ func TestExecuteTemplate_ForDefaultServerForNGINXPlusWithoutCustomDefaultHTTPAnd
 			t.Errorf("want %q in generated config", want)
 		}
 	}
+	if strings.Contains(mainConf, "status_zone") {
+		t.Errorf("status_zone directive should not be present in default server config, got: %s", mainConf)
+	}
 	snaps.MatchSnapshot(t, buf.String())
 }
 


### PR DESCRIPTION
### Proposed changes

Closes #10459

When Prometheus metrics are enabled on NGINX Plus (-prometheus-metrics), nginx-prometheus-exporter scrapes /api/10/http/server_zones and attempts to extract 3 custom resource labels (resource_type, resource_name, resource_namespace).

For the default fallback server (default-server.conf), status_zone was set to "_", but no resource labels were defined. This caused nginx-prometheus-exporter to log a warning on every scrape interval: "wrong number of labels for http zone ... zone=_ expected=3 got=0"

This commit updates internal/configs/version1/nginx-plus.ingress.tmpl to omit status_zone _ when rendering default server blocks that are not backed by an actual Ingress resource.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
