### PR TITLE
fix: prevent F5 WAF interfering with subrequests

### DIFF
--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -769,6 +769,7 @@ func generateNginxCfg(ncp NginxCfgParams) (version1.IngressNginxConfig, Warnings
 		StaticSSLPath:           ncp.staticParams.StaticSSLPath,
 		LimitReqZones:           limitReqZones,
 		Maps:                    removeDuplicateMaps(maps),
+		AppProtectLoadModule:    ncp.staticParams.MainAppProtectLoadModule,
 	}, allWarnings
 }
 
@@ -1415,6 +1416,7 @@ func generateNginxCfgForMergeableIngresses(ncp NginxCfgParams) (version1.Ingress
 		StaticSSLPath:           ncp.staticParams.StaticSSLPath,
 		LimitReqZones:           limitReqZones,
 		Maps:                    removeDuplicateMaps(maps),
+		AppProtectLoadModule:    ncp.staticParams.MainAppProtectLoadModule,
 	}, warnings
 }
 

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -4524,6 +4524,7 @@ func TestGenerateNginxCfgForAppProtect(t *testing.T) {
 	expected.Servers[0].AppProtectLogConfs = []string{"/etc/nginx/waf/nac-logconfs/default_logconf syslog:server=127.0.0.1:514"}
 	expected.Servers[0].AppProtectLogEnable = "on"
 	expected.Ingress.Annotations = cafeIngressEx.Ingress.Annotations
+	expected.AppProtectLoadModule = true
 
 	result, warnings := generateNginxCfg(NginxCfgParams{
 		staticParams:         staticCfgParams,
@@ -4587,6 +4588,7 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtect(t *testing.T) {
 	expected.Servers[0].AppProtectLogConfs = []string{"/etc/nginx/waf/nac-logconfs/default_logconf syslog:server=127.0.0.1:514"}
 	expected.Servers[0].AppProtectLogEnable = "on"
 	expected.Ingress.Annotations = mergeableIngresses.Master.Ingress.Annotations
+	expected.AppProtectLoadModule = true
 
 	result, warnings := generateNginxCfgForMergeableIngresses(NginxCfgParams{
 		mergeableIngs:        mergeableIngresses,

--- a/internal/configs/version1/__snapshots__/template_test.snap
+++ b/internal/configs/version1/__snapshots__/template_test.snap
@@ -3409,6 +3409,74 @@ server {
 
 ---
 
+[TestExecuteTemplate_ForIngressForNGINXPlus_DisablesWAFOnInternalLocations/module_loaded_disables_WAF_on_internal_locations - 1]
+# configuration for default/ing
+upstream test-upstream {
+    zone test-upstream 256k;
+    server 10.0.0.20:8001 max_fails=0 fail_timeout= max_conns=0;
+}
+
+
+server {
+
+    server_tokens "off";
+
+    server_name example.com;
+
+    status_zone example.com;
+    set $resource_type "ingress";
+    set $resource_name "ing";
+    set $resource_namespace "default";
+    set $service "-";
+
+    
+
+    
+    location / {
+        set $service "svc";
+        status_zone "svc";
+        proxy_http_version 1.1;
+
+        proxy_connect_timeout ;
+        proxy_read_timeout ;
+        proxy_send_timeout ;
+        client_max_body_size ;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_pass ;
+        
+    }
+    
+    location /_external_auth/authsvc {
+        set $service "authsvc";
+        internal;
+        app_protect_enable off;
+        proxy_http_version 1.1;
+
+        proxy_connect_timeout ;
+        proxy_read_timeout ;
+        proxy_send_timeout ;
+        client_max_body_size ;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_pass http://ext-auth-authsvc/verify;
+        
+    }
+    
+}
+
+---
+
 [TestExecuteTemplate_ForIngressForNGINXRewriteTarget/case_insensitive_regex_rewrite - 1]
 # configuration for default/cafe-ingress
 

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -24,6 +24,10 @@ type IngressNginxConfig struct {
 	DynamicSSLReloadEnabled bool
 	StaticSSLPath           string
 	LimitReqZones           []LimitReqZone
+	// AppProtectLoadModule mirrors the controller's --enable-app-protect flag so
+	// templates can safely emit app_protect_enable off; in internal sub-request
+	// locations only when the WAF module is actually loaded.
+	AppProtectLoadModule bool
 }
 
 // Ingress holds information about an Ingress resource.

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -24,7 +24,7 @@ type IngressNginxConfig struct {
 	DynamicSSLReloadEnabled bool
 	StaticSSLPath           string
 	LimitReqZones           []LimitReqZone
-	// AppProtectLoadModule mirrors the controller's --enable-app-protect flag so
+	// AppProtectLoadModule mirrors the controller's -enable-app-protect flag so
 	// templates can safely emit app_protect_enable off; in internal sub-request
 	// locations only when the WAF module is actually loaded.
 	AppProtectLoadModule bool

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -315,6 +315,9 @@ server {
 		{{- end}}
 		{{- if $location.Internal}}
 		internal;
+		{{- if $.AppProtectLoadModule}}
+		app_protect_enable off;
+		{{- end}}
 		{{- end}}
 		{{- with $location.MinionIngress}}
 		# location for minion {{$location.MinionIngress.Namespace}}/{{$location.MinionIngress.Name}}

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -151,6 +151,71 @@ func TestExecuteTemplate_ForIngressForNGINXPlus(t *testing.T) {
 	snaps.MatchSnapshot(t, buf.String())
 }
 
+func TestExecuteTemplate_ForIngressForNGINXPlus_DisablesWAFOnInternalLocations(t *testing.T) {
+	t.Parallel()
+
+	baseCfg := IngressNginxConfig{
+		Upstreams: []Upstream{
+			{Name: "test-upstream", UpstreamServers: []UpstreamServer{{Address: "10.0.0.20:8001"}}, UpstreamZoneSize: "256k"},
+		},
+		Servers: []Server{
+			{
+				Name:         "example.com",
+				StatusZone:   "example.com",
+				ServerTokens: "off",
+				Locations: []Location{
+					{Path: "/", Upstream: Upstream{Name: "test-upstream"}, ServiceName: "svc"},
+					{
+						Path:        "/_external_auth/authsvc",
+						Internal:    true,
+						ProxyPass:   "http://ext-auth-authsvc/verify",
+						ServiceName: "authsvc",
+					},
+				},
+			},
+		},
+		Ingress: Ingress{Name: "ing", Namespace: "default"},
+	}
+
+	t.Run("module not loaded emits no override", func(t *testing.T) {
+		t.Parallel()
+		tmpl := newNGINXPlusIngressTmpl(t)
+		buf := &bytes.Buffer{}
+		cfg := baseCfg
+		if err := tmpl.Execute(buf, cfg); err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Contains(buf.Bytes(), []byte("app_protect_enable off;")) {
+			t.Errorf("expected no app_protect_enable off; when AppProtectLoadModule is false, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("module loaded disables WAF on internal locations", func(t *testing.T) {
+		t.Parallel()
+		tmpl := newNGINXPlusIngressTmpl(t)
+		buf := &bytes.Buffer{}
+		cfg := baseCfg
+		cfg.AppProtectLoadModule = true
+		if err := tmpl.Execute(buf, cfg); err != nil {
+			t.Fatal(err)
+		}
+		out := buf.Bytes()
+		marker := []byte("location /_external_auth/authsvc")
+		idx := bytes.Index(out, marker)
+		if idx < 0 {
+			t.Fatalf("marker %q missing from rendered template", marker)
+		}
+		end := idx + 400
+		if end > len(out) {
+			end = len(out)
+		}
+		if !bytes.Contains(out[idx:end], []byte("app_protect_enable off;")) {
+			t.Errorf("missing app_protect_enable off; inside external auth location\nrendered slice:\n%s", out[idx:end])
+		}
+		snaps.MatchSnapshot(t, buf.String())
+	})
+}
+
 func TestExecuteTemplate_ForIngressForNGINX(t *testing.T) {
 	t.Parallel()
 

--- a/internal/configs/version2/__snapshots__/templates_test.snap
+++ b/internal/configs/version2/__snapshots__/templates_test.snap
@@ -1,4 +1,127 @@
 
+[TestExecuteOIDCTemplate_DisablesWAFOnInternalLocationsWhenAppProtectLoaded/module_loaded_disables_WAF_on_every_internal_OIDC_location - 1]
+    # Advanced configuration START
+    set $internal_error_message "NGINX / OpenID Connect login failure\n";
+    set $pkce_id "";
+    set $idp_sid "";
+    # resolver 8.8.8.8; # For DNS lookup of IdP endpoints;
+    subrequest_output_buffer_size 32k; # To fit a complete tokenset response
+    gunzip on; # Decompress IdP responses if necessary
+    # Advanced configuration END
+
+    location = /_jwks_uri {
+        internal;
+        app_protect_enable off;
+        client_max_body_size 0;                       # Subrequest inherits parent Content-Length
+        proxy_cache jwk;                              # Cache the JWK Set received from IdP
+        proxy_cache_valid 200 12h;                    # How long to consider keys "fresh"
+        proxy_cache_use_stale error timeout updating; # Use old JWK Set if cannot reach IdP
+        proxy_ssl_server_name on;                     # Send SNI to IdP host
+
+        proxy_method GET;                             # In case client request was non-GET
+        proxy_set_header Content-Length "";           # ''
+        proxy_pass $oidc_jwt_keyfile;                 # Expecting to find a URI here
+        proxy_ignore_headers Cache-Control Expires Set-Cookie; # Does not influence caching
+    }
+
+    location @do_oidc_flow {
+        status_zone "OIDC start";
+        js_content oidc.auth;
+        default_type text/plain; # In case we throw an error
+    }
+
+    set $redir_location "/_codexch";
+    location = /_codexch {
+        # This location is called by the IdP after successful authentication
+        status_zone "OIDC code exchange";
+        js_content oidc.codeExchange;
+        error_page 500 502 504 @oidc_error;
+    }
+
+    location = /_token {
+        # This location is called by oidcCodeExchange(). We use the proxy_ directives
+        # to construct the OpenID Connect token request, as per:
+        #  http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
+        internal;
+        app_protect_enable off;
+        client_max_body_size 0;                       # Subrequest inherits parent Content-Length
+
+        # Exclude client headers to avoid CORS errors with certain IdPs (e.g., Microsoft Entra ID)
+        proxy_pass_request_headers off;
+        proxy_ssl_server_name on;    # Send SNI to IdP host
+
+        proxy_set_header      Content-Type "application/x-www-form-urlencoded";
+        proxy_set_header      Authorization $arg_secret_basic;
+        proxy_pass            $oidc_token_endpoint;
+    }
+
+    location = /_refresh {
+        # This location is called by oidcAuth() when performing a token refresh. We
+        # use the proxy_ directives to construct the OpenID Connect token request, as per:
+        #  https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken
+        internal;
+        app_protect_enable off;
+        client_max_body_size 0;                       # Subrequest inherits parent Content-Length
+
+        # Exclude client headers to avoid CORS errors with certain IdPs (e.g., Microsoft Entra ID)
+        proxy_pass_request_headers off;
+        proxy_ssl_server_name on;                    # Send SNI to IdP host
+
+        proxy_set_header      Content-Type "application/x-www-form-urlencoded";
+        proxy_set_header      Authorization $arg_secret_basic;
+        proxy_pass            $oidc_token_endpoint;
+    }
+
+    location = /_token_validation {
+        # Internal location to verify any JWT (e.g., id_token, logout_token)
+        # using the auth_jwt module. Extracts the claims and returns them as JSON.
+        internal;
+        app_protect_enable off;
+        client_max_body_size 0;                       # Subrequest inherits parent Content-Length
+        auth_jwt "" token=$arg_token;
+        js_content oidc.extractTokenClaims;
+        error_page 500 502 504 @oidc_error;
+    }
+
+    location = /logout {
+        status_zone "OIDC logout";
+        add_header Set-Cookie "auth_token=; $oidc_cookie_flags";
+        add_header Set-Cookie "auth_nonce=; $oidc_cookie_flags";
+        add_header Set-Cookie "auth_redir=; $oidc_cookie_flags";
+        js_content oidc.logout;
+    }
+
+    location = /front_channel_logout {
+        status_zone "OIDC logout";
+        add_header Cache-Control "no-store";
+        default_type text/plain;
+        js_content oidc.handleFrontChannelLogout;
+    }
+
+    location = /_logout {
+        # This location is the default value of $oidc_logout_redirect (in case it wasn't configured)
+        default_type text/plain;
+        return 200 "Logged out\n";
+    }
+
+    location @oidc_error {
+        # This location is called when oidcAuth() or oidcCodeExchange() returns an error
+        status_zone "OIDC error";
+        default_type text/plain;
+        return 500 $internal_error_message;
+    }
+
+    # location /api/ {
+    #     api write=on;
+    #     allow 127.0.0.1; # Only the NGINX host may call the NGINX Plus API
+    #     deny all;
+    #     access_log off;
+    # }
+
+# vim: syntax=nginx
+
+---
+
 [TestExecuteTemplateForNGINXOSSTransportServerWithSNI - 1]
 
 upstream cafe-upstream {
@@ -1688,6 +1811,113 @@ server {
 
         
         set $default_connection_header close;
+    }
+}
+
+---
+
+[TestExecuteVirtualServerTemplate_DisablesWAFOnInternalLocationsWhenAppProtectLoaded/module_loaded_disables_WAF_on_every_internal_location - 1]
+
+upstream upstream1 {
+    zone upstream1 ;
+    server 10.0.0.20:8001 max_fails=0 fail_timeout= max_conns=0;
+}
+
+
+server {
+    listen 80;
+    listen [::]:80;
+
+
+    server_name example.com;
+    status_zone example.com;
+    set $resource_type "virtualserver";
+    set $resource_name "";
+    set $resource_namespace "";
+    set $service "-";
+
+    server_tokens "";
+    location = /_jwks_uri_server_tenant1 {
+        internal;
+        app_protect_enable off;
+        proxy_method GET;
+        proxy_set_header Content-Length "";
+        proxy_ssl_verify off;
+        proxy_pass_request_headers off;
+        proxy_pass_request_body off;
+        proxy_set_header Host idp.example.com;
+        set $idp_backend idp.example.com;
+        proxy_pass ://$idp_backend/keys;
+    }
+    location = /_validate_apikey_njs {
+            internal;
+            app_protect_enable off;
+            js_content apikey_auth.validate;
+    }
+    js_var $header_query_value "${http_x_api_key}";
+    js_var $apikey_auth_local_map "apikey_map";
+    js_var $apikey_auth_token $apikey_auth_hash;
+    auth_request /_validate_apikey_njs;
+    js_var $apikey_client_name $apikey_map;
+
+    
+
+    
+    location / {
+        set $service "svc";
+        status_zone "svc";
+
+        
+        set $header_query_value "${http_x_api_key}";
+        set $default_connection_header close;
+        proxy_connect_timeout ;
+        proxy_read_timeout ;
+        proxy_send_timeout ;
+        client_max_body_size ;
+
+        proxy_buffering off;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $vs_connection_header;
+        proxy_pass_request_headers off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://upstream1;
+        proxy_next_upstream ;
+        proxy_next_upstream_timeout ;
+        proxy_next_upstream_tries 0;
+    }
+    location /_external_auth/authsvc {
+        set $service "authsvc";
+        status_zone "authsvc";
+        internal;
+        app_protect_enable off;
+
+        
+        set $header_query_value "${http_x_api_key}";
+        set $default_connection_header close;
+        proxy_connect_timeout ;
+        proxy_read_timeout ;
+        proxy_send_timeout ;
+        client_max_body_size ;
+
+        proxy_buffering off;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $vs_connection_header;
+        proxy_pass_request_headers off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://vs_default_ext_auth_authsvc/verify;
+        proxy_next_upstream ;
+        proxy_next_upstream_timeout ;
+        proxy_next_upstream_tries 0;
     }
 }
 

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -29,6 +29,10 @@ type VirtualServerConfig struct {
 	Upstreams               []Upstream
 	DynamicSSLReloadEnabled bool
 	StaticSSLPath           string
+	// AppProtectLoadModule mirrors the controller's --enable-app-protect flag so
+	// templates can safely emit app_protect_enable off; in internal sub-request
+	// locations only when the WAF module is actually loaded.
+	AppProtectLoadModule bool
 }
 
 // AuthJWTClaimSet defines the values for the `auth_jwt_claim_set` directive
@@ -163,6 +167,10 @@ type OIDC struct {
 	VerifyDepth           int
 	CAFile                string
 	PolicyName            string
+	// AppProtectLoadModule mirrors the controller's --enable-app-protect flag so
+	// oidc.tmpl can emit app_protect_enable off; on its internal sub-request
+	// locations only when the WAF module is actually loaded.
+	AppProtectLoadModule bool
 }
 
 // APIKey holds API key configuration.

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -29,7 +29,7 @@ type VirtualServerConfig struct {
 	Upstreams               []Upstream
 	DynamicSSLReloadEnabled bool
 	StaticSSLPath           string
-	// AppProtectLoadModule mirrors the controller's --enable-app-protect flag so
+	// AppProtectLoadModule mirrors the controller's -enable-app-protect flag so
 	// templates can safely emit app_protect_enable off; in internal sub-request
 	// locations only when the WAF module is actually loaded.
 	AppProtectLoadModule bool

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -303,6 +303,9 @@ server {
     {{- range $index, $element := $s.JWTAuthList }}
     location = /_jwks_uri_server_{{ .Key }} {
         internal;
+        {{- if $.AppProtectLoadModule }}
+        app_protect_enable off;
+        {{- end }}
         proxy_method GET;
         proxy_set_header Content-Length "";
         {{- with .JwksURI }}
@@ -335,6 +338,9 @@ server {
     {{- if $s.APIKeyEnabled}}
     location = /_validate_apikey_njs {
             internal;
+            {{- if $.AppProtectLoadModule }}
+            app_protect_enable off;
+            {{- end }}
             js_content apikey_auth.validate;
     }
     {{- end }}
@@ -517,6 +523,9 @@ server {
         {{- end }}
         {{- if $l.Internal }}
         internal;
+        {{- if $.AppProtectLoadModule }}
+        app_protect_enable off;
+        {{- end }}
         {{- end }}
         {{- if $l.AddHeaderInherit }}
         add_header_inherit {{ $l.AddHeaderInherit }};

--- a/internal/configs/version2/oidc.tmpl
+++ b/internal/configs/version2/oidc.tmpl
@@ -9,6 +9,9 @@
 
     location = /_jwks_uri {
         internal;
+        {{- if .AppProtectLoadModule }}
+        app_protect_enable off;
+        {{- end }}
         client_max_body_size 0;                       # Subrequest inherits parent Content-Length
         proxy_cache jwk;                              # Cache the JWK Set received from IdP
         proxy_cache_valid 200 12h;                    # How long to consider keys "fresh"
@@ -46,6 +49,9 @@
         # to construct the OpenID Connect token request, as per:
         #  http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
         internal;
+        {{- if .AppProtectLoadModule }}
+        app_protect_enable off;
+        {{- end }}
         client_max_body_size 0;                       # Subrequest inherits parent Content-Length
 
         # Exclude client headers to avoid CORS errors with certain IdPs (e.g., Microsoft Entra ID)
@@ -68,6 +74,9 @@
         # use the proxy_ directives to construct the OpenID Connect token request, as per:
         #  https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken
         internal;
+        {{- if .AppProtectLoadModule }}
+        app_protect_enable off;
+        {{- end }}
         client_max_body_size 0;                       # Subrequest inherits parent Content-Length
 
         # Exclude client headers to avoid CORS errors with certain IdPs (e.g., Microsoft Entra ID)
@@ -89,6 +98,9 @@
         # Internal location to verify any JWT (e.g., id_token, logout_token)
         # using the auth_jwt module. Extracts the claims and returns them as JSON.
         internal;
+        {{- if .AppProtectLoadModule }}
+        app_protect_enable off;
+        {{- end }}
         client_max_body_size 0;                       # Subrequest inherits parent Content-Length
         auth_jwt "" token=$arg_token;
         js_content oidc.extractTokenClaims;

--- a/internal/configs/version2/templates_test.go
+++ b/internal/configs/version2/templates_test.go
@@ -1337,6 +1337,142 @@ func TestExecuteVirtualServerTemplateWithCachePolicyOSS(t *testing.T) {
 	t.Log(string(got))
 }
 
+func TestExecuteVirtualServerTemplate_DisablesWAFOnInternalLocationsWhenAppProtectLoaded(t *testing.T) {
+	t.Parallel()
+
+	baseCfg := VirtualServerConfig{
+		Upstreams: []Upstream{
+			{Name: "upstream1", Servers: []UpstreamServer{{Address: "10.0.0.20:8001"}}},
+		},
+		Server: Server{
+			ServerName: "example.com",
+			StatusZone: "example.com",
+			Locations: []Location{
+				{Path: "/", ProxyPass: "http://upstream1", ServiceName: "svc"},
+				{
+					Path:        "/_external_auth/authsvc",
+					Internal:    true,
+					ProxyPass:   "http://vs_default_ext_auth_authsvc/verify",
+					ServiceName: "authsvc",
+				},
+			},
+			JWTAuthList: map[string]*JWTAuth{
+				"tenant1": {Key: "tenant1", JwksURI: JwksURI{JwksHost: "idp.example.com", JwksPath: "/keys"}},
+			},
+			APIKeyEnabled: true,
+			APIKey:        &APIKey{MapName: "apikey_map", Header: []string{"X-API-Key"}},
+		},
+	}
+
+	t.Run("module not loaded emits no override", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseCfg
+		executor := newTmplExecutorNGINXPlus(t)
+		got, err := executor.ExecuteVirtualServerTemplate(&cfg)
+		if err != nil {
+			t.Fatalf("Failed to execute template: %v", err)
+		}
+		if bytes.Contains(got, []byte("app_protect_enable off;")) {
+			t.Errorf("expected no app_protect_enable off; when AppProtectLoadModule is false, got:\n%s", got)
+		}
+	})
+
+	t.Run("module loaded disables WAF on every internal location", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseCfg
+		cfg.AppProtectLoadModule = true
+		executor := newTmplExecutorNGINXPlus(t)
+		got, err := executor.ExecuteVirtualServerTemplate(&cfg)
+		if err != nil {
+			t.Fatalf("Failed to execute template: %v", err)
+		}
+
+		wantContext := []string{
+			"location /_external_auth/authsvc",
+			"location = /_jwks_uri_server_tenant1",
+			"location = /_validate_apikey_njs",
+		}
+		for _, marker := range wantContext {
+			idx := bytes.Index(got, []byte(marker))
+			if idx < 0 {
+				t.Fatalf("marker %q missing from rendered template", marker)
+			}
+			// Look for app_protect_enable off; within the next 400 bytes (single location body).
+			end := idx + 400
+			if end > len(got) {
+				end = len(got)
+			}
+			if !bytes.Contains(got[idx:end], []byte("app_protect_enable off;")) {
+				t.Errorf("missing app_protect_enable off; inside %q\nrendered slice:\n%s", marker, got[idx:end])
+			}
+		}
+		snaps.MatchSnapshot(t, string(got))
+	})
+}
+
+func TestExecuteOIDCTemplate_DisablesWAFOnInternalLocationsWhenAppProtectLoaded(t *testing.T) {
+	t.Parallel()
+
+	base := OIDC{
+		AuthEndpoint:       "https://idp.example.com/auth",
+		TokenEndpoint:      "https://idp.example.com/token",
+		JwksURI:            "https://idp.example.com/keys",
+		EndSessionEndpoint: "https://idp.example.com/logout",
+		ClientID:           "nic-oidc",
+		ClientSecret:       "secret",
+		Scope:              "openid",
+		RedirectURI:        "/_codexch",
+		ZoneSyncLeeway:     200,
+		PolicyName:         "default/oidc-policy",
+	}
+
+	internalLocations := []string{
+		"location = /_jwks_uri",
+		"location = /_token",
+		"location = /_refresh",
+		"location = /_token_validation",
+	}
+
+	t.Run("module not loaded emits no override", func(t *testing.T) {
+		t.Parallel()
+		cfg := base
+		executor := newTmplExecutorNGINXPlus(t)
+		got, err := executor.ExecuteOIDCTemplate(&cfg)
+		if err != nil {
+			t.Fatalf("Failed to execute OIDC template: %v", err)
+		}
+		if bytes.Contains(got, []byte("app_protect_enable off;")) {
+			t.Errorf("expected no app_protect_enable off; when AppProtectLoadModule is false, got:\n%s", got)
+		}
+	})
+
+	t.Run("module loaded disables WAF on every internal OIDC location", func(t *testing.T) {
+		t.Parallel()
+		cfg := base
+		cfg.AppProtectLoadModule = true
+		executor := newTmplExecutorNGINXPlus(t)
+		got, err := executor.ExecuteOIDCTemplate(&cfg)
+		if err != nil {
+			t.Fatalf("Failed to execute OIDC template: %v", err)
+		}
+
+		for _, marker := range internalLocations {
+			idx := bytes.Index(got, []byte(marker))
+			if idx < 0 {
+				t.Fatalf("marker %q missing from rendered oidc template", marker)
+			}
+			end := idx + 400
+			if end > len(got) {
+				end = len(got)
+			}
+			if !bytes.Contains(got[idx:end], []byte("app_protect_enable off;")) {
+				t.Errorf("missing app_protect_enable off; inside %q\nrendered slice:\n%s", marker, got[idx:end])
+			}
+		}
+		snaps.MatchSnapshot(t, string(got))
+	})
+}
+
 func vsConfig() VirtualServerConfig {
 	return VirtualServerConfig{
 		LimitReqZones: []LimitReqZone{

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -306,6 +306,7 @@ type virtualServerConfigurator struct {
 	DynamicWeightChangesReload bool
 	bundleValidator            bundleValidator
 	IngressControllerReplicas  int
+	appProtectLoadModule       bool
 }
 
 func (vsc *virtualServerConfigurator) addWarningf(obj runtime.Object, msgFmt string, args ...interface{}) {
@@ -348,6 +349,7 @@ func newVirtualServerConfigurator(
 		CABundlePath:               staticParams.DefaultCABundle,
 		DynamicWeightChangesReload: staticParams.DynamicWeightChangesReload,
 		bundleValidator:            bundleValidator,
+		appProtectLoadModule:       staticParams.MainAppProtectLoadModule,
 	}
 }
 
@@ -1113,6 +1115,10 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 
 	addHSTSToLocationsWithAddHeaders(policiesCfg.HSTS, locations)
 
+	if policiesCfg.OIDC != nil {
+		policiesCfg.OIDC.AppProtectLoadModule = vsc.appProtectLoadModule
+	}
+
 	vsCfg := version2.VirtualServerConfig{
 		Upstreams:        upstreams,
 		Maps:             removeDuplicateMaps(maps),
@@ -1178,6 +1184,7 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 		KeyVals:                 keyVals,
 		SplitClients:            splitClients,
 		TwoWaySplitClients:      twoWaySplitClients,
+		AppProtectLoadModule:    vsc.appProtectLoadModule,
 	}
 
 	return vsCfg, vsc.warnings


### PR DESCRIPTION
This pull request adds support for conditionally disabling the App Protect WAF module (`app_protect_enable off;`) in NGINX internal sub-request locations, but only when the App Protect module is actually loaded. This is achieved by passing a new `AppProtectLoadModule` flag through the configuration structs and templates, ensuring correct and safe template rendering. The changes are covered by new and updated tests and snapshot files.

> Subrequest-based modules (modules that generate internal HTTP subrequests) are not supported when F5 WAF for NGINX (app_protect_enable) is applied to the same scope.

https://docs.nginx.com/waf/configure/nginx-features/

Note: `AppProtectLoadModule` was used on `VirtualServerConfig` &  `IngressNginxConfig` structs, therefore it does not match `MainAppProtectLoadModule` used in the main config generation.