### PR TITLE
PLM updates, helm-chart and examples

### DIFF
--- a/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/nginx-ingress/templates/_helpers.tpl
@@ -250,7 +250,7 @@ Create the global configuration custom namespace from the globalConfiguration.cu
 Build the args for the service binary.
 */}}
 {{- define "nginx-ingress.appprotect.plmStorage.validate" -}}
-{{- $plm := .Values.controller.appprotect.plmStorage -}}
+{{- $plm := default (dict) .Values.controller.appprotect.plmStorage -}}
 {{- if $plm.url }}
 {{- if not .Values.controller.nginxplus }}
 {{- fail "controller.appprotect.plmStorage.url requires controller.nginxplus=true" }}
@@ -295,16 +295,17 @@ Build the args for the service binary.
 {{- if and .Values.controller.appprotect.enable .Values.controller.appprotect.v5 }}
 - -app-protect-enforcer-address="{{ .Values.controller.appprotect.enforcer.host | default "127.0.0.1" }}:{{ .Values.controller.appprotect.enforcer.port | default 50000 }}"
 {{- end }}
-{{- if .Values.controller.appprotect.plmStorage.url }}
-- {{ printf "-plm-storage-url=%s" .Values.controller.appprotect.plmStorage.url | quote }}
-- {{ printf "-plm-storage-credentials-secret=%s" .Values.controller.appprotect.plmStorage.credentialsSecret | quote }}
-{{- if .Values.controller.appprotect.plmStorage.caSecret }}
-- {{ printf "-plm-storage-ca-secret=%s" .Values.controller.appprotect.plmStorage.caSecret | quote }}
+{{- $plm := default (dict) .Values.controller.appprotect.plmStorage -}}
+{{- if $plm.url }}
+- {{ printf "-plm-storage-url=%s" $plm.url | quote }}
+- {{ printf "-plm-storage-credentials-secret=%s" $plm.credentialsSecret | quote }}
+{{- if $plm.caSecret }}
+- {{ printf "-plm-storage-ca-secret=%s" $plm.caSecret | quote }}
 {{- end }}
-{{- if .Values.controller.appprotect.plmStorage.clientSSLSecret }}
-- {{ printf "-plm-storage-client-ssl-secret=%s" .Values.controller.appprotect.plmStorage.clientSSLSecret | quote }}
+{{- if $plm.clientSSLSecret }}
+- {{ printf "-plm-storage-client-ssl-secret=%s" $plm.clientSSLSecret | quote }}
 {{- end }}
-- -plm-storage-insecure-skip-verify={{ .Values.controller.appprotect.plmStorage.insecureSkipVerify }}
+- -plm-storage-insecure-skip-verify={{ $plm.insecureSkipVerify }}
 {{- end }}
 - -enable-app-protect-dos={{ .Values.controller.appprotectdos.enable }}
 {{- if .Values.controller.appprotectdos.enable }}

--- a/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/nginx-ingress/templates/_helpers.tpl
@@ -249,7 +249,28 @@ Create the global configuration custom namespace from the globalConfiguration.cu
 {{/*
 Build the args for the service binary.
 */}}
+{{- define "nginx-ingress.appprotect.plmStorage.validate" -}}
+{{- $plm := .Values.controller.appprotect.plmStorage -}}
+{{- if $plm.url }}
+{{- if not .Values.controller.nginxplus }}
+{{- fail "controller.appprotect.plmStorage.url requires controller.nginxplus=true" }}
+{{- end }}
+{{- if not .Values.controller.appprotect.enable }}
+{{- fail "controller.appprotect.plmStorage.url requires controller.appprotect.enable=true" }}
+{{- end }}
+{{- if not .Values.controller.appprotect.v5 }}
+{{- fail "controller.appprotect.plmStorage.url requires controller.appprotect.v5=true" }}
+{{- end }}
+{{- if not $plm.credentialsSecret }}
+{{- fail "controller.appprotect.plmStorage.credentialsSecret must be set when controller.appprotect.plmStorage.url is set" }}
+{{- end }}
+{{- else if or $plm.credentialsSecret $plm.caSecret $plm.clientSSLSecret $plm.insecureSkipVerify }}
+{{- fail "controller.appprotect.plmStorage auxiliary values require controller.appprotect.plmStorage.url" }}
+{{- end }}
+{{- end }}
+
 {{- define "nginx-ingress.args" -}}
+{{- include "nginx-ingress.appprotect.plmStorage.validate" . -}}
 {{- if and .Values.controller.debug .Values.controller.debug.enable }}
 - --listen=:2345
 - --headless=true
@@ -273,6 +294,17 @@ Build the args for the service binary.
 {{ end }}
 {{- if and .Values.controller.appprotect.enable .Values.controller.appprotect.v5 }}
 - -app-protect-enforcer-address="{{ .Values.controller.appprotect.enforcer.host | default "127.0.0.1" }}:{{ .Values.controller.appprotect.enforcer.port | default 50000 }}"
+{{- end }}
+{{- if .Values.controller.appprotect.plmStorage.url }}
+- {{ printf "-plm-storage-url=%s" .Values.controller.appprotect.plmStorage.url | quote }}
+- {{ printf "-plm-storage-credentials-secret=%s" .Values.controller.appprotect.plmStorage.credentialsSecret | quote }}
+{{- if .Values.controller.appprotect.plmStorage.caSecret }}
+- {{ printf "-plm-storage-ca-secret=%s" .Values.controller.appprotect.plmStorage.caSecret | quote }}
+{{- end }}
+{{- if .Values.controller.appprotect.plmStorage.clientSSLSecret }}
+- {{ printf "-plm-storage-client-ssl-secret=%s" .Values.controller.appprotect.plmStorage.clientSSLSecret | quote }}
+{{- end }}
+- -plm-storage-insecure-skip-verify={{ .Values.controller.appprotect.plmStorage.insecureSkipVerify }}
 {{- end }}
 - -enable-app-protect-dos={{ .Values.controller.appprotectdos.enable }}
 {{- if .Values.controller.appprotectdos.enable }}

--- a/charts/nginx-ingress/values.schema.json
+++ b/charts/nginx-ingress/values.schema.json
@@ -291,6 +291,38 @@
                 "trace"
               ]
             },
+            "plmStorage": {
+              "type": "object",
+              "default": {},
+              "title": "Configuration for fetching bundles compiled by F5 WAF Policy Controller",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "default": "",
+                  "title": "SeaweedFS S3 endpoint; an empty value disables PLM support"
+                },
+                "credentialsSecret": {
+                  "type": "string",
+                  "default": "",
+                  "title": "namespace/name Secret containing the SeaweedFS admin secret"
+                },
+                "caSecret": {
+                  "type": "string",
+                  "default": "",
+                  "title": "Optional namespace/name Secret containing ca.crt for SeaweedFS TLS verification"
+                },
+                "clientSSLSecret": {
+                  "type": "string",
+                  "default": "",
+                  "title": "Optional namespace/name Secret containing tls.crt and tls.key for SeaweedFS mTLS"
+                },
+                "insecureSkipVerify": {
+                  "type": "boolean",
+                  "default": false,
+                  "title": "Disable SeaweedFS TLS verification; for development and testing only"
+                }
+              }
+            },
             "volumes": {
               "type": "array",
               "default": [

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -131,6 +131,21 @@ controller:
       #    cpu: 500m
       #    memory: 512Mi
 
+    ## Configuration for fetching bundles compiled by F5 WAF Policy Controller (PLM).
+    ## Requires nginxplus=true, appprotect.enable=true, and appprotect.v5=true.
+    ## Secret references must use the namespace/name format.
+    plmStorage:
+      ## SeaweedFS S3 endpoint. Leave empty to disable PLM support.
+      url: ""
+      ## Secret containing the SeaweedFS admin secret under seaweedfs_admin_secret, namespace/name format.
+      credentialsSecret: ""
+      ## Optional Secret containing ca.crt for SeaweedFS TLS verification, namespace/name format.
+      caSecret: ""
+      ## Optional Secret containing tls.crt and tls.key for SeaweedFS mTLS, namespace/name format.
+      clientSSLSecret: ""
+      ## Disable SeaweedFS TLS verification. For development and testing only.
+      insecureSkipVerify: false
+
     ## Configuration for App Protect WAF v5 IP Intelligence
     ipIntelligence:
       enable: false

--- a/charts/tests/__snapshots__/helmunit_test.snap
+++ b/charts/tests/__snapshots__/helmunit_test.snap
@@ -1815,7 +1815,7 @@ spec:
           - -enable-app-protect=true
           - -enable-app-protect-ip-intelligence=false
           - -app-protect-enforcer-address="127.0.0.1:50000"
-          - "-plm-storage-url=https://f5-waf-seaweed-filer.plm.svc.cluster.local:8333"
+          - "-plm-storage-url=http://f5-waf-seaweed-filer.plm.svc.cluster.local:8333"
           - "-plm-storage-credentials-secret=plm/seaweedfs-auth"
           - "-plm-storage-ca-secret=plm/seaweedfs-ca"
           - "-plm-storage-client-ssl-secret=plm/seaweedfs-client"

--- a/charts/tests/__snapshots__/helmunit_test.snap
+++ b/charts/tests/__snapshots__/helmunit_test.snap
@@ -1395,6 +1395,529 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 ---
 
+[TestHelmNICTemplate/appProtectWAFPLM - 1]
+/-/-/-/
+# Source: nginx-ingress/templates/controller-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appprotect-waf-plm-nginx-ingress
+  namespace: appprotect-waf-plm
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+/-/-/-/
+# Source: nginx-ingress/templates/controller-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: appprotect-waf-plm-nginx-ingress
+  namespace: appprotect-waf-plm
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  {}
+/-/-/-/
+# Source: nginx-ingress/templates/controller-configmap.yaml
+/-/-/-/
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: appprotect-waf-plm-nginx-ingress-mgmt
+  namespace: appprotect-waf-plm
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  license-token-secret-name: license-token
+/-/-/-/
+# Source: nginx-ingress/templates/controller-leader-election-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: appprotect-waf-plm-nginx-ingress-leader-election
+  namespace: appprotect-waf-plm
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+/-/-/-/
+# Source: nginx-ingress/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appprotect-waf-plm-nginx-ingress
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - "apps"
+  resources:
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - appprotect.f5.com
+  resources:
+  - appolicies
+  - aplogconfs
+  - apusersigs
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - k8s.nginx.org
+  resources:
+  - virtualservers
+  - virtualserverroutes
+  - globalconfigurations
+  - transportservers
+  - policies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - k8s.nginx.org
+  resources:
+  - virtualservers/status
+  - virtualserverroutes/status
+  - policies/status
+  - transportservers/status
+  verbs:
+  - update
+/-/-/-/
+# Source: nginx-ingress/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appprotect-waf-plm-nginx-ingress
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+- kind: ServiceAccount
+  name: appprotect-waf-plm-nginx-ingress
+  namespace: appprotect-waf-plm
+roleRef:
+  kind: ClusterRole
+  name: appprotect-waf-plm-nginx-ingress
+  apiGroup: rbac.authorization.k8s.io
+/-/-/-/
+# Source: nginx-ingress/templates/controller-role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appprotect-waf-plm-nginx-ingress
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+  namespace: appprotect-waf-plm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - ""
+  resources:
+    - namespaces
+  verbs:
+    - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - appprotect-waf-plm-nginx-ingress-leader-election
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+/-/-/-/
+# Source: nginx-ingress/templates/controller-rolebinding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appprotect-waf-plm-nginx-ingress
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+  namespace: appprotect-waf-plm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: appprotect-waf-plm-nginx-ingress
+subjects:
+- kind: ServiceAccount
+  name: appprotect-waf-plm-nginx-ingress
+  namespace: appprotect-waf-plm
+/-/-/-/
+# Source: nginx-ingress/templates/controller-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: appprotect-waf-plm-nginx-ingress-controller
+  namespace: appprotect-waf-plm
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+    nodePort: 
+  - port: 443
+    targetPort: 443
+    protocol: TCP
+    name: https
+    nodePort: 
+  selector:
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+/-/-/-/
+# Source: nginx-ingress/templates/controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: appprotect-waf-plm-nginx-ingress-controller
+  namespace: appprotect-waf-plm
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-ingress
+      app.kubernetes.io/instance: appprotect-waf-plm
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-ingress
+        app.kubernetes.io/instance: appprotect-waf-plm
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9113"
+        prometheus.io/scheme: "http"
+    spec:      
+      volumes:
+      
+      - emptyDir: {}
+        name: app-protect-bd-config
+      - emptyDir: {}
+        name: app-protect-config
+      - emptyDir: {}
+        name: app-protect-bundles
+      serviceAccountName: appprotect-waf-plm-nginx-ingress
+      automountServiceAccountToken: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      hostNetwork: false
+      dnsPolicy: ClusterFirst
+      containers:
+      - image: nginx/nginx-ingress:5.6.0
+        name: nginx-ingress
+        imagePullPolicy: "IfNotPresent"
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        - name: https
+          containerPort: 443
+          protocol: TCP
+        - name: prometheus
+          containerPort: 9113
+        - name: readiness-port
+          containerPort: 8081
+        readinessProbe:
+          httpGet:
+            path: /nginx-ready
+            port: readiness-port
+          periodSeconds: 1
+          initialDelaySeconds: 0
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          runAsUser: 101 #nginx
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE        
+        volumeMounts:
+        
+        - name: app-protect-bd-config
+          mountPath: /opt/app_protect/bd_config
+        - name: app-protect-config
+          mountPath: /opt/app_protect/config
+          # app-protect-bundles is mounted so that Ingress Controller
+          # can verify that referenced bundles are present
+        - name: app-protect-bundles
+          mountPath: /etc/app_protect/bundles
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        args:
+          
+          - -nginx-plus=true
+          - -nginx-reload-timeout=60000
+          - -enable-app-protect=true
+          - -enable-app-protect-ip-intelligence=false
+          - -app-protect-enforcer-address="127.0.0.1:50000"
+          - "-plm-storage-url=https://f5-waf-seaweed-filer.plm.svc.cluster.local:8333"
+          - "-plm-storage-credentials-secret=plm/seaweedfs-auth"
+          - "-plm-storage-ca-secret=plm/seaweedfs-ca"
+          - "-plm-storage-client-ssl-secret=plm/seaweedfs-client"
+          - -plm-storage-insecure-skip-verify=false
+          - -enable-app-protect-dos=false
+          - -nginx-configmaps=$(POD_NAMESPACE)/appprotect-waf-plm-nginx-ingress
+          - -mgmt-configmap=$(POD_NAMESPACE)/appprotect-waf-plm-nginx-ingress-mgmt
+          - -ingress-class=nginx
+          - -health-status=false
+          - -health-status-uri=/nginx-health
+          - -nginx-debug=false
+          - -log-level=info
+          - -log-format=glog
+          - -enable-config-safety=false
+          - -nginx-status=true
+          - -nginx-status-port=8080
+          - -nginx-status-allow-cidrs=127.0.0.1
+          - -report-ingress-status
+          - -external-service=appprotect-waf-plm-nginx-ingress-controller
+          - -enable-leader-election=true
+          - -leader-election-lock-name=appprotect-waf-plm-nginx-ingress-leader-election
+          - -enable-prometheus-metrics=true
+          - -prometheus-metrics-listen-port=9113
+          - -prometheus-tls-secret=
+          - -enable-service-insight=false
+          - -service-insight-listen-port=9114
+          - -service-insight-tls-secret=
+          - -enable-custom-resources=true
+          - -enable-snippets=false
+          - -disable-ipv6=false
+          - -enable-tls-passthrough=false
+          - -enable-cert-manager=false
+          - -enable-oidc=false
+          - -enable-external-dns=false
+          - -default-http-listener-port=80
+          - -default-https-listener-port=443
+          - -allow-empty-ingress-host=false
+          - -ready-status=true
+          - -ready-status-port=8081
+          - -enable-latency-metrics=false
+          - -ssl-dynamic-reload=true
+          - -enable-telemetry-reporting=true
+          - -weight-changes-dynamic-reload=false
+      
+      - name: waf-enforcer
+        image: private-registry.nginx.com/nap/waf-enforcer:5.14.0
+        imagePullPolicy: "IfNotPresent"
+        env:
+          - name: ENFORCER_PORT
+            value: "50000"
+          - name: ENFORCER_CONFIG_TIMEOUT
+            value: "0"
+        volumeMounts:
+          - name: app-protect-bd-config
+            mountPath: /opt/app_protect/bd_config
+      - name: waf-config-mgr
+        image: private-registry.nginx.com/nap/waf-config-mgr:5.14.0
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+      
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - all
+            runAsNonRoot: true
+            runAsUser: 101
+        volumeMounts:
+          - name: app-protect-bd-config
+            mountPath: /opt/app_protect/bd_config
+          - name: app-protect-config
+            mountPath: /opt/app_protect/config
+          - name: app-protect-bundles
+            mountPath: /etc/app_protect/bundles
+/-/-/-/
+# Source: nginx-ingress/templates/controller-ingress-class.yaml
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: nginx
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  controller: nginx.org/ingress-controller
+/-/-/-/
+# Source: nginx-ingress/templates/controller-lease.yaml
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: appprotect-waf-plm-nginx-ingress-leader-election
+  namespace: appprotect-waf-plm
+  labels:
+    helm.sh/chart: nginx-ingress-2.7.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: appprotect-waf-plm
+    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/managed-by: Helm
+---
+
 [TestHelmNICTemplate/appProtectWAFV4AgentV2 - 1]
 /-/-/-/
 # Source: nginx-ingress/templates/controller-serviceaccount.yaml
@@ -9312,454 +9835,6 @@ metadata:
     helm.sh/chart: nginx-ingress-2.7.0
     app.kubernetes.io/name: nginx-ingress
     app.kubernetes.io/instance: list-configs
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
----
-
-[TestHelmNICTemplate/loadBalancerClass - 1]
-/-/-/-/
-# Source: nginx-ingress/templates/controller-serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: loadbalancerclass-nginx-ingress
-  namespace: default
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
-/-/-/-/
-# Source: nginx-ingress/templates/controller-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: loadbalancerclass-nginx-ingress
-  namespace: default
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
-data:
-  {}
-/-/-/-/
-# Source: nginx-ingress/templates/controller-leader-election-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: loadbalancerclass-nginx-ingress-leader-election
-  namespace: default
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
-/-/-/-/
-# Source: nginx-ingress/templates/clusterrole.yaml
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: loadbalancerclass-nginx-ingress
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - namespaces
-  - pods
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - list
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - discovery.k8s.io
-  resources:
-  - endpointslices
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - list
-- apiGroups:
-  - "apps"
-  resources:
-  - replicasets
-  - daemonsets
-  - statefulsets
-  verbs:
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingressclasses
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - k8s.nginx.org
-  resources:
-  - virtualservers
-  - virtualserverroutes
-  - globalconfigurations
-  - transportservers
-  - policies
-  verbs:
-  - list
-  - watch
-  - get
-- apiGroups:
-  - k8s.nginx.org
-  resources:
-  - virtualservers/status
-  - virtualserverroutes/status
-  - policies/status
-  - transportservers/status
-  verbs:
-  - update
-/-/-/-/
-# Source: nginx-ingress/templates/clusterrolebinding.yaml
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: loadbalancerclass-nginx-ingress
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
-subjects:
-- kind: ServiceAccount
-  name: loadbalancerclass-nginx-ingress
-  namespace: default
-roleRef:
-  kind: ClusterRole
-  name: loadbalancerclass-nginx-ingress
-  apiGroup: rbac.authorization.k8s.io
-/-/-/-/
-# Source: nginx-ingress/templates/controller-role.yaml
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: loadbalancerclass-nginx-ingress
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
-  namespace: default
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - pods
-  - secrets
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-    - ""
-  resources:
-    - namespaces
-  verbs:
-    - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - list
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  resourceNames:
-  - loadbalancerclass-nginx-ingress-leader-election
-  verbs:
-  - get
-  - update
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-/-/-/-/
-# Source: nginx-ingress/templates/controller-rolebinding.yaml
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: loadbalancerclass-nginx-ingress
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: loadbalancerclass-nginx-ingress
-subjects:
-- kind: ServiceAccount
-  name: loadbalancerclass-nginx-ingress
-  namespace: default
-/-/-/-/
-# Source: nginx-ingress/templates/controller-service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: loadbalancerclass-nginx-ingress-controller
-  namespace: default
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  externalTrafficPolicy: Local
-  loadBalancerClass: antrea
-  type: LoadBalancer
-  ports:
-  - port: 80
-    targetPort: 80
-    protocol: TCP
-    name: http
-    nodePort: 
-  - port: 443
-    targetPort: 443
-    protocol: TCP
-    name: https
-    nodePort: 
-  selector:
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-/-/-/-/
-# Source: nginx-ingress/templates/controller-deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: loadbalancerclass-nginx-ingress-controller
-  namespace: default
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: nginx-ingress
-      app.kubernetes.io/instance: loadbalancerclass
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: nginx-ingress
-        app.kubernetes.io/instance: loadbalancerclass
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9113"
-        prometheus.io/scheme: "http"
-    spec:      
-      volumes: []
-      serviceAccountName: loadbalancerclass-nginx-ingress
-      automountServiceAccountToken: true
-      securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 30
-      hostNetwork: false
-      dnsPolicy: ClusterFirst
-      containers:
-      - image: nginx/nginx-ingress:5.6.0
-        name: nginx-ingress
-        imagePullPolicy: "IfNotPresent"
-        ports:
-        - name: http
-          containerPort: 80
-          protocol: TCP
-        - name: https
-          containerPort: 443
-          protocol: TCP
-        - name: prometheus
-          containerPort: 9113
-        - name: readiness-port
-          containerPort: 8081
-        readinessProbe:
-          httpGet:
-            path: /nginx-ready
-            port: readiness-port
-          periodSeconds: 1
-          initialDelaySeconds: 0
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
-          runAsUser: 101 #nginx
-          runAsNonRoot: true
-          capabilities:
-            drop:
-            - ALL
-            add:
-            - NET_BIND_SERVICE        
-        volumeMounts: []
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        args:
-          
-          - -nginx-plus=false
-          - -nginx-reload-timeout=60000
-          - -enable-app-protect=false
-          - -enable-app-protect-ip-intelligence=false
-          - -enable-app-protect-dos=false
-          - -nginx-configmaps=$(POD_NAMESPACE)/loadbalancerclass-nginx-ingress
-          - -ingress-class=nginx
-          - -health-status=false
-          - -health-status-uri=/nginx-health
-          - -nginx-debug=false
-          - -log-level=info
-          - -log-format=glog
-          - -enable-config-safety=false
-          - -nginx-status=true
-          - -nginx-status-port=8080
-          - -nginx-status-allow-cidrs=127.0.0.1
-          - -report-ingress-status
-          - -external-service=loadbalancerclass-nginx-ingress-controller
-          - -enable-leader-election=true
-          - -leader-election-lock-name=loadbalancerclass-nginx-ingress-leader-election
-          - -enable-prometheus-metrics=true
-          - -prometheus-metrics-listen-port=9113
-          - -prometheus-tls-secret=
-          - -enable-service-insight=false
-          - -service-insight-listen-port=9114
-          - -service-insight-tls-secret=
-          - -enable-custom-resources=true
-          - -enable-snippets=false
-          - -disable-ipv6=false
-          - -enable-tls-passthrough=false
-          - -enable-cert-manager=false
-          - -enable-oidc=false
-          - -enable-external-dns=false
-          - -default-http-listener-port=80
-          - -default-https-listener-port=443
-          - -allow-empty-ingress-host=false
-          - -ready-status=true
-          - -ready-status-port=8081
-          - -enable-latency-metrics=false
-          - -ssl-dynamic-reload=true
-          - -enable-telemetry-reporting=true
-          - -weight-changes-dynamic-reload=false
-/-/-/-/
-# Source: nginx-ingress/templates/controller-ingress-class.yaml
-apiVersion: networking.k8s.io/v1
-kind: IngressClass
-metadata:
-  name: nginx
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
-    app.kubernetes.io/version: "5.6.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  controller: nginx.org/ingress-controller
-/-/-/-/
-# Source: nginx-ingress/templates/controller-configmap.yaml
-/-/-/-/
-/-/-/-/
-# Source: nginx-ingress/templates/controller-lease.yaml
-apiVersion: coordination.k8s.io/v1
-kind: Lease
-metadata:
-  name: loadbalancerclass-nginx-ingress-leader-election
-  namespace: default
-  labels:
-    helm.sh/chart: nginx-ingress-2.7.0
-    app.kubernetes.io/name: nginx-ingress
-    app.kubernetes.io/instance: loadbalancerclass
     app.kubernetes.io/version: "5.6.0"
     app.kubernetes.io/managed-by: Helm
 ---

--- a/charts/tests/helmunit_test.go
+++ b/charts/tests/helmunit_test.go
@@ -277,6 +277,30 @@ func TestHelmNICTemplateNegative(t *testing.T) {
 			namespace:         "default",
 			expectedErrorMsgs: []string{"controller.appprotect.plmStorage.url requires controller.appprotect.v5=true"},
 		},
+		"appProtectWAFPLMWithoutPlus": {
+			valuesFile:        "testdata/app-protect-waf-plm-without-plus.yaml",
+			releaseName:       "appprotect-waf-plm-without-plus",
+			namespace:         "default",
+			expectedErrorMsgs: []string{"controller.appprotect.plmStorage.url requires controller.nginxplus=true"},
+		},
+		"appProtectWAFPLMWithoutAppProtect": {
+			valuesFile:        "testdata/app-protect-waf-plm-without-appprotect.yaml",
+			releaseName:       "appprotect-waf-plm-without-appprotect",
+			namespace:         "default",
+			expectedErrorMsgs: []string{"controller.appprotect.plmStorage.url requires controller.appprotect.enable=true"},
+		},
+		"appProtectWAFPLMWithoutCredentials": {
+			valuesFile:        "testdata/app-protect-waf-plm-without-credentials.yaml",
+			releaseName:       "appprotect-waf-plm-without-credentials",
+			namespace:         "default",
+			expectedErrorMsgs: []string{"controller.appprotect.plmStorage.credentialsSecret must be set when controller.appprotect.plmStorage.url is set"},
+		},
+		"appProtectWAFPLMWithoutURL": {
+			valuesFile:        "testdata/app-protect-waf-plm-without-url.yaml",
+			releaseName:       "appprotect-waf-plm-without-url",
+			namespace:         "default",
+			expectedErrorMsgs: []string{"controller.appprotect.plmStorage auxiliary values require controller.appprotect.plmStorage.url"},
+		},
 	}
 
 	// Path to the helm chart we will test

--- a/charts/tests/helmunit_test.go
+++ b/charts/tests/helmunit_test.go
@@ -146,6 +146,11 @@ func TestHelmNICTemplate(t *testing.T) {
 			releaseName: "appprotect-wafv5-resources",
 			namespace:   "appprotect-wafv5",
 		},
+		"appProtectWAFPLM": {
+			valuesFile:  "testdata/app-protect-waf-plm.yaml",
+			releaseName: "appprotect-waf-plm",
+			namespace:   "appprotect-waf-plm",
+		},
 		"appProtectDOS": {
 			valuesFile:  "testdata/app-protect-dos.yaml",
 			releaseName: "appprotect-dos",
@@ -265,6 +270,12 @@ func TestHelmNICTemplateNegative(t *testing.T) {
 			releaseName:       "global-config-empty-name",
 			namespace:         "default",
 			expectedErrorMsgs: []string{"globalConfiguration.customName namespace and name parts cannot be empty (e.g., \"my-namespace/my-global-config\")"},
+		},
+		"appProtectWAFPLMWithoutV5": {
+			valuesFile:        "testdata/app-protect-waf-plm-without-v5.yaml",
+			releaseName:       "appprotect-waf-plm-without-v5",
+			namespace:         "default",
+			expectedErrorMsgs: []string{"controller.appprotect.plmStorage.url requires controller.appprotect.v5=true"},
 		},
 	}
 

--- a/charts/tests/testdata/app-protect-waf-plm-without-appprotect.yaml
+++ b/charts/tests/testdata/app-protect-waf-plm-without-appprotect.yaml
@@ -1,0 +1,8 @@
+controller:
+  nginxplus: true
+  appprotect:
+    enable: false
+    v5: true
+    plmStorage:
+      url: https://f5-waf-seaweed-filer.plm.svc.cluster.local:9333
+      credentialsSecret: plm/seaweedfs-auth

--- a/charts/tests/testdata/app-protect-waf-plm-without-credentials.yaml
+++ b/charts/tests/testdata/app-protect-waf-plm-without-credentials.yaml
@@ -1,0 +1,8 @@
+controller:
+  nginxplus: true
+  appprotect:
+    enable: true
+    v5: true
+    plmStorage:
+      url: https://f5-waf-seaweed-filer.plm.svc.cluster.local:9333
+      credentialsSecret: ""

--- a/charts/tests/testdata/app-protect-waf-plm-without-plus.yaml
+++ b/charts/tests/testdata/app-protect-waf-plm-without-plus.yaml
@@ -1,0 +1,8 @@
+controller:
+  nginxplus: false
+  appprotect:
+    enable: true
+    v5: true
+    plmStorage:
+      url: https://f5-waf-seaweed-filer.plm.svc.cluster.local:9333
+      credentialsSecret: plm/seaweedfs-auth

--- a/charts/tests/testdata/app-protect-waf-plm-without-url.yaml
+++ b/charts/tests/testdata/app-protect-waf-plm-without-url.yaml
@@ -1,0 +1,8 @@
+controller:
+  nginxplus: true
+  appprotect:
+    enable: true
+    v5: true
+    plmStorage:
+      url: ""
+      credentialsSecret: plm/seaweedfs-auth

--- a/charts/tests/testdata/app-protect-waf-plm-without-v5.yaml
+++ b/charts/tests/testdata/app-protect-waf-plm-without-v5.yaml
@@ -1,0 +1,7 @@
+controller:
+  nginxplus: true
+  appprotect:
+    enable: true
+    plmStorage:
+      url: https://f5-waf-seaweed-filer.plm.svc.cluster.local:8333
+      credentialsSecret: plm/seaweedfs-auth

--- a/charts/tests/testdata/app-protect-waf-plm.yaml
+++ b/charts/tests/testdata/app-protect-waf-plm.yaml
@@ -1,0 +1,11 @@
+controller:
+  nginxplus: true
+  appprotect:
+    enable: true
+    v5: true
+    plmStorage:
+      url: https://f5-waf-seaweed-filer.plm.svc.cluster.local:8333
+      credentialsSecret: plm/seaweedfs-auth
+      caSecret: plm/seaweedfs-ca
+      clientSSLSecret: plm/seaweedfs-client
+      insecureSkipVerify: false

--- a/charts/tests/testdata/app-protect-waf-plm.yaml
+++ b/charts/tests/testdata/app-protect-waf-plm.yaml
@@ -4,7 +4,7 @@ controller:
     enable: true
     v5: true
     plmStorage:
-      url: https://f5-waf-seaweed-filer.plm.svc.cluster.local:8333
+      url: http://f5-waf-seaweed-filer.plm.svc.cluster.local:8333
       credentialsSecret: plm/seaweedfs-auth
       caSecret: plm/seaweedfs-ca
       clientSSLSecret: plm/seaweedfs-client

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -239,6 +239,7 @@ func main() {
 		NginxVersion:                   nginxVersion,
 		AppProtectBundlePath:           appProtectBundlePath,
 		DefaultCABundle:                caBundlePath,
+		PLMEnabled:                     *plmStorageURL != "",
 	}
 
 	if *nginxPlus {

--- a/config/crd/bases/k8s.nginx.org_policies.yaml
+++ b/config/crd/bases/k8s.nginx.org_policies.yaml
@@ -882,16 +882,13 @@ spec:
                           Not recommended for production use.
                         type: boolean
                       name:
-                        description: |-
-                          Name is the policy name on the management plane (NIM/N1C), or the name of the
-                          APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS.
+                        description: Name is the policy name on the management plane.
+                          Required for NIM and N1C; forbidden for HTTPS.
                         maxLength: 63
                         type: string
                       namespace:
-                        description: |-
-                          Namespace is the namespace/tenant on the management plane (N1C), or the namespace of
-                          the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to
-                          the Policy's own namespace); forbidden otherwise.
+                        description: Namespace is the namespace/tenant on the management
+                          plane. Required for N1C; forbidden otherwise.
                         maxLength: 63
                         type: string
                       pollInterval:
@@ -932,12 +929,10 @@ spec:
                         - HTTPS
                         - NIM
                         - N1C
-                        - PLM
                         type: string
                       url:
-                        description: |-
-                          URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://.
-                          Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle.
+                        description: URL is the full bundle URL for HTTPS type, or
+                          the API base URL for NIM/N1C. Must use https://.
                         maxLength: 2083
                         pattern: ^(https://.*)?$
                         type: string
@@ -946,35 +941,6 @@ spec:
                           the downloaded bundle. HTTPS type only.
                         type: boolean
                     type: object
-                    x-kubernetes-validations:
-                    - message: url is not allowed when type is PLM; the bundle location
-                        is read from the referenced CR's status
-                      rule: self.type != 'PLM' || !has(self.url) || size(self.url)
-                        == 0
-                    - message: secret is not allowed when type is PLM; S3 credentials
-                        are configured cluster-wide via -plm-storage-credentials-secret
-                      rule: self.type != 'PLM' || !has(self.secret) || size(self.secret)
-                        == 0
-                    - message: trustedCertSecret is not allowed when type is PLM;
-                        TLS is configured cluster-wide via -plm-storage-ca-secret
-                      rule: self.type != 'PLM' || !has(self.trustedCertSecret) ||
-                        size(self.trustedCertSecret) == 0
-                    - message: verifyChecksum is not allowed when type is PLM; the
-                        checksum is read from the referenced CR's status
-                      rule: self.type != 'PLM' || !has(self.verifyChecksum) || self.verifyChecksum
-                        == false
-                    - message: enablePolling is not allowed when type is PLM; PLM
-                        bundles refresh automatically when the referenced CR's status
-                        changes
-                      rule: self.type != 'PLM' || !has(self.enablePolling) || self.enablePolling
-                        == false
-                    - message: pollInterval is not allowed when type is PLM; PLM bundles
-                        refresh automatically when the referenced CR's status changes
-                      rule: self.type != 'PLM' || !has(self.pollInterval)
-                    - message: name is required when type is PLM and must reference
-                        an APPolicy/APLogConf resource
-                      rule: self.type != 'PLM' || (has(self.name) && size(self.name)
-                        > 0)
                   apPolicy:
                     description: The App Protect WAF policy of the WAF. Accepts an
                       optional namespace. Mutually exclusive with apBundle and apBundleSource.
@@ -1010,16 +976,13 @@ spec:
                               Not recommended for production use.
                             type: boolean
                           name:
-                            description: |-
-                              Name is the policy name on the management plane (NIM/N1C), or the name of the
-                              APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS.
+                            description: Name is the policy name on the management
+                              plane. Required for NIM and N1C; forbidden for HTTPS.
                             maxLength: 63
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace/tenant on the management plane (N1C), or the namespace of
-                              the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to
-                              the Policy's own namespace); forbidden otherwise.
+                            description: Namespace is the namespace/tenant on the
+                              management plane. Required for N1C; forbidden otherwise.
                             maxLength: 63
                             type: string
                           pollInterval:
@@ -1060,12 +1023,10 @@ spec:
                             - HTTPS
                             - NIM
                             - N1C
-                            - PLM
                             type: string
                           url:
-                            description: |-
-                              URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://.
-                              Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle.
+                            description: URL is the full bundle URL for HTTPS type,
+                              or the API base URL for NIM/N1C. Must use https://.
                             maxLength: 2083
                             pattern: ^(https://.*)?$
                             type: string
@@ -1074,36 +1035,6 @@ spec:
                               of the downloaded bundle. HTTPS type only.
                             type: boolean
                         type: object
-                        x-kubernetes-validations:
-                        - message: url is not allowed when type is PLM; the bundle
-                            location is read from the referenced CR's status
-                          rule: self.type != 'PLM' || !has(self.url) || size(self.url)
-                            == 0
-                        - message: secret is not allowed when type is PLM; S3 credentials
-                            are configured cluster-wide via -plm-storage-credentials-secret
-                          rule: self.type != 'PLM' || !has(self.secret) || size(self.secret)
-                            == 0
-                        - message: trustedCertSecret is not allowed when type is PLM;
-                            TLS is configured cluster-wide via -plm-storage-ca-secret
-                          rule: self.type != 'PLM' || !has(self.trustedCertSecret)
-                            || size(self.trustedCertSecret) == 0
-                        - message: verifyChecksum is not allowed when type is PLM;
-                            the checksum is read from the referenced CR's status
-                          rule: self.type != 'PLM' || !has(self.verifyChecksum) ||
-                            self.verifyChecksum == false
-                        - message: enablePolling is not allowed when type is PLM;
-                            PLM bundles refresh automatically when the referenced
-                            CR's status changes
-                          rule: self.type != 'PLM' || !has(self.enablePolling) ||
-                            self.enablePolling == false
-                        - message: pollInterval is not allowed when type is PLM; PLM
-                            bundles refresh automatically when the referenced CR's
-                            status changes
-                          rule: self.type != 'PLM' || !has(self.pollInterval)
-                        - message: name is required when type is PLM and must reference
-                            an APPolicy/APLogConf resource
-                          rule: self.type != 'PLM' || (has(self.name) && size(self.name)
-                            > 0)
                       apLogConf:
                         description: The App Protect WAF log conf resource. Accepts
                           an optional namespace. Only works with apPolicy.
@@ -1146,16 +1077,13 @@ spec:
                                 Not recommended for production use.
                               type: boolean
                             name:
-                              description: |-
-                                Name is the policy name on the management plane (NIM/N1C), or the name of the
-                                APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS.
+                              description: Name is the policy name on the management
+                                plane. Required for NIM and N1C; forbidden for HTTPS.
                               maxLength: 63
                               type: string
                             namespace:
-                              description: |-
-                                Namespace is the namespace/tenant on the management plane (N1C), or the namespace of
-                                the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to
-                                the Policy's own namespace); forbidden otherwise.
+                              description: Namespace is the namespace/tenant on the
+                                management plane. Required for N1C; forbidden otherwise.
                               maxLength: 63
                               type: string
                             pollInterval:
@@ -1196,12 +1124,10 @@ spec:
                               - HTTPS
                               - NIM
                               - N1C
-                              - PLM
                               type: string
                             url:
-                              description: |-
-                                URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://.
-                                Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle.
+                              description: URL is the full bundle URL for HTTPS type,
+                                or the API base URL for NIM/N1C. Must use https://.
                               maxLength: 2083
                               pattern: ^(https://.*)?$
                               type: string
@@ -1210,36 +1136,6 @@ spec:
                                 of the downloaded bundle. HTTPS type only.
                               type: boolean
                           type: object
-                          x-kubernetes-validations:
-                          - message: url is not allowed when type is PLM; the bundle
-                              location is read from the referenced CR's status
-                            rule: self.type != 'PLM' || !has(self.url) || size(self.url)
-                              == 0
-                          - message: secret is not allowed when type is PLM; S3 credentials
-                              are configured cluster-wide via -plm-storage-credentials-secret
-                            rule: self.type != 'PLM' || !has(self.secret) || size(self.secret)
-                              == 0
-                          - message: trustedCertSecret is not allowed when type is
-                              PLM; TLS is configured cluster-wide via -plm-storage-ca-secret
-                            rule: self.type != 'PLM' || !has(self.trustedCertSecret)
-                              || size(self.trustedCertSecret) == 0
-                          - message: verifyChecksum is not allowed when type is PLM;
-                              the checksum is read from the referenced CR's status
-                            rule: self.type != 'PLM' || !has(self.verifyChecksum)
-                              || self.verifyChecksum == false
-                          - message: enablePolling is not allowed when type is PLM;
-                              PLM bundles refresh automatically when the referenced
-                              CR's status changes
-                            rule: self.type != 'PLM' || !has(self.enablePolling) ||
-                              self.enablePolling == false
-                          - message: pollInterval is not allowed when type is PLM;
-                              PLM bundles refresh automatically when the referenced
-                              CR's status changes
-                            rule: self.type != 'PLM' || !has(self.pollInterval)
-                          - message: name is required when type is PLM and must reference
-                              an APPolicy/APLogConf resource
-                            rule: self.type != 'PLM' || (has(self.name) && size(self.name)
-                              > 0)
                         apLogConf:
                           description: The App Protect WAF log conf resource. Accepts
                             an optional namespace. Only works with apPolicy.

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -1053,16 +1053,13 @@ spec:
                           Not recommended for production use.
                         type: boolean
                       name:
-                        description: |-
-                          Name is the policy name on the management plane (NIM/N1C), or the name of the
-                          APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS.
+                        description: Name is the policy name on the management plane.
+                          Required for NIM and N1C; forbidden for HTTPS.
                         maxLength: 63
                         type: string
                       namespace:
-                        description: |-
-                          Namespace is the namespace/tenant on the management plane (N1C), or the namespace of
-                          the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to
-                          the Policy's own namespace); forbidden otherwise.
+                        description: Namespace is the namespace/tenant on the management
+                          plane. Required for N1C; forbidden otherwise.
                         maxLength: 63
                         type: string
                       pollInterval:
@@ -1103,12 +1100,10 @@ spec:
                         - HTTPS
                         - NIM
                         - N1C
-                        - PLM
                         type: string
                       url:
-                        description: |-
-                          URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://.
-                          Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle.
+                        description: URL is the full bundle URL for HTTPS type, or
+                          the API base URL for NIM/N1C. Must use https://.
                         maxLength: 2083
                         pattern: ^(https://.*)?$
                         type: string
@@ -1117,35 +1112,6 @@ spec:
                           the downloaded bundle. HTTPS type only.
                         type: boolean
                     type: object
-                    x-kubernetes-validations:
-                    - message: url is not allowed when type is PLM; the bundle location
-                        is read from the referenced CR's status
-                      rule: self.type != 'PLM' || !has(self.url) || size(self.url)
-                        == 0
-                    - message: secret is not allowed when type is PLM; S3 credentials
-                        are configured cluster-wide via -plm-storage-credentials-secret
-                      rule: self.type != 'PLM' || !has(self.secret) || size(self.secret)
-                        == 0
-                    - message: trustedCertSecret is not allowed when type is PLM;
-                        TLS is configured cluster-wide via -plm-storage-ca-secret
-                      rule: self.type != 'PLM' || !has(self.trustedCertSecret) ||
-                        size(self.trustedCertSecret) == 0
-                    - message: verifyChecksum is not allowed when type is PLM; the
-                        checksum is read from the referenced CR's status
-                      rule: self.type != 'PLM' || !has(self.verifyChecksum) || self.verifyChecksum
-                        == false
-                    - message: enablePolling is not allowed when type is PLM; PLM
-                        bundles refresh automatically when the referenced CR's status
-                        changes
-                      rule: self.type != 'PLM' || !has(self.enablePolling) || self.enablePolling
-                        == false
-                    - message: pollInterval is not allowed when type is PLM; PLM bundles
-                        refresh automatically when the referenced CR's status changes
-                      rule: self.type != 'PLM' || !has(self.pollInterval)
-                    - message: name is required when type is PLM and must reference
-                        an APPolicy/APLogConf resource
-                      rule: self.type != 'PLM' || (has(self.name) && size(self.name)
-                        > 0)
                   apPolicy:
                     description: The App Protect WAF policy of the WAF. Accepts an
                       optional namespace. Mutually exclusive with apBundle and apBundleSource.
@@ -1181,16 +1147,13 @@ spec:
                               Not recommended for production use.
                             type: boolean
                           name:
-                            description: |-
-                              Name is the policy name on the management plane (NIM/N1C), or the name of the
-                              APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS.
+                            description: Name is the policy name on the management
+                              plane. Required for NIM and N1C; forbidden for HTTPS.
                             maxLength: 63
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace/tenant on the management plane (N1C), or the namespace of
-                              the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to
-                              the Policy's own namespace); forbidden otherwise.
+                            description: Namespace is the namespace/tenant on the
+                              management plane. Required for N1C; forbidden otherwise.
                             maxLength: 63
                             type: string
                           pollInterval:
@@ -1231,12 +1194,10 @@ spec:
                             - HTTPS
                             - NIM
                             - N1C
-                            - PLM
                             type: string
                           url:
-                            description: |-
-                              URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://.
-                              Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle.
+                            description: URL is the full bundle URL for HTTPS type,
+                              or the API base URL for NIM/N1C. Must use https://.
                             maxLength: 2083
                             pattern: ^(https://.*)?$
                             type: string
@@ -1245,36 +1206,6 @@ spec:
                               of the downloaded bundle. HTTPS type only.
                             type: boolean
                         type: object
-                        x-kubernetes-validations:
-                        - message: url is not allowed when type is PLM; the bundle
-                            location is read from the referenced CR's status
-                          rule: self.type != 'PLM' || !has(self.url) || size(self.url)
-                            == 0
-                        - message: secret is not allowed when type is PLM; S3 credentials
-                            are configured cluster-wide via -plm-storage-credentials-secret
-                          rule: self.type != 'PLM' || !has(self.secret) || size(self.secret)
-                            == 0
-                        - message: trustedCertSecret is not allowed when type is PLM;
-                            TLS is configured cluster-wide via -plm-storage-ca-secret
-                          rule: self.type != 'PLM' || !has(self.trustedCertSecret)
-                            || size(self.trustedCertSecret) == 0
-                        - message: verifyChecksum is not allowed when type is PLM;
-                            the checksum is read from the referenced CR's status
-                          rule: self.type != 'PLM' || !has(self.verifyChecksum) ||
-                            self.verifyChecksum == false
-                        - message: enablePolling is not allowed when type is PLM;
-                            PLM bundles refresh automatically when the referenced
-                            CR's status changes
-                          rule: self.type != 'PLM' || !has(self.enablePolling) ||
-                            self.enablePolling == false
-                        - message: pollInterval is not allowed when type is PLM; PLM
-                            bundles refresh automatically when the referenced CR's
-                            status changes
-                          rule: self.type != 'PLM' || !has(self.pollInterval)
-                        - message: name is required when type is PLM and must reference
-                            an APPolicy/APLogConf resource
-                          rule: self.type != 'PLM' || (has(self.name) && size(self.name)
-                            > 0)
                       apLogConf:
                         description: The App Protect WAF log conf resource. Accepts
                           an optional namespace. Only works with apPolicy.
@@ -1317,16 +1248,13 @@ spec:
                                 Not recommended for production use.
                               type: boolean
                             name:
-                              description: |-
-                                Name is the policy name on the management plane (NIM/N1C), or the name of the
-                                APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS.
+                              description: Name is the policy name on the management
+                                plane. Required for NIM and N1C; forbidden for HTTPS.
                               maxLength: 63
                               type: string
                             namespace:
-                              description: |-
-                                Namespace is the namespace/tenant on the management plane (N1C), or the namespace of
-                                the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to
-                                the Policy's own namespace); forbidden otherwise.
+                              description: Namespace is the namespace/tenant on the
+                                management plane. Required for N1C; forbidden otherwise.
                               maxLength: 63
                               type: string
                             pollInterval:
@@ -1367,12 +1295,10 @@ spec:
                               - HTTPS
                               - NIM
                               - N1C
-                              - PLM
                               type: string
                             url:
-                              description: |-
-                                URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://.
-                                Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle.
+                              description: URL is the full bundle URL for HTTPS type,
+                                or the API base URL for NIM/N1C. Must use https://.
                               maxLength: 2083
                               pattern: ^(https://.*)?$
                               type: string
@@ -1381,36 +1307,6 @@ spec:
                                 of the downloaded bundle. HTTPS type only.
                               type: boolean
                           type: object
-                          x-kubernetes-validations:
-                          - message: url is not allowed when type is PLM; the bundle
-                              location is read from the referenced CR's status
-                            rule: self.type != 'PLM' || !has(self.url) || size(self.url)
-                              == 0
-                          - message: secret is not allowed when type is PLM; S3 credentials
-                              are configured cluster-wide via -plm-storage-credentials-secret
-                            rule: self.type != 'PLM' || !has(self.secret) || size(self.secret)
-                              == 0
-                          - message: trustedCertSecret is not allowed when type is
-                              PLM; TLS is configured cluster-wide via -plm-storage-ca-secret
-                            rule: self.type != 'PLM' || !has(self.trustedCertSecret)
-                              || size(self.trustedCertSecret) == 0
-                          - message: verifyChecksum is not allowed when type is PLM;
-                              the checksum is read from the referenced CR's status
-                            rule: self.type != 'PLM' || !has(self.verifyChecksum)
-                              || self.verifyChecksum == false
-                          - message: enablePolling is not allowed when type is PLM;
-                              PLM bundles refresh automatically when the referenced
-                              CR's status changes
-                            rule: self.type != 'PLM' || !has(self.enablePolling) ||
-                              self.enablePolling == false
-                          - message: pollInterval is not allowed when type is PLM;
-                              PLM bundles refresh automatically when the referenced
-                              CR's status changes
-                            rule: self.type != 'PLM' || !has(self.pollInterval)
-                          - message: name is required when type is PLM and must reference
-                              an APPolicy/APLogConf resource
-                            rule: self.type != 'PLM' || (has(self.name) && size(self.name)
-                              > 0)
                         apLogConf:
                           description: The App Protect WAF log conf resource. Accepts
                             an optional namespace. Only works with apPolicy.

--- a/docs/crd/k8s.nginx.org_policies.md
+++ b/docs/crd/k8s.nginx.org_policies.md
@@ -147,15 +147,15 @@ The `.spec` object supports the following fields:
 | `waf.apBundleSource` | `object` | ApBundleSource fetches the WAF policy bundle from N1C, NIM, or an HTTPS endpoint. Mutually exclusive with ApPolicy and ApBundle. |
 | `waf.apBundleSource.enablePolling` | `boolean` | EnablePolling enables background polling to automatically detect and fetch updated bundles at the configured PollInterval. Defaults to false. When false, the bundle is fetched once on policy creation or update; subsequent updates require modifying the Policy resource to trigger a new fetch. |
 | `waf.apBundleSource.insecureSkipVerify` | `boolean` | InsecureSkipVerify disables TLS certificate verification when fetching bundles. Not recommended for production use. |
-| `waf.apBundleSource.name` | `string` | Name is the policy name on the management plane (NIM/N1C), or the name of the APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS. |
-| `waf.apBundleSource.namespace` | `string` | Namespace is the namespace/tenant on the management plane (N1C), or the namespace of the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to the Policy's own namespace); forbidden otherwise. |
+| `waf.apBundleSource.name` | `string` | Name is the policy name on the management plane. Required for NIM and N1C; forbidden for HTTPS. |
+| `waf.apBundleSource.namespace` | `string` | Namespace is the namespace/tenant on the management plane. Required for N1C; forbidden otherwise. |
 | `waf.apBundleSource.pollInterval` | `string` | PollInterval is how often to re-fetch the bundle when enablePolling is true. Minimum 1m. Default 5m. Ignored when enablePolling is false. |
 | `waf.apBundleSource.retryAttempts` | `integer` | RetryAttempts is the number of retry attempts on transient failure. Range 1–10. |
 | `waf.apBundleSource.secret` | `string` | Secret is the name of a Kubernetes Secret in the same namespace as the Policy. For HTTPS: kubernetes.io/tls (tls.crt + tls.key for client mTLS; optional ca.crt for server CA). For N1C: nginx.com/waf-bundle Secret with a 'token' field containing the API token. For NIM: nginx.com/waf-bundle Secret with a 'token' field (bearer auth) or 'username'+'password' fields (basic auth). |
 | `waf.apBundleSource.timeout` | `string` | Timeout is the per-request HTTP timeout. Default 60s. |
 | `waf.apBundleSource.trustedCertSecret` | `string` | TrustedCertSecret is the name of a Kubernetes Secret with a custom CA certificate for verifying the remote endpoint TLS certificate. The secret must be in the same namespace as the Policy, must be of type nginx.org/ca, and must include ca.crt. |
-| `waf.apBundleSource.type` | `string` | Type is the bundle source backend. Defaults to HTTPS. Allowed values: `"HTTPS"`, `"NIM"`, `"N1C"`, `"PLM"`. |
-| `waf.apBundleSource.url` | `string` | URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://. Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle. |
+| `waf.apBundleSource.type` | `string` | Type is the bundle source backend. Defaults to HTTPS. Allowed values: `"HTTPS"`, `"NIM"`, `"N1C"`. |
+| `waf.apBundleSource.url` | `string` | URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://. |
 | `waf.apBundleSource.verifyChecksum` | `boolean` | VerifyChecksum enables SHA-256 verification of the downloaded bundle. HTTPS type only. |
 | `waf.apPolicy` | `string` | The App Protect WAF policy of the WAF. Accepts an optional namespace. Mutually exclusive with apBundle and apBundleSource. |
 | `waf.enable` | `boolean` | Enables NGINX App Protect WAF. |
@@ -164,15 +164,15 @@ The `.spec` object supports the following fields:
 | `waf.securityLog.apLogBundleSource` | `object` | ApLogBundleSource fetches the log profile bundle from N1C, NIM, or an HTTPS endpoint. Mutually exclusive with ApLogConf and ApLogBundle. Requires apBundleSource on the parent WAF. |
 | `waf.securityLog.apLogBundleSource.enablePolling` | `boolean` | EnablePolling enables background polling to automatically detect and fetch updated bundles at the configured PollInterval. Defaults to false. When false, the bundle is fetched once on policy creation or update; subsequent updates require modifying the Policy resource to trigger a new fetch. |
 | `waf.securityLog.apLogBundleSource.insecureSkipVerify` | `boolean` | InsecureSkipVerify disables TLS certificate verification when fetching bundles. Not recommended for production use. |
-| `waf.securityLog.apLogBundleSource.name` | `string` | Name is the policy name on the management plane (NIM/N1C), or the name of the APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS. |
-| `waf.securityLog.apLogBundleSource.namespace` | `string` | Namespace is the namespace/tenant on the management plane (N1C), or the namespace of the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to the Policy's own namespace); forbidden otherwise. |
+| `waf.securityLog.apLogBundleSource.name` | `string` | Name is the policy name on the management plane. Required for NIM and N1C; forbidden for HTTPS. |
+| `waf.securityLog.apLogBundleSource.namespace` | `string` | Namespace is the namespace/tenant on the management plane. Required for N1C; forbidden otherwise. |
 | `waf.securityLog.apLogBundleSource.pollInterval` | `string` | PollInterval is how often to re-fetch the bundle when enablePolling is true. Minimum 1m. Default 5m. Ignored when enablePolling is false. |
 | `waf.securityLog.apLogBundleSource.retryAttempts` | `integer` | RetryAttempts is the number of retry attempts on transient failure. Range 1–10. |
 | `waf.securityLog.apLogBundleSource.secret` | `string` | Secret is the name of a Kubernetes Secret in the same namespace as the Policy. For HTTPS: kubernetes.io/tls (tls.crt + tls.key for client mTLS; optional ca.crt for server CA). For N1C: nginx.com/waf-bundle Secret with a 'token' field containing the API token. For NIM: nginx.com/waf-bundle Secret with a 'token' field (bearer auth) or 'username'+'password' fields (basic auth). |
 | `waf.securityLog.apLogBundleSource.timeout` | `string` | Timeout is the per-request HTTP timeout. Default 60s. |
 | `waf.securityLog.apLogBundleSource.trustedCertSecret` | `string` | TrustedCertSecret is the name of a Kubernetes Secret with a custom CA certificate for verifying the remote endpoint TLS certificate. The secret must be in the same namespace as the Policy, must be of type nginx.org/ca, and must include ca.crt. |
-| `waf.securityLog.apLogBundleSource.type` | `string` | Type is the bundle source backend. Defaults to HTTPS. Allowed values: `"HTTPS"`, `"NIM"`, `"N1C"`, `"PLM"`. |
-| `waf.securityLog.apLogBundleSource.url` | `string` | URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://. Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle. |
+| `waf.securityLog.apLogBundleSource.type` | `string` | Type is the bundle source backend. Defaults to HTTPS. Allowed values: `"HTTPS"`, `"NIM"`, `"N1C"`. |
+| `waf.securityLog.apLogBundleSource.url` | `string` | URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://. |
 | `waf.securityLog.apLogBundleSource.verifyChecksum` | `boolean` | VerifyChecksum enables SHA-256 verification of the downloaded bundle. HTTPS type only. |
 | `waf.securityLog.apLogConf` | `string` | The App Protect WAF log conf resource. Accepts an optional namespace. Only works with apPolicy. |
 | `waf.securityLog.enable` | `boolean` | Enables security log. |
@@ -182,15 +182,15 @@ The `.spec` object supports the following fields:
 | `waf.securityLogs[].apLogBundleSource` | `object` | ApLogBundleSource fetches the log profile bundle from N1C, NIM, or an HTTPS endpoint. Mutually exclusive with ApLogConf and ApLogBundle. Requires apBundleSource on the parent WAF. |
 | `waf.securityLogs[].apLogBundleSource.enablePolling` | `boolean` | EnablePolling enables background polling to automatically detect and fetch updated bundles at the configured PollInterval. Defaults to false. When false, the bundle is fetched once on policy creation or update; subsequent updates require modifying the Policy resource to trigger a new fetch. |
 | `waf.securityLogs[].apLogBundleSource.insecureSkipVerify` | `boolean` | InsecureSkipVerify disables TLS certificate verification when fetching bundles. Not recommended for production use. |
-| `waf.securityLogs[].apLogBundleSource.name` | `string` | Name is the policy name on the management plane (NIM/N1C), or the name of the APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS. |
-| `waf.securityLogs[].apLogBundleSource.namespace` | `string` | Namespace is the namespace/tenant on the management plane (N1C), or the namespace of the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to the Policy's own namespace); forbidden otherwise. |
+| `waf.securityLogs[].apLogBundleSource.name` | `string` | Name is the policy name on the management plane. Required for NIM and N1C; forbidden for HTTPS. |
+| `waf.securityLogs[].apLogBundleSource.namespace` | `string` | Namespace is the namespace/tenant on the management plane. Required for N1C; forbidden otherwise. |
 | `waf.securityLogs[].apLogBundleSource.pollInterval` | `string` | PollInterval is how often to re-fetch the bundle when enablePolling is true. Minimum 1m. Default 5m. Ignored when enablePolling is false. |
 | `waf.securityLogs[].apLogBundleSource.retryAttempts` | `integer` | RetryAttempts is the number of retry attempts on transient failure. Range 1–10. |
 | `waf.securityLogs[].apLogBundleSource.secret` | `string` | Secret is the name of a Kubernetes Secret in the same namespace as the Policy. For HTTPS: kubernetes.io/tls (tls.crt + tls.key for client mTLS; optional ca.crt for server CA). For N1C: nginx.com/waf-bundle Secret with a 'token' field containing the API token. For NIM: nginx.com/waf-bundle Secret with a 'token' field (bearer auth) or 'username'+'password' fields (basic auth). |
 | `waf.securityLogs[].apLogBundleSource.timeout` | `string` | Timeout is the per-request HTTP timeout. Default 60s. |
 | `waf.securityLogs[].apLogBundleSource.trustedCertSecret` | `string` | TrustedCertSecret is the name of a Kubernetes Secret with a custom CA certificate for verifying the remote endpoint TLS certificate. The secret must be in the same namespace as the Policy, must be of type nginx.org/ca, and must include ca.crt. |
-| `waf.securityLogs[].apLogBundleSource.type` | `string` | Type is the bundle source backend. Defaults to HTTPS. Allowed values: `"HTTPS"`, `"NIM"`, `"N1C"`, `"PLM"`. |
-| `waf.securityLogs[].apLogBundleSource.url` | `string` | URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://. Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle. |
+| `waf.securityLogs[].apLogBundleSource.type` | `string` | Type is the bundle source backend. Defaults to HTTPS. Allowed values: `"HTTPS"`, `"NIM"`, `"N1C"`. |
+| `waf.securityLogs[].apLogBundleSource.url` | `string` | URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://. |
 | `waf.securityLogs[].apLogBundleSource.verifyChecksum` | `boolean` | VerifyChecksum enables SHA-256 verification of the downloaded bundle. HTTPS type only. |
 | `waf.securityLogs[].apLogConf` | `string` | The App Protect WAF log conf resource. Accepts an optional namespace. Only works with apPolicy. |
 | `waf.securityLogs[].enable` | `boolean` | Enables security log. |

--- a/examples/custom-resources/waf-plm/README.md
+++ b/examples/custom-resources/waf-plm/README.md
@@ -16,7 +16,7 @@ bundle once its `status.bundle.state` becomes `ready`.
 1. Confirm the CRDs are installed and served at `v1`:
 
     ```console
-    kubectl describe crd appolicies.appprotect.f5.com aplogconfs.appprotect.f5.com
+    kubectl describe crd appolicies.appprotect.f5.com aplogconfs.appprotect.f5.com apsignatures.appprotect.f5.com apusersigs.appprotect.f5.com 
     ```
 
 ## Step 1 - Create the PLM Policy and Log Configuration
@@ -125,9 +125,7 @@ For an installation without TLS, use the HTTP endpoint on port `8333` and leave
 `caSecret` and `clientSSLSecret` empty. The endpoint scheme must match how PLM was
 installed: a plaintext `http://` request sent to the TLS port fails.
 
-Because PLM owns the App Protect CRDs, install NIC with `--skip-crds` so it does not
-overwrite them and create rest of the CRDs before installation otherwise NIC pod won't become ready.
-
+Apply the CRDs before installing NIC using `kubectl apply -f ../../../deploy/crds.yaml`. Pass `--skip-crds` when using `helm install`
 If `controller.watchNamespace` is restricted, include the namespace holding the
 `APPolicy` and `APLogConf` resources so NIC can watch their status. If
 `controller.watchSecretNamespace` is restricted, include the namespace holding the

--- a/examples/custom-resources/waf-plm/README.md
+++ b/examples/custom-resources/waf-plm/README.md
@@ -1,0 +1,245 @@
+# WAF with F5 WAF Policy Controller
+
+In this example we deploy the NGINX Plus Ingress Controller with F5 WAF for NGINX, where the policy and log
+configuration bundles are compiled by the F5 WAF Policy Controller (PLM).
+
+PLM owns the `APPolicy` and `APLogConf` lifecycle and publishes the compiled bundles to
+SeaweedFS. NGINX Ingress Controller (NIC) watches the referenced resources and fetches a
+bundle once its `status.bundle.state` becomes `ready`.
+
+## Prerequisites
+
+1. Install the F5 WAF Policy Controller (PLM). PLM installs and owns the
+   `appprotect.f5.com/v1` CRDs (`APPolicy`, `APLogConf`, `APUserSig`, `APSignatures`)
+   and runs the compiler and SeaweedFS bundle store.
+
+1. Confirm the CRDs are installed and served at `v1`:
+
+    ```console
+    kubectl describe crd appolicies.appprotect.f5.com aplogconfs.appprotect.f5.com
+    ```
+
+## Step 1 - Create the PLM Policy and Log Configuration
+
+Create the `APPolicy` and `APLogConf` resources. PLM compiles each resource and publishes
+the resulting bundle to SeaweedFS.
+
+```console
+kubectl apply -f ap-dataguard-alarm-policy.yaml
+kubectl apply -f ap-logconf.yaml
+```
+
+## Step 2 - Verify Both Bundles Are Ready
+
+Check that PLM reports `ready` for both resources. NIC does not fetch a bundle before
+this point.
+
+```console
+kubectl describe appolicy dataguard-alarm
+kubectl describe aplogconf logconf
+```
+
+Each resource reports the compiled bundle under `Status`:
+
+- for appolicy:
+
+   ```text
+   Status:
+   Bundle:
+      Compiler Version:  5.14.0
+      Location:          s3://default/bundles/dataguard-alarm20260807160340-dataguard-alarm-1-1786118620559717186.tgz
+      sha256:            47a6fdcd07b9adafaaa415fa9fd2ab2cab84b54b26a91fd518a4ff5e2dab3f8d
+      Signatures:
+         Attack Signatures:  2026-07-18T13:39:26Z
+         Bot Signatures:     2026-07-16T07:35:37Z
+         Threat Campaigns:   2026-07-13T11:56:06Z
+      State:                ready
+   Last Good Bundle:
+      Compiler Version:  5.14.0
+      Location:          s3://default/bundles/dataguard-alarm20260807160340-dataguard-alarm-1-1786118620559717186.tgz
+      sha256:            47a6fdcd07b9adafaaa415fa9fd2ab2cab84b54b26a91fd518a4ff5e2dab3f8d
+      Signatures:
+         Attack Signatures:  2026-07-18T13:39:26Z
+         Bot Signatures:     2026-07-16T07:35:37Z
+         Threat Campaigns:   2026-07-13T11:56:06Z
+      State:                ready
+   Observed Generation:    1
+   Observed Policy Name:   dataguard-alarm
+   Policy Location:        s3://default/policies/dataguard-alarm.json
+   Processing:
+      Datetime:     2026-08-07T16:03:46Z
+      Is Compiled:  true
+   ```
+
+- for aplogconf:
+
+   ```text
+   Status:
+   Bundle:
+      Compiler Version:   5.14.0
+      Location:           s3://default/bundles/logconf20260807160340.tgz
+      sha256:             0728d1cc822e32af2b880f49c433f7fe8ef28bd5fcf1761af2be4f04acace9de
+      State:              ready
+   Observed Generation:  1
+   Processing:
+      Datetime:     2026-08-07T16:03:46Z
+      Is Compiled:  true
+   Events:           <none>
+   ```
+
+If a resource never reaches `ready`, inspect the PLM policy-controller and compiler logs
+before continuing.
+
+## Step 3 - Install the Ingress Controller
+
+Deploy NIC with NGINX Plus, App Protect, and PLM storage enabled. PLM
+storage is configured with cluster-wide command-line arguments, which the Helm chart
+renders from `controller.appprotect.plmStorage`:
+
+| Argument | Purpose |
+| --- | --- |
+| `-plm-storage-url` | SeaweedFS S3 endpoint. Enables the PLM integration and makes NIC watch the `appprotect.f5.com/v1` CRDs. |
+| `-plm-storage-credentials-secret` | Secret holding the SeaweedFS admin key under `seaweedfs_admin_secret`. Required. |
+| `-plm-storage-ca-secret` | Optional Secret containing `ca.crt` for TLS verification. |
+| `-plm-storage-client-ssl-secret` | Optional Secret containing `tls.crt` and `tls.key` for mTLS. |
+| `-plm-storage-insecure-skip-verify` | Disables TLS verification. Development and testing only. |
+
+Secret references use the `namespace/name` format. For a PLM installation with TLS and
+mTLS enabled, the Helm values are:
+
+```yaml
+controller:
+  nginxplus: true
+  appprotect:
+    enable: true
+    v5: true
+    plmStorage:
+      url: "https://<plm_release>-f5-waf-seaweed-filer.<plm_namespace>.svc.cluster.local:9333"
+      credentialsSecret: "<plm_namespace>/<plm_release>-f5-waf-seaweedfs-auth"
+      caSecret: "<plm_namespace>/<plm_release>-f5-waf-seaweedfs-ca-cert"
+      clientSSLSecret: "<plm_namespace>/<plm_release>-f5-waf-seaweedfs-client-cert"
+      insecureSkipVerify: false
+```
+
+For an installation without TLS, use the HTTP endpoint on port `8333` and leave
+`caSecret` and `clientSSLSecret` empty. The endpoint scheme must match how PLM was
+installed: a plaintext `http://` request sent to the TLS port fails.
+
+Because PLM owns the App Protect CRDs, install NIC with `--skip-crds` so it does not
+overwrite them and create rest of the CRDs before installation otherwise NIC pod won't become ready.
+
+If `controller.watchNamespace` is restricted, include the namespace holding the
+`APPolicy` and `APLogConf` resources so NIC can watch their status. If
+`controller.watchSecretNamespace` is restricted, include the namespace holding the
+storage Secrets so NIC observes their rotation.
+
+Then save the public IP address and HTTP port of the Ingress Controller into shell
+variables:
+
+```console
+IC_IP=XXX.YYY.ZZZ.III
+IC_HTTP_PORT=<port number>
+```
+
+## Step 4 - Deploy the Application and WAF Policy
+
+1. Create the application deployment and service:
+
+    ```console
+    kubectl apply -f webapp.yaml
+    ```
+
+1. Create the syslog service and pod for the security logs:
+
+    ```console
+    kubectl apply -f syslog.yaml
+    ```
+
+1. Create the WAF policy:
+
+    ```console
+    kubectl apply -f waf-plm.yaml
+    ```
+
+PLM sources do not use `url`, `secret`, `trustedCertSecret`, `enablePolling`,
+`pollInterval`, or `verifyChecksum`. NIC reads the bundle location and SHA-256 from the
+referenced resource status, and bundle updates are driven by status watch events rather
+than polling.
+
+## Step 5 - Check the Policy Status
+
+The Policy becomes valid once NIC has fetched both bundles from SeaweedFS:
+
+```console
+kubectl describe policy waf-policy
+```
+
+```text
+Events:
+  Type    Reason          Message
+  ----    ------          -------
+  Normal  AddedOrUpdated  Policy default/waf-policy was added or updated
+```
+
+A `BundleFetchFailed` warning means NIC reached the fetch stage but could not retrieve
+the bundle. Verify the storage endpoint, credentials, and TLS settings from Step 3.
+
+## Step 6 - Check policy and logconf bundles
+
+Optional but you can check for the presence of compiled bundles in pod file-system
+
+```console
+kubectl exec -it -n <NIC_NAMESPACE> <ANY_NIC_POD> -c nginx-ingress -- ls -ltr /etc/app_protect/bundles
+```
+
+```text
+-rw------- 1 nginx nginx 1901282 Aug  7 16:26 fetched_default_waf-policy_policy.tgz
+-rw------- 1 nginx nginx    1655 Aug  7 16:26 fetched_default_waf-policy_log_0.tgz
+```
+
+## Step 7 - Configure Load Balancing
+
+Create the VirtualServer resource, which references the `waf-policy` created in Step 4:
+
+```console
+kubectl apply -f virtual-server.yaml
+```
+
+## Step 8 - Test the Application
+
+1. Send a request to the application:
+
+   ```console
+   curl --resolve webapp.example.com:$IC_HTTP_PORT:$IC_IP http://webapp.example.com:$IC_HTTP_PORT/
+   ```
+
+   ```text
+   Server address: 10.104.1.11:8080
+   Server name: webapp-d568db6b5-bx92b
+   Date: 07/Aug/2026:16:29:39 +0000
+   URI: /
+   Request ID: d18679e4cb94c0f6279a5f053898d8df
+   ```
+
+1. Send a request that triggers the data guard violation.
+
+   ```console
+   curl --resolve webapp.example.com:$IC_HTTP_PORT:$IC_IP "http://webapp.example.com:$IC_HTTP_PORT/</script>"
+   ```
+
+   ```text
+   <html><head><title>Request Rejected</title></head><body>The requested URL was rejected. Please consult with your administrator.<br><br>Your support ID is: 14276123774182424059<br><br><a href='javascript:history.back();'>[Go Back]</a></body></html>%     
+   ```
+
+1. Check the security logs in the syslog pod:
+
+   ```console
+   kubectl exec -it <SYSLOG_POD> -- cat /var/log/messages
+   ```
+
+   ```text
+   Aug  7 16:29:57 nic-nginx-ingress-controller-f6c988865-twql8 ASM:attack_type="Non-browser Client,Abuse of Functionality,Cross Site Scripting (XSS),Other Application Activity",blocking_exception_reason="N/A",date_time="2026-08-07 16:29:57",dest_port="80",ip_client="<some_ip>",is_truncated="false",method="GET",policy_name="dataguard-alarm",protocol="HTTP",request_status="blocked",response_code="0",severity="Critical",sig_cves="N/A",sig_ids="200000093",sig_names="XSS script tag end (URI)",sig_set_names="{High Accuracy Signatures;Cross Site Scripting Signatures}",src_port="53923",sub_violations="N/A",support_id="14276123774182424059",threat_campaign_names="N/A",unit_hostname="nic-nginx-ingress-controller-f6c988865-twql8",uri="/</script>"
+   .
+   .
+   .
+   ```

--- a/examples/custom-resources/waf-plm/ap-dataguard-alarm-policy.yaml
+++ b/examples/custom-resources/waf-plm/ap-dataguard-alarm-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: appprotect.f5.com/v1
+kind: APPolicy
+metadata:
+  name: dataguard-alarm
+spec:
+  policy:
+    applicationLanguage: utf-8
+    blocking-settings:
+      violations:
+      - alarm: true
+        block: false
+        name: VIOL_DATA_GUARD
+    data-guard:
+      creditCardNumbers: true
+      enabled: true
+      enforcementMode: ignore-urls-in-list
+      enforcementUrls: []
+      lastCcnDigitsToExpose: 4
+      lastSsnDigitsToExpose: 4
+      maskData: true
+      usSocialSecurityNumbers: true
+    enforcementMode: blocking
+    name: dataguard-alarm
+    template:
+      name: POLICY_TEMPLATE_NGINX_BASE

--- a/examples/custom-resources/waf-plm/ap-logconf.yaml
+++ b/examples/custom-resources/waf-plm/ap-logconf.yaml
@@ -1,0 +1,11 @@
+apiVersion: appprotect.f5.com/v1
+kind: APLogConf
+metadata:
+  name: logconf
+spec:
+  content:
+    format: default
+    max_message_size: 64k
+    max_request_size: any
+  filter:
+    request_type: all

--- a/examples/custom-resources/waf-plm/syslog.yaml
+++ b/examples/custom-resources/waf-plm/syslog.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: syslog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: syslog
+  template:
+    metadata:
+      labels:
+        app: syslog
+    spec:
+      containers:
+        - name: syslog
+          image: balabit/syslog-ng:4.12.0
+          ports:
+            - containerPort: 514
+            - containerPort: 601
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: syslog-svc
+spec:
+  ports:
+    - port: 514
+      targetPort: 514
+      protocol: TCP
+  selector:
+    app: syslog

--- a/examples/custom-resources/waf-plm/virtual-server.yaml
+++ b/examples/custom-resources/waf-plm/virtual-server.yaml
@@ -1,0 +1,16 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: webapp
+spec:
+  host: webapp.example.com
+  policies:
+  - name: waf-policy
+  upstreams:
+  - name: webapp
+    service: webapp-svc
+    port: 80
+  routes:
+  - path: /
+    action:
+      pass: webapp

--- a/examples/custom-resources/waf-plm/waf-plm.yaml
+++ b/examples/custom-resources/waf-plm/waf-plm.yaml
@@ -5,14 +5,12 @@ metadata:
 spec:
   waf:
     enable: true
-    apBundleSource:
-      type: PLM
-      name: "dataguard-alarm"
-      # namespace: optional
+    # apPolicy references an APPolicy CR by "[<namespace>/]<name>". When NIC is
+    # started with -plm-storage-url, the referenced APPolicy must have been
+    # compiled by PLM (status.bundle.state == ready) and NIC fetches the compiled
+    # bundle from PLM S3 storage.
+    apPolicy: "dataguard-alarm"
     securityLogs:
     - enable: true
-      apLogBundleSource:
-        type: PLM
-        name: "logconf"
-        # namespace: optional
+      apLogConf: "logconf"
       logDest: "syslog:server=syslog-svc.default:514"

--- a/examples/custom-resources/waf-plm/waf-plm.yaml
+++ b/examples/custom-resources/waf-plm/waf-plm.yaml
@@ -1,0 +1,18 @@
+apiVersion: k8s.nginx.org/v1
+kind: Policy
+metadata:
+  name: waf-policy
+spec:
+  waf:
+    enable: true
+    apBundleSource:
+      type: PLM
+      name: "dataguard-alarm"
+      # namespace: optional
+    securityLogs:
+    - enable: true
+      apLogBundleSource:
+        type: PLM
+        name: "logconf"
+        # namespace: optional
+      logDest: "syslog:server=syslog-svc.default:514"

--- a/examples/custom-resources/waf-plm/webapp.yaml
+++ b/examples/custom-resources/waf-plm/webapp.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webapp
+  template:
+    metadata:
+      labels:
+        app: webapp
+    spec:
+      containers:
+      - name: webapp
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webapp-svc
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: webapp

--- a/examples/ingress-resources/waf-plm/README.md
+++ b/examples/ingress-resources/waf-plm/README.md
@@ -8,10 +8,6 @@ PLM owns the `APPolicy` and `APLogConf` lifecycle and publishes the compiled bun
 SeaweedFS. NGINX Ingress Controller (NIC) watches the referenced resources and fetches a
 bundle once its `status.bundle.state` becomes `ready`.
 
-For VirtualServer equivalents, see [custom-resources/waf-plm](../../custom-resources/waf-plm/).
-For sourcing bundles from NGINX Instance Manager or NGINX One Console instead, see
-[waf-management-plane](../waf-management-plane/).
-
 ## Prerequisites
 
 1. Install the F5 WAF Policy Controller (PLM). PLM installs and owns the
@@ -21,7 +17,7 @@ For sourcing bundles from NGINX Instance Manager or NGINX One Console instead, s
 1. Confirm the CRDs are installed and served at `v1`:
 
     ```console
-    kubectl describe crd appolicies.appprotect.f5.com aplogconfs.appprotect.f5.com
+    kubectl describe crd appolicies.appprotect.f5.com aplogconfs.appprotect.f5.com apsignatures.appprotect.f5.com apusersigs.appprotect.f5.com 
     ```
 
 ## Step 1 - Create the PLM Policy and Log Configuration
@@ -121,9 +117,7 @@ For an installation without TLS, use the HTTP endpoint on port `8333` and leave
 `caSecret` and `clientSSLSecret` empty. The endpoint scheme must match how PLM was
 installed: a plaintext `http://` request sent to the TLS port fails.
 
-Because PLM owns the App Protect CRDs, install NIC with `--skip-crds` so it does not
-overwrite them, and create the rest of the CRDs before installation otherwise the NIC pod
-won't become ready.
+Apply the CRDs before installing NIC using `kubectl apply -f ../../../deploy/crds.yaml`. Pass `--skip-crds` when using `helm install`
 
 If `controller.watchNamespace` is restricted, include the namespace holding the
 `APPolicy` and `APLogConf` resources so NIC can watch their status. If

--- a/examples/ingress-resources/waf-plm/README.md
+++ b/examples/ingress-resources/waf-plm/README.md
@@ -1,0 +1,243 @@
+# WAF with F5 WAF Policy Controller (Ingress)
+
+In this example we deploy the NGINX Plus Ingress Controller with F5 WAF for NGINX, where
+the policy and log configuration bundles are compiled by the F5 WAF Policy Controller
+(PLM), and apply WAF protection to an Ingress resource.
+
+PLM owns the `APPolicy` and `APLogConf` lifecycle and publishes the compiled bundles to
+SeaweedFS. NGINX Ingress Controller (NIC) watches the referenced resources and fetches a
+bundle once its `status.bundle.state` becomes `ready`.
+
+For VirtualServer equivalents, see [custom-resources/waf-plm](../../custom-resources/waf-plm/).
+For sourcing bundles from NGINX Instance Manager or NGINX One Console instead, see
+[waf-management-plane](../waf-management-plane/).
+
+## Prerequisites
+
+1. Install the F5 WAF Policy Controller (PLM). PLM installs and owns the
+   `appprotect.f5.com/v1` CRDs (`APPolicy`, `APLogConf`, `APUserSig`, `APSignatures`)
+   and runs the compiler and SeaweedFS bundle store.
+
+1. Confirm the CRDs are installed and served at `v1`:
+
+    ```console
+    kubectl describe crd appolicies.appprotect.f5.com aplogconfs.appprotect.f5.com
+    ```
+
+## Step 1 - Create the PLM Policy and Log Configuration
+
+Create the `APPolicy` and `APLogConf` resources. PLM compiles each resource and publishes
+the resulting bundle to SeaweedFS.
+
+```console
+kubectl apply -f ap-dataguard-alarm-policy.yaml
+kubectl apply -f ap-logconf.yaml
+```
+
+## Step 2 - Verify Both Bundles Are Ready
+
+Check that PLM reports `ready` for both resources. NIC does not fetch a bundle before
+this point.
+
+```console
+kubectl describe appolicy dataguard-alarm
+kubectl describe aplogconf logconf
+```
+
+Each resource reports the compiled bundle under `Status`:
+
+- for appolicy:
+
+   ```text
+   Status:
+   Bundle:
+      Compiler Version:  5.14.0
+      Location:          s3://default/bundles/dataguard-alarm20260807160340-dataguard-alarm-1-1786118620559717186.tgz
+      sha256:            47a6fdcd07b9adafaaa415fa9fd2ab2cab84b54b26a91fd518a4ff5e2dab3f8d
+      Signatures:
+         Attack Signatures:  2026-07-18T13:39:26Z
+         Bot Signatures:     2026-07-16T07:35:37Z
+         Threat Campaigns:   2026-07-13T11:56:06Z
+      State:                ready
+   Observed Generation:    1
+   Observed Policy Name:   dataguard-alarm
+   Policy Location:        s3://default/policies/dataguard-alarm.json
+   Processing:
+      Datetime:     2026-08-07T16:03:46Z
+      Is Compiled:  true
+   ```
+
+- for aplogconf:
+
+   ```text
+   Status:
+   Bundle:
+      Compiler Version:   5.14.0
+      Location:           s3://default/bundles/logconf20260807160340.tgz
+      sha256:             0728d1cc822e32af2b880f49c433f7fe8ef28bd5fcf1761af2be4f04acace9de
+      State:              ready
+   Observed Generation:  1
+   Processing:
+      Datetime:     2026-08-07T16:03:46Z
+      Is Compiled:  true
+   Events:           <none>
+   ```
+
+If a resource never reaches `ready`, inspect the PLM policy-controller and compiler logs
+before continuing.
+
+## Step 3 - Install the Ingress Controller
+
+Deploy NIC with NGINX Plus, App Protect, and PLM storage enabled. PLM storage is
+configured with cluster-wide command-line arguments, which the Helm chart renders from
+`controller.appprotect.plmStorage`:
+
+| Argument | Purpose |
+| --- | --- |
+| `-plm-storage-url` | SeaweedFS S3 endpoint. Enables the PLM integration and makes NIC watch the `appprotect.f5.com/v1` CRDs. |
+| `-plm-storage-credentials-secret` | Secret holding the SeaweedFS admin key under `seaweedfs_admin_secret`. Required. |
+| `-plm-storage-ca-secret` | Optional Secret containing `ca.crt` for TLS verification. |
+| `-plm-storage-client-ssl-secret` | Optional Secret containing `tls.crt` and `tls.key` for mTLS. |
+| `-plm-storage-insecure-skip-verify` | Disables TLS verification. Development and testing only. |
+
+Secret references use the `namespace/name` format. For a PLM installation with TLS and
+mTLS enabled, the Helm values are:
+
+```yaml
+controller:
+  nginxplus: true
+  appprotect:
+    enable: true
+    v5: true
+    plmStorage:
+      url: "https://<plm_release>-f5-waf-seaweed-filer.<plm_namespace>.svc.cluster.local:9333"
+      credentialsSecret: "<plm_namespace>/<plm_release>-f5-waf-seaweedfs-auth"
+      caSecret: "<plm_namespace>/<plm_release>-f5-waf-seaweedfs-ca-cert"
+      clientSSLSecret: "<plm_namespace>/<plm_release>-f5-waf-seaweedfs-client-cert"
+      insecureSkipVerify: false
+```
+
+For an installation without TLS, use the HTTP endpoint on port `8333` and leave
+`caSecret` and `clientSSLSecret` empty. The endpoint scheme must match how PLM was
+installed: a plaintext `http://` request sent to the TLS port fails.
+
+Because PLM owns the App Protect CRDs, install NIC with `--skip-crds` so it does not
+overwrite them, and create the rest of the CRDs before installation otherwise the NIC pod
+won't become ready.
+
+If `controller.watchNamespace` is restricted, include the namespace holding the
+`APPolicy` and `APLogConf` resources so NIC can watch their status. If
+`controller.watchSecretNamespace` is restricted, include the namespace holding the
+storage Secrets so NIC observes their rotation.
+
+Then save the public IP address and HTTP port of the Ingress Controller into shell
+variables:
+
+```console
+IC_IP=XXX.YYY.ZZZ.III
+IC_HTTP_PORT=<port number>
+```
+
+## Step 4 - Deploy the Application and WAF Policy
+
+1. Create the application deployments and services:
+
+    ```console
+    kubectl apply -f cafe.yaml
+    ```
+
+1. Create the syslog service and pod for the security logs:
+
+    ```console
+    kubectl apply -f syslog.yaml
+    ```
+
+1. Create the WAF policy:
+
+    ```console
+    kubectl apply -f waf-plm.yaml
+    ```
+
+PLM sources do not use `url`, `secret`, `trustedCertSecret`, `enablePolling`,
+`pollInterval`, or `verifyChecksum`. NIC reads the bundle location and SHA-256 from the
+referenced resource status, and bundle updates are driven by status watch events rather
+than polling.
+
+## Step 5 - Check the Policy Status
+
+The Policy becomes valid once NIC has fetched both bundles from SeaweedFS:
+
+```console
+kubectl describe policy waf-policy
+```
+
+```text
+Events:
+  Type    Reason          Message
+  ----    ------          -------
+  Normal  AddedOrUpdated  Policy default/waf-policy was added or updated
+```
+
+A `BundleFetchFailed` warning means NIC reached the fetch stage but could not retrieve
+the bundle. Verify the storage endpoint, credentials, and TLS settings from Step 3.
+
+## Step 6 - Check policy and logconf bundles
+
+Optional but you can check for the presence of compiled bundles in pod file-system
+
+```console
+kubectl exec -it -n <NIC_NAMESPACE> <ANY_NIC_POD> -c nginx-ingress -- ls -ltr /etc/app_protect/bundles
+```
+
+```text
+-rw------- 1 nginx nginx 1901282 Aug  7 16:26 fetched_default_waf-policy_policy.tgz
+-rw------- 1 nginx nginx    1655 Aug  7 16:26 fetched_default_waf-policy_log_0.tgz
+```
+
+## Step 7 - Configure Load Balancing
+
+Create the Ingress resource, which references the `waf-policy` created in Step 4 through
+the `nginx.com/policies` annotation:
+
+```console
+kubectl apply -f cafe-ingress.yaml
+```
+
+## Step 8 - Test the Application
+
+1. Send a request to the application:
+
+    ```console
+    curl --resolve cafe.example.com:$IC_HTTP_PORT:$IC_IP http://cafe.example.com:$IC_HTTP_PORT/coffee
+    ```
+
+    ```text
+    Server address: 10.76.1.11:80
+    Server name: coffee-55c788878b-j4tgm
+    Date: 10/Aug/2026:11:05:10 +0000
+    URI: /coffee
+    Request ID: 20734e6c3a0ec54874d984c32804c266
+    ```
+
+1. Send a request that triggers the data guard violation.
+
+    ```console
+    curl --resolve cafe.example.com:$IC_HTTP_PORT:$IC_IP "http://cafe.example.com:$IC_HTTP_PORT/coffee/</script>"
+    ```
+
+    ```text
+    <html><head><title>Request Rejected</title></head><body>The requested URL was rejected. Please consult with your administrator.<br><br>Your support ID is: 3607539252134092173<br><br><a href='javascript:history.back();'>[Go Back]</a></body></html>% 
+    ```
+
+1. Check the security logs in the syslog pod:
+
+    ```console
+    kubectl exec -it <SYSLOG_POD> -- cat /var/log/messages
+    ```
+
+    ```text
+    Aug 10 11:05:15 nic-nginx-ingress-controller-f6c988865-9b84b ASM:attack_type="Non-browser Client,Abuse of Functionality,Cross Site Scripting (XSS),Other Application Activity",blocking_exception_reason="N/A",date_time="2026-08-10 11:05:15",dest_port="80",ip_client="87.192.103.246",is_truncated="false",method="GET",policy_name="dataguard-alarm",protocol="HTTP",request_status="blocked",response_code="0",severity="Critical",sig_cves="N/A",sig_ids="200000093",sig_names="XSS script tag end (URI)",sig_set_names="{High Accuracy Signatures;Cross Site Scripting Signatures}",src_port="60437",sub_violations="N/A",support_id="3607539252134092173",threat_campaign_names="N/A",unit_hostname="nic-nginx-ingress-controller-f6c988865-9b84b",uri="/coffee/</script>"
+    .
+    .
+    .
+    ```

--- a/examples/ingress-resources/waf-plm/ap-dataguard-alarm-policy.yaml
+++ b/examples/ingress-resources/waf-plm/ap-dataguard-alarm-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: appprotect.f5.com/v1
+kind: APPolicy
+metadata:
+  name: dataguard-alarm
+spec:
+  policy:
+    applicationLanguage: utf-8
+    blocking-settings:
+      violations:
+      - alarm: true
+        block: false
+        name: VIOL_DATA_GUARD
+    data-guard:
+      creditCardNumbers: true
+      enabled: true
+      enforcementMode: ignore-urls-in-list
+      enforcementUrls: []
+      lastCcnDigitsToExpose: 4
+      lastSsnDigitsToExpose: 4
+      maskData: true
+      usSocialSecurityNumbers: true
+    enforcementMode: blocking
+    name: dataguard-alarm
+    template:
+      name: POLICY_TEMPLATE_NGINX_BASE

--- a/examples/ingress-resources/waf-plm/ap-logconf.yaml
+++ b/examples/ingress-resources/waf-plm/ap-logconf.yaml
@@ -1,0 +1,11 @@
+apiVersion: appprotect.f5.com/v1
+kind: APLogConf
+metadata:
+  name: logconf
+spec:
+  content:
+    format: default
+    max_message_size: 64k
+    max_request_size: any
+  filter:
+    request_type: all

--- a/examples/ingress-resources/waf-plm/cafe-ingress.yaml
+++ b/examples/ingress-resources/waf-plm/cafe-ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cafe-ingress
+  annotations:
+    nginx.com/policies: "waf-policy"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: cafe.example.com
+    http:
+      paths:
+      - path: /tea
+        pathType: Prefix
+        backend:
+          service:
+            name: tea-svc
+            port:
+              number: 80
+      - path: /coffee
+        pathType: Prefix
+        backend:
+          service:
+            name: coffee-svc
+            port:
+              number: 80

--- a/examples/ingress-resources/waf-plm/cafe.yaml
+++ b/examples/ingress-resources/waf-plm/cafe.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coffee
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: coffee
+  template:
+    metadata:
+      labels:
+        app: coffee
+    spec:
+      containers:
+      - name: coffee
+        image: nginxdemos/hello:plain-text
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coffee-svc
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: coffee
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tea
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: tea
+  template:
+    metadata:
+      labels:
+        app: tea
+    spec:
+      containers:
+      - name: tea
+        image: nginxdemos/hello:plain-text
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tea-svc
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: tea

--- a/examples/ingress-resources/waf-plm/syslog.yaml
+++ b/examples/ingress-resources/waf-plm/syslog.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: syslog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: syslog
+  template:
+    metadata:
+      labels:
+        app: syslog
+    spec:
+      containers:
+        - name: syslog
+          image: balabit/syslog-ng:4.12.0
+          ports:
+            - containerPort: 514
+            - containerPort: 601
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: syslog-svc
+spec:
+  ports:
+    - port: 514
+      targetPort: 514
+      protocol: TCP
+  selector:
+    app: syslog

--- a/examples/ingress-resources/waf-plm/waf-plm.yaml
+++ b/examples/ingress-resources/waf-plm/waf-plm.yaml
@@ -5,14 +5,12 @@ metadata:
 spec:
   waf:
     enable: true
-    apBundleSource:
-      type: PLM
-      name: "dataguard-alarm"
-      # namespace: "plm"
+    # apPolicy references an APPolicy CR by "[<namespace>/]<name>". When NIC is
+    # started with -plm-storage-url, the referenced APPolicy must have been
+    # compiled by PLM (status.bundle.state == ready) and NIC fetches the compiled
+    # bundle from PLM S3 storage.
+    apPolicy: "dataguard-alarm"
     securityLogs:
     - enable: true
-      apLogBundleSource:
-        type: PLM
-        name: "logconf"
-        # namespace: "plm"
+      apLogConf: "logconf"
       logDest: "syslog:server=syslog-svc.default:514"

--- a/examples/ingress-resources/waf-plm/waf-plm.yaml
+++ b/examples/ingress-resources/waf-plm/waf-plm.yaml
@@ -1,0 +1,18 @@
+apiVersion: k8s.nginx.org/v1
+kind: Policy
+metadata:
+  name: waf-policy
+spec:
+  waf:
+    enable: true
+    apBundleSource:
+      type: PLM
+      name: "dataguard-alarm"
+      # namespace: "plm"
+    securityLogs:
+    - enable: true
+      apLogBundleSource:
+        type: PLM
+        name: "logconf"
+        # namespace: "plm"
+      logDest: "syslog:server=syslog-svc.default:514"

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -178,6 +178,10 @@ type StaticConfigParams struct {
 	NginxVersion                   nginx.Version
 	AppProtectBundlePath           string
 	DefaultCABundle                string
+	// PLMEnabled reports whether WAF bundles are sourced from the F5 WAF Policy
+	// Controller. When true, apPolicy/apLogConf references resolve to PLM bundles
+	// instead of in-pod compiled App Protect resources.
+	PLMEnabled bool
 }
 
 // GlobalConfigParams holds global configuration parameters. For now, it only holds listeners.

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -345,6 +345,7 @@ func generateNginxCfg(ncp NginxCfgParams) (version1.IngressNginxConfig, Warnings
 				defaultCABundle: ncp.staticParams.DefaultCABundle,
 				replicas:        ncp.ingressControllerReplicas,
 				oidcPolicyName:  "",
+				plmEnabled:      ncp.staticParams.PLMEnabled,
 			},
 			bundleValidator,
 		)

--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -94,12 +94,12 @@ type policyOptions struct {
 	defaultCABundle string
 	replicas        int
 	oidcPolicyName  string
-	// plmEnabled routes apPolicy/apLogConf references to PLM-fetched bundles.
-	plmEnabled bool
 	// oidcConfig holds the already-built OIDC config from the first route or spec that defined
 	// this OIDC policy. It is reused by addOIDCConfig() when the same policy name is encountered
 	// on subsequent routes.
 	oidcConfig *version2.OIDC
+	// plmEnabled routes apPolicy/apLogConf references to PLM-fetched bundles.
+	plmEnabled bool
 }
 
 func newPoliciesConfig(bv bundleValidator) *policiesCfg {

--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -94,6 +94,8 @@ type policyOptions struct {
 	defaultCABundle string
 	replicas        int
 	oidcPolicyName  string
+	// plmEnabled routes apPolicy/apLogConf references to PLM-fetched bundles.
+	plmEnabled bool
 	// oidcConfig holds the already-built OIDC config from the first route or spec that defined
 	// this OIDC policy. It is reused by addOIDCConfig() when the same policy name is encountered
 	// on subsequent routes.
@@ -823,6 +825,7 @@ func (p *policiesCfg) addWAFConfig(
 	polKey string,
 	polNamespace string,
 	apResources *appProtectPolicyResources,
+	plmEnabled bool,
 ) *validationResults {
 	l := nl.LoggerFromContext(ctx)
 	res := newValidationResults()
@@ -837,7 +840,11 @@ func (p *policiesCfg) addWAFConfig(
 		p.WAF = &version2.WAF{Enable: "off"}
 	}
 
-	if waf.ApPolicy != "" {
+	// Under PLM, apPolicy names a PLM-compiled APPolicy whose bundle is fetched to
+	// disk, so it resolves through the bundle path rather than apResources.
+	usePLMPolicyBundle := plmEnabled && waf.ApPolicy != ""
+
+	if waf.ApPolicy != "" && !plmEnabled {
 		apPolKey := waf.ApPolicy
 		if !nsutils.HasNamespace(apPolKey) {
 			apPolKey = fmt.Sprintf("%v/%v", polNamespace, apPolKey)
@@ -861,7 +868,7 @@ func (p *policiesCfg) addWAFConfig(
 		p.WAF.ApBundle = bundlePath
 	}
 
-	if waf.ApBundleSource != nil {
+	if waf.ApBundleSource != nil || usePLMPolicyBundle {
 		// Bundle was written to disk by syncPolicy() before config generation runs.
 		ns, name, _ := helpers.ParseNamespaceName(polKey)
 		filename := wafbundle.FetchedBundleFilename(ns, name, "policy")
@@ -885,7 +892,9 @@ func (p *policiesCfg) addWAFConfig(
 		for idx, loco := range waf.SecurityLogs {
 			logDest := generateString(loco.LogDest, defaultLogOutput)
 
-			if loco.ApLogConf != "" {
+			usePLMLogBundle := plmEnabled && loco.ApLogConf != ""
+
+			if loco.ApLogConf != "" && !plmEnabled {
 				logConfKey := loco.ApLogConf
 				if !nsutils.HasNamespace(logConfKey) {
 					logConfKey = fmt.Sprintf("%v/%v", polNamespace, logConfKey)
@@ -908,7 +917,7 @@ func (p *policiesCfg) addWAFConfig(
 				}
 			}
 
-			if loco.ApLogBundleSource != nil {
+			if loco.ApLogBundleSource != nil || usePLMLogBundle {
 				ns, name, _ := helpers.ParseNamespaceName(polKey)
 				filename := wafbundle.FetchedBundleFilename(ns, name, fmt.Sprintf("log_%d", idx))
 				logBundle, err := p.BundleValidator.validate(filename)
@@ -1278,7 +1287,7 @@ func generatePolicies(
 			case pol.Spec.APIKey != nil:
 				res = config.addAPIKeyConfig(pol.Spec.APIKey, key, polNamespace, ownerDetails, policyOpts.secretRefs)
 			case pol.Spec.WAF != nil:
-				res = config.addWAFConfig(ctx, pol.Spec.WAF, key, polNamespace, policyOpts.apResources)
+				res = config.addWAFConfig(ctx, pol.Spec.WAF, key, polNamespace, policyOpts.apResources, policyOpts.plmEnabled)
 			case pol.Spec.Cache != nil:
 				res = config.addCacheConfig(pol.Spec.Cache, key, ownerDetails)
 			case pol.Spec.CORS != nil:

--- a/internal/configs/policy_test.go
+++ b/internal/configs/policy_test.go
@@ -5176,9 +5176,48 @@ func TestAddWafConfig(t *testing.T) {
 
 	for _, test := range tests {
 		polCfg := newPoliciesConfig(&fakeBV)
-		result := polCfg.addWAFConfig(context.Background(), test.wafInput, test.polKey, test.polNamespace, test.apResources)
+		result := polCfg.addWAFConfig(context.Background(), test.wafInput, test.polKey, test.polNamespace, test.apResources, false)
 		if diff := cmp.Diff(test.expected.warnings, result.warnings); diff != "" {
 			t.Errorf("policiesCfg.addWAFConfig() '%v' mismatch (-want +got):\n%s", test.msg, diff)
 		}
+	}
+}
+
+// Under PLM an apPolicy/apLogConf resolves to the fetched bundle path instead of an
+// in-pod compiled AP resource. apResources is intentionally empty to prove resolution
+// does not depend on the in-pod compilation lookup.
+func TestAddWafConfigPLMResolvesAPRefs(t *testing.T) {
+	t.Parallel()
+
+	waf := &conf_v1.WAF{
+		Enable:   true,
+		ApPolicy: "default/dataguard-alarm",
+		SecurityLogs: []*conf_v1.SecurityLog{
+			{ApLogConf: "default/logconf", LogDest: "syslog:server=syslog-svc:514"},
+		},
+	}
+	apResources := &appProtectPolicyResources{
+		Policies: map[string]string{},
+		LogConfs: map[string]string{},
+	}
+
+	polCfg := newPoliciesConfig(&fakeBV)
+	result := polCfg.addWAFConfig(context.Background(), waf, "default/waf-policy", "default", apResources, true)
+
+	if result.isError {
+		t.Errorf("addWAFConfig() isError = true, want false; warnings: %v", result.warnings)
+	}
+	if len(result.warnings) != 0 {
+		t.Errorf("addWAFConfig() unexpected warnings: %v", result.warnings)
+	}
+	if polCfg.WAF.ApPolicy != "" {
+		t.Errorf("ApPolicy = %q, want empty under PLM", polCfg.WAF.ApPolicy)
+	}
+	if want := "/fake/bundle/path/fetched_default_waf-policy_policy.tgz"; polCfg.WAF.ApBundle != want {
+		t.Errorf("ApBundle = %q, want %q", polCfg.WAF.ApBundle, want)
+	}
+	wantLog := []string{"/fake/bundle/path/fetched_default_waf-policy_log_0.tgz syslog:server=syslog-svc:514"}
+	if diff := cmp.Diff(wantLog, polCfg.WAF.ApLogConf); diff != "" {
+		t.Errorf("ApLogConf mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -306,6 +306,7 @@ type virtualServerConfigurator struct {
 	DynamicWeightChangesReload bool
 	bundleValidator            bundleValidator
 	IngressControllerReplicas  int
+	plmEnabled                 bool
 }
 
 func (vsc *virtualServerConfigurator) addWarningf(obj runtime.Object, msgFmt string, args ...interface{}) {
@@ -348,6 +349,7 @@ func newVirtualServerConfigurator(
 		CABundlePath:               staticParams.DefaultCABundle,
 		DynamicWeightChangesReload: staticParams.DynamicWeightChangesReload,
 		bundleValidator:            bundleValidator,
+		plmEnabled:                 staticParams.PLMEnabled,
 	}
 }
 
@@ -428,6 +430,7 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 		apResources:     apResources,
 		defaultCABundle: vsc.CABundlePath,
 		replicas:        vsc.IngressControllerReplicas,
+		plmEnabled:      vsc.plmEnabled,
 	}
 
 	ownerDetails := policyOwnerDetails{

--- a/internal/configs/wafbundle/bundle.go
+++ b/internal/configs/wafbundle/bundle.go
@@ -48,7 +48,10 @@ const (
 	LogProfileBundle
 )
 
-// SourceType mirrors conf_v1.BundleSourceType without importing it here.
+// SourceType is the internal discriminator used by the fetcher to dispatch requests.
+// The HTTPS/NIM/N1C values mirror conf_v1.BundleSourceType. PLM has no public CRD
+// counterpart; it is set at request-build time when NIC resolves an
+// apPolicy/apLogConf reference under -plm-storage-url.
 type SourceType string
 
 const (
@@ -59,6 +62,7 @@ const (
 	// SourceTypeN1C fetches bundles from NGINX One Console.
 	SourceTypeN1C SourceType = "N1C"
 	// SourceTypePLM fetches bundles from the SeaweedFS S3-compatible object store.
+	// Internal only — not surfaced on the BundleSource CRD.
 	SourceTypePLM SourceType = "PLM"
 )
 

--- a/internal/k8s/appprotect_waf.go
+++ b/internal/k8s/appprotect_waf.go
@@ -292,35 +292,34 @@ func isMatchingResourceRef(ownerNs, resRef, key string) bool {
 	return resRef == key
 }
 
-// getPLMPoliciesForAppProtectPolicy returns the WAF Policies whose apBundleSource is a
-// PLM source referencing the APPolicy identified by key (namespace/name). Used to
-// re-enqueue those Policies when the APPolicy status changes (event-driven PLM refresh).
-func getPLMPoliciesForAppProtectPolicy(pols []*conf_v1.Policy, key string) []*conf_v1.Policy {
+// getPLMPoliciesForAppProtectPolicy returns the WAF Policies whose apPolicy
+// reference (under PLM) points at the APPolicy identified by key. Used to re-enqueue
+// those Policies when the APPolicy status changes (event-driven PLM refresh).
+func (lbc *LoadBalancerController) getPLMPoliciesForAppProtectPolicy(pols []*conf_v1.Policy, key string) []*conf_v1.Policy {
 	var policies []*conf_v1.Policy
 	for _, pol := range pols {
 		if pol.Spec.WAF == nil {
 			continue
 		}
-		bs := pol.Spec.WAF.ApBundleSource
-		if bs != nil && bs.Type == conf_v1.BundleSourceTypePLM && plmRefMatchesKey(pol.Namespace, bs, key) {
+		ns, name, ok := lbc.effectivePLMPolicyRef(pol)
+		if ok && ns+"/"+name == key {
 			policies = append(policies, pol)
 		}
 	}
 	return policies
 }
 
-// getPLMPoliciesForAppProtectLogConf returns the WAF Policies whose securityLogs contain a
-// PLM apLogBundleSource referencing the APLogConf identified by key (namespace/name).
-func getPLMPoliciesForAppProtectLogConf(pols []*conf_v1.Policy, key string) []*conf_v1.Policy {
+// getPLMPoliciesForAppProtectLogConf returns the WAF Policies whose securityLogs
+// apLogConf reference (under PLM) points at the APLogConf identified by key.
+func (lbc *LoadBalancerController) getPLMPoliciesForAppProtectLogConf(pols []*conf_v1.Policy, key string) []*conf_v1.Policy {
 	var policies []*conf_v1.Policy
 	for _, pol := range pols {
 		if pol.Spec.WAF == nil {
 			continue
 		}
 		for _, sl := range pol.Spec.WAF.SecurityLogs {
-			if sl != nil && sl.ApLogBundleSource != nil &&
-				sl.ApLogBundleSource.Type == conf_v1.BundleSourceTypePLM &&
-				plmRefMatchesKey(pol.Namespace, sl.ApLogBundleSource, key) {
+			ns, name, ok := lbc.effectivePLMLogRef(sl, pol.Namespace)
+			if ok && ns+"/"+name == key {
 				policies = append(policies, pol)
 				break
 			}
@@ -337,24 +336,13 @@ func bundleStatusChanged(oldObj, newObj *unstructured.Unstructured) bool {
 	return !reflect.DeepEqual(oldBundle, newBundle)
 }
 
-// plmRefMatchesKey reports whether a PLM BundleSource references the APPolicy/APLogConf
-// identified by key. The reference is bs.Name in bs.Namespace, defaulting to
-// the owning Policy's namespace when unset.
-func plmRefMatchesKey(ownerNs string, bs *conf_v1.BundleSource, key string) bool {
-	ns := bs.Namespace
-	if ns == "" {
-		ns = ownerNs
-	}
-	return ns+"/"+bs.Name == key
-}
-
 // enqueuePLMPoliciesForAppPolicy re-enqueues every PLM WAF Policy that references the
 // APPolicy identified by key. No-op when PLM is disabled.
 func (lbc *LoadBalancerController) enqueuePLMPoliciesForAppPolicy(key string) {
 	if !lbc.plmEnabled {
 		return
 	}
-	for _, pol := range getPLMPoliciesForAppProtectPolicy(lbc.getAllPolicies(), key) {
+	for _, pol := range lbc.getPLMPoliciesForAppProtectPolicy(lbc.getAllPolicies(), key) {
 		nl.Debugf(lbc.Logger, "Re-enqueuing PLM policy %s/%s due to APPolicy %s change", pol.Namespace, pol.Name, key)
 		lbc.AddSyncQueue(pol)
 	}
@@ -366,7 +354,7 @@ func (lbc *LoadBalancerController) enqueuePLMPoliciesForAppLogConf(key string) {
 	if !lbc.plmEnabled {
 		return
 	}
-	for _, pol := range getPLMPoliciesForAppProtectLogConf(lbc.getAllPolicies(), key) {
+	for _, pol := range lbc.getPLMPoliciesForAppProtectLogConf(lbc.getAllPolicies(), key) {
 		nl.Debugf(lbc.Logger, "Re-enqueuing PLM policy %s/%s due to APLogConf %s change", pol.Namespace, pol.Name, key)
 		lbc.AddSyncQueue(pol)
 	}
@@ -384,7 +372,7 @@ func (lbc *LoadBalancerController) enqueuePoliciesUsingPLMStorage(key string) {
 	if !lbc.plmEnabled || !lbc.isConfiguredPLMStorageSecret(key) {
 		return
 	}
-	for _, pol := range getPoliciesUsingPLMStorage(lbc.getAllPolicies()) {
+	for _, pol := range lbc.getPoliciesUsingPLMStorage(lbc.getAllPolicies()) {
 		if !lbc.policyNeedsPLMBundleFetch(pol) {
 			continue
 		}
@@ -393,18 +381,21 @@ func (lbc *LoadBalancerController) enqueuePoliciesUsingPLMStorage(key string) {
 	}
 }
 
-func getPoliciesUsingPLMStorage(policies []*conf_v1.Policy) []*conf_v1.Policy {
+// getPoliciesUsingPLMStorage returns WAF Policies whose bundle references require the
+// configured PLM S3 storage. Under -plm-storage-url this is any Policy with an
+// apPolicy or securityLogs.apLogConf field.
+func (lbc *LoadBalancerController) getPoliciesUsingPLMStorage(policies []*conf_v1.Policy) []*conf_v1.Policy {
 	var result []*conf_v1.Policy
 	for _, pol := range policies {
 		if pol.Spec.WAF == nil {
 			continue
 		}
-		if pol.Spec.WAF.ApBundleSource != nil && pol.Spec.WAF.ApBundleSource.Type == conf_v1.BundleSourceTypePLM {
+		if _, _, ok := lbc.effectivePLMPolicyRef(pol); ok {
 			result = append(result, pol)
 			continue
 		}
 		for _, sl := range pol.Spec.WAF.SecurityLogs {
-			if sl != nil && sl.ApLogBundleSource != nil && sl.ApLogBundleSource.Type == conf_v1.BundleSourceTypePLM {
+			if _, _, ok := lbc.effectivePLMLogRef(sl, pol.Namespace); ok {
 				result = append(result, pol)
 				break
 			}
@@ -423,18 +414,10 @@ func (lbc *LoadBalancerController) addWAFPolicyRefs(
 		if pol.Spec.WAF == nil {
 			continue
 		}
+		// Under PLM these references resolve to PLM-compiled bundles fetched by
+		// syncWAFBundleSource, so there are no in-pod AP resources to collect here.
 		if lbc.plmEnabled {
-			if pol.Spec.WAF.ApPolicy != "" {
-				return fmt.Errorf("WAF policy %q uses apPolicy, which is not supported when PLM is enabled", pol.Namespace+"/"+pol.Name)
-			}
-			if pol.Spec.WAF.SecurityLog != nil && pol.Spec.WAF.SecurityLog.ApLogConf != "" {
-				return fmt.Errorf("WAF policy %q uses securityLog.apLogConf, which is not supported when PLM is enabled", pol.Namespace+"/"+pol.Name)
-			}
-			for _, log := range pol.Spec.WAF.SecurityLogs {
-				if log != nil && log.ApLogConf != "" {
-					return fmt.Errorf("WAF policy %q uses securityLogs.apLogConf, which is not supported when PLM is enabled", pol.Namespace+"/"+pol.Name)
-				}
-			}
+			continue
 		}
 
 		if pol.Spec.WAF.ApPolicy != "" {

--- a/internal/k8s/appprotect_waf_test.go
+++ b/internal/k8s/appprotect_waf_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -248,28 +247,26 @@ func TestAddWAFPolicyRefs(t *testing.T) {
 	}
 }
 
-func TestAddWAFPolicyRefs_PLMRejectsRawReferences(t *testing.T) {
+// apPolicy/apLogConf references resolve to PLM bundles rather than in-pod AP resources,
+// so addWAFPolicyRefs must accept them and collect nothing.
+func TestAddWAFPolicyRefs_PLMAcceptsAPRefs(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		waf     *conf_v1.WAF
-		wantErr string
+		name string
+		waf  *conf_v1.WAF
 	}{
 		{
-			name:    "apPolicy",
-			waf:     &conf_v1.WAF{ApPolicy: "raw-policy"},
-			wantErr: "apPolicy",
+			name: "apPolicy",
+			waf:  &conf_v1.WAF{ApPolicy: "raw-policy"},
 		},
 		{
-			name:    "deprecated security log apLogConf",
-			waf:     &conf_v1.WAF{SecurityLog: &conf_v1.SecurityLog{ApLogConf: "raw-log"}},
-			wantErr: "securityLog.apLogConf",
+			name: "deprecated security log apLogConf",
+			waf:  &conf_v1.WAF{SecurityLog: &conf_v1.SecurityLog{ApLogConf: "raw-log"}},
 		},
 		{
-			name:    "security logs apLogConf",
-			waf:     &conf_v1.WAF{SecurityLogs: []*conf_v1.SecurityLog{{ApLogConf: "raw-log"}}},
-			wantErr: "securityLogs.apLogConf",
+			name: "security logs apLogConf",
+			waf:  &conf_v1.WAF{SecurityLogs: []*conf_v1.SecurityLog{{ApLogConf: "raw-log"}}},
 		},
 	}
 
@@ -282,11 +279,167 @@ func TestAddWAFPolicyRefs_PLMRejectsRawReferences(t *testing.T) {
 				Spec:       conf_v1.PolicySpec{WAF: tc.waf},
 			}}
 
-			err := lbc.addWAFPolicyRefs(map[string]*unstructured.Unstructured{}, map[string]*unstructured.Unstructured{}, policies)
-			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
-				t.Errorf("addWAFPolicyRefs() error = %v, want error containing %q", err, tc.wantErr)
+			apPolRefs := map[string]*unstructured.Unstructured{}
+			logConfRefs := map[string]*unstructured.Unstructured{}
+			if err := lbc.addWAFPolicyRefs(apPolRefs, logConfRefs, policies); err != nil {
+				t.Errorf("addWAFPolicyRefs() unexpected error = %v", err)
+			}
+			if len(apPolRefs) != 0 || len(logConfRefs) != 0 {
+				t.Errorf("addWAFPolicyRefs() collected refs %v / %v, want none", apPolRefs, logConfRefs)
 			}
 		})
+	}
+}
+
+func TestEffectivePLMPolicyRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		plmEnabled    bool
+		waf           *conf_v1.WAF
+		wantOK        bool
+		wantName      string
+		wantNamespace string
+	}{
+		{
+			name:       "plm off leaves apPolicy unresolved",
+			plmEnabled: false,
+			waf:        &conf_v1.WAF{ApPolicy: "default/dataguard-alarm"},
+			wantOK:     false,
+		},
+		{
+			name:          "qualified apPolicy keeps its namespace",
+			plmEnabled:    true,
+			waf:           &conf_v1.WAF{ApPolicy: "plm-ns/dataguard-alarm"},
+			wantOK:        true,
+			wantName:      "dataguard-alarm",
+			wantNamespace: "plm-ns",
+		},
+		{
+			name:          "bare apPolicy defaults to the policy namespace",
+			plmEnabled:    true,
+			waf:           &conf_v1.WAF{ApPolicy: "dataguard-alarm"},
+			wantOK:        true,
+			wantName:      "dataguard-alarm",
+			wantNamespace: "default",
+		},
+		{
+			name:       "no apPolicy set",
+			plmEnabled: true,
+			waf:        &conf_v1.WAF{},
+			wantOK:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			lbc := &LoadBalancerController{plmEnabled: tc.plmEnabled}
+			pol := &conf_v1.Policy{
+				ObjectMeta: meta_v1.ObjectMeta{Namespace: "default", Name: "waf-policy"},
+				Spec:       conf_v1.PolicySpec{WAF: tc.waf},
+			}
+
+			ns, name, ok := lbc.effectivePLMPolicyRef(pol)
+			if ok != tc.wantOK {
+				t.Fatalf("effectivePLMPolicyRef() ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if name != tc.wantName {
+				t.Errorf("Name = %q, want %q", name, tc.wantName)
+			}
+			if ns != tc.wantNamespace {
+				t.Errorf("Namespace = %q, want %q", ns, tc.wantNamespace)
+			}
+		})
+	}
+}
+
+func TestEffectivePLMLogRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		plmEnabled    bool
+		securityLog   *conf_v1.SecurityLog
+		wantOK        bool
+		wantName      string
+		wantNamespace string
+	}{
+		{
+			name:        "nil security log",
+			plmEnabled:  true,
+			securityLog: nil,
+			wantOK:      false,
+		},
+		{
+			name:        "plm off leaves apLogConf unresolved",
+			plmEnabled:  false,
+			securityLog: &conf_v1.SecurityLog{ApLogConf: "default/logconf"},
+			wantOK:      false,
+		},
+		{
+			name:          "bare apLogConf defaults to the policy namespace",
+			plmEnabled:    true,
+			securityLog:   &conf_v1.SecurityLog{ApLogConf: "logconf"},
+			wantOK:        true,
+			wantName:      "logconf",
+			wantNamespace: "default",
+		},
+		{
+			name:          "qualified apLogConf keeps its namespace",
+			plmEnabled:    true,
+			securityLog:   &conf_v1.SecurityLog{ApLogConf: "plm-ns/logconf"},
+			wantOK:        true,
+			wantName:      "logconf",
+			wantNamespace: "plm-ns",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			lbc := &LoadBalancerController{plmEnabled: tc.plmEnabled}
+
+			ns, name, ok := lbc.effectivePLMLogRef(tc.securityLog, "default")
+			if ok != tc.wantOK {
+				t.Fatalf("effectivePLMLogRef() ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if name != tc.wantName {
+				t.Errorf("Name = %q, want %q", name, tc.wantName)
+			}
+			if ns != tc.wantNamespace {
+				t.Errorf("Namespace = %q, want %q", ns, tc.wantNamespace)
+			}
+		})
+	}
+}
+
+// An apPolicy reference must re-enqueue its Policy on APPolicy status changes, otherwise
+// PLM bundle updates would never reach a policy still using that field.
+func TestGetPLMPoliciesForAppProtectPolicy_APPolicyRef(t *testing.T) {
+	t.Parallel()
+
+	apPolicyPol := &conf_v1.Policy{
+		ObjectMeta: meta_v1.ObjectMeta{Namespace: "default", Name: "waf-policy"},
+		Spec:       conf_v1.PolicySpec{WAF: &conf_v1.WAF{ApPolicy: "dataguard-alarm"}},
+	}
+	policies := []*conf_v1.Policy{apPolicyPol}
+
+	lbcOn := &LoadBalancerController{plmEnabled: true}
+	if got := lbcOn.getPLMPoliciesForAppProtectPolicy(policies, "default/dataguard-alarm"); len(got) != 1 {
+		t.Errorf("with PLM enabled got %d policies, want 1", len(got))
+	}
+
+	lbcOff := &LoadBalancerController{plmEnabled: false}
+	if got := lbcOff.getPLMPoliciesForAppProtectPolicy(policies, "default/dataguard-alarm"); got != nil {
+		t.Errorf("with PLM disabled got %v, want nil", got)
 	}
 }
 
@@ -316,9 +469,8 @@ func TestResolvePLMBundleStatus_ReadsInformerStore(t *testing.T) {
 		},
 	}
 	pol := &conf_v1.Policy{ObjectMeta: meta_v1.ObjectMeta{Namespace: "default", Name: "waf-policy"}}
-	bs := &conf_v1.BundleSource{Name: "compiled-policy", Namespace: "plm"}
 
-	got := lbc.resolvePLMBundleStatus(pol, bs, wafbundle.PolicyBundle)
+	got := lbc.resolvePLMBundleStatus(pol, "plm", "compiled-policy", wafbundle.PolicyBundle)
 	if got == nil {
 		t.Fatal("resolvePLMBundleStatus() = nil, want ready bundle status")
 	}
@@ -515,36 +667,29 @@ func TestGetWAFPoliciesForAppProtectLogConf(t *testing.T) {
 func TestGetPLMPoliciesForAppProtectPolicy(t *testing.T) {
 	t.Parallel()
 
-	// PLM source with an explicit namespace on the ref.
+	// PLM source with an explicit namespace on the apPolicy ref.
 	plmExplicitNs := &conf_v1.Policy{
 		ObjectMeta: meta_v1.ObjectMeta{Namespace: "apps"},
 		Spec: conf_v1.PolicySpec{
 			WAF: &conf_v1.WAF{
-				Enable: true,
-				ApBundleSource: &conf_v1.BundleSource{
-					Type:      conf_v1.BundleSourceTypePLM,
-					Name:      "ap-pol",
-					Namespace: "plm-policies",
-				},
+				Enable:   true,
+				ApPolicy: "plm-policies/ap-pol",
 			},
 		},
 	}
 
-	// PLM source without a namespace on the ref; defaults to the Policy's own namespace.
+	// PLM source without a namespace; defaults to the Policy's own namespace.
 	plmDefaultNs := &conf_v1.Policy{
 		ObjectMeta: meta_v1.ObjectMeta{Namespace: "apps"},
 		Spec: conf_v1.PolicySpec{
 			WAF: &conf_v1.WAF{
-				Enable: true,
-				ApBundleSource: &conf_v1.BundleSource{
-					Type: conf_v1.BundleSourceTypePLM,
-					Name: "ap-pol",
-				},
+				Enable:   true,
+				ApPolicy: "ap-pol",
 			},
 		},
 	}
 
-	// HTTPS source must never match a PLM key.
+	// HTTPS apBundleSource must never match a PLM key.
 	httpsSource := &conf_v1.Policy{
 		ObjectMeta: meta_v1.ObjectMeta{Namespace: "apps"},
 		Spec: conf_v1.PolicySpec{
@@ -587,8 +732,9 @@ func TestGetPLMPoliciesForAppProtectPolicy(t *testing.T) {
 			msg:  "no PLM source references this key",
 		},
 	}
+	lbc := &LoadBalancerController{plmEnabled: true}
 	for _, test := range tests {
-		got := getPLMPoliciesForAppProtectPolicy(policies, test.key)
+		got := lbc.getPLMPoliciesForAppProtectPolicy(policies, test.key)
 		if diff := cmp.Diff(test.want, got); diff != "" {
 			t.Errorf("getPLMPoliciesForAppProtectPolicy() %v (-want +got):\n%s", test.msg, diff)
 		}
@@ -598,7 +744,7 @@ func TestGetPLMPoliciesForAppProtectPolicy(t *testing.T) {
 func TestGetPLMPoliciesForAppProtectLogConf(t *testing.T) {
 	t.Parallel()
 
-	// PLM log source with explicit namespace.
+	// PLM log source with explicit namespace on the apLogConf ref.
 	plmLogExplicitNs := &conf_v1.Policy{
 		ObjectMeta: meta_v1.ObjectMeta{Namespace: "apps"},
 		Spec: conf_v1.PolicySpec{
@@ -606,12 +752,8 @@ func TestGetPLMPoliciesForAppProtectLogConf(t *testing.T) {
 				Enable: true,
 				SecurityLogs: []*conf_v1.SecurityLog{
 					{
-						Enable: true,
-						ApLogBundleSource: &conf_v1.BundleSource{
-							Type:      conf_v1.BundleSourceTypePLM,
-							Name:      "log-conf",
-							Namespace: "plm-policies",
-						},
+						Enable:    true,
+						ApLogConf: "plm-policies/log-conf",
 					},
 				},
 			},
@@ -626,11 +768,8 @@ func TestGetPLMPoliciesForAppProtectLogConf(t *testing.T) {
 				Enable: true,
 				SecurityLogs: []*conf_v1.SecurityLog{
 					{
-						Enable: true,
-						ApLogBundleSource: &conf_v1.BundleSource{
-							Type: conf_v1.BundleSourceTypePLM,
-							Name: "log-conf",
-						},
+						Enable:    true,
+						ApLogConf: "log-conf",
 					},
 				},
 			},
@@ -680,8 +819,9 @@ func TestGetPLMPoliciesForAppProtectLogConf(t *testing.T) {
 			msg:  "no PLM log source references this key",
 		},
 	}
+	lbc := &LoadBalancerController{plmEnabled: true}
 	for _, test := range tests {
-		got := getPLMPoliciesForAppProtectLogConf(policies, test.key)
+		got := lbc.getPLMPoliciesForAppProtectLogConf(policies, test.key)
 		if diff := cmp.Diff(test.want, got); diff != "" {
 			t.Errorf("getPLMPoliciesForAppProtectLogConf() %v (-want +got):\n%s", test.msg, diff)
 		}
@@ -691,12 +831,26 @@ func TestGetPLMPoliciesForAppProtectLogConf(t *testing.T) {
 func TestGetPoliciesUsingPLMStorage(t *testing.T) {
 	t.Parallel()
 
-	plmPolicy := &conf_v1.Policy{Spec: conf_v1.PolicySpec{WAF: &conf_v1.WAF{ApBundleSource: &conf_v1.BundleSource{Type: conf_v1.BundleSourceTypePLM}}}}
-	plmLog := &conf_v1.Policy{Spec: conf_v1.PolicySpec{WAF: &conf_v1.WAF{SecurityLogs: []*conf_v1.SecurityLog{{ApLogBundleSource: &conf_v1.BundleSource{Type: conf_v1.BundleSourceTypePLM}}}}}}
-	nimPolicy := &conf_v1.Policy{Spec: conf_v1.PolicySpec{WAF: &conf_v1.WAF{ApBundleSource: &conf_v1.BundleSource{Type: conf_v1.BundleSourceTypeNIM}}}}
-	noWAF := &conf_v1.Policy{}
+	plmPolicy := &conf_v1.Policy{
+		ObjectMeta: meta_v1.ObjectMeta{Namespace: "default", Name: "plm-policy"},
+		Spec:       conf_v1.PolicySpec{WAF: &conf_v1.WAF{ApPolicy: "dataguard-alarm"}},
+	}
+	plmLog := &conf_v1.Policy{
+		ObjectMeta: meta_v1.ObjectMeta{Namespace: "default", Name: "plm-log"},
+		Spec: conf_v1.PolicySpec{
+			WAF: &conf_v1.WAF{SecurityLogs: []*conf_v1.SecurityLog{{ApLogConf: "logconf"}}},
+		},
+	}
+	nimPolicy := &conf_v1.Policy{
+		ObjectMeta: meta_v1.ObjectMeta{Namespace: "default", Name: "nim-policy"},
+		Spec: conf_v1.PolicySpec{
+			WAF: &conf_v1.WAF{ApBundleSource: &conf_v1.BundleSource{Type: conf_v1.BundleSourceTypeNIM}},
+		},
+	}
+	noWAF := &conf_v1.Policy{ObjectMeta: meta_v1.ObjectMeta{Namespace: "default", Name: "no-waf"}}
 
-	got := getPoliciesUsingPLMStorage([]*conf_v1.Policy{plmPolicy, plmLog, nimPolicy, noWAF})
+	lbc := &LoadBalancerController{plmEnabled: true}
+	got := lbc.getPoliciesUsingPLMStorage([]*conf_v1.Policy{plmPolicy, plmLog, nimPolicy, noWAF})
 	want := []*conf_v1.Policy{plmPolicy, plmLog}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("getPoliciesUsingPLMStorage() (-want +got):\n%s", diff)
@@ -725,13 +879,12 @@ func TestPolicyNeedsPLMBundleFetch(t *testing.T) {
 	dir := t.TempDir()
 	pol := &conf_v1.Policy{
 		ObjectMeta: meta_v1.ObjectMeta{Namespace: "default", Name: "waf-policy"},
-		Spec: conf_v1.PolicySpec{WAF: &conf_v1.WAF{ApBundleSource: &conf_v1.BundleSource{
-			Type: conf_v1.BundleSourceTypePLM, Name: "compiled-policy", Namespace: "plm",
-		}}},
+		Spec:       conf_v1.PolicySpec{WAF: &conf_v1.WAF{ApPolicy: "plm/compiled-policy"}},
 	}
 	lbc := &LoadBalancerController{
 		Logger:        nl.LoggerFromContext(context.Background()),
 		wafBundlePath: dir,
+		plmEnabled:    true,
 		namespacedInformers: map[string]*namespacedInformer{
 			"": {appProtectPolicyLister: store},
 		},

--- a/internal/k8s/policy.go
+++ b/internal/k8s/policy.go
@@ -116,7 +116,7 @@ func (lbc *LoadBalancerController) syncPolicy(task task) {
 				state := conf_v1.StateValid
 				reason := "AddedOrUpdated"
 				statusMsg := msg
-				if hasBundleSource(pol) && !lbc.bundleFilesReady(pol) {
+				if lbc.hasBundleSource(pol) && !lbc.bundleFilesReady(pol) {
 					state = conf_v1.StateWarning
 					reason = "BundlePending"
 					statusMsg = fmt.Sprintf("Policy %v/%v: WAF bundle fetch pending", pol.Namespace, pol.Name)
@@ -142,7 +142,7 @@ func (lbc *LoadBalancerController) syncPolicy(task task) {
 	if lbc.bundlePollerMgr != nil {
 		if polExists && lbc.HasCorrectIngressClass(obj) {
 			pol := obj.(*conf_v1.Policy)
-			if pol.Spec.WAF != nil && hasBundleSource(pol) {
+			if pol.Spec.WAF != nil && lbc.hasBundleSource(pol) {
 				lbc.syncWAFBundleSource(pol)
 			} else {
 				lbc.bundlePollerMgr.StopPoller(key)
@@ -269,17 +269,54 @@ func (lbc *LoadBalancerController) syncPolicy(task task) {
 	// Note: updating the status of a policy based on a reload is not needed.
 }
 
+// parseAPRef splits a "namespace/name" App Protect reference. The namespace
+// defaults to polNamespace when the reference is unqualified.
+func parseAPRef(ref, polNamespace string) (namespace, name string) {
+	if parsedNs, parsedName, err := helpers.ParseNamespaceName(ref); err == nil {
+		return parsedNs, parsedName
+	}
+	return polNamespace, ref
+}
+
+// effectivePLMPolicyRef returns the (namespace, name) that NIC should fetch as a PLM
+// policy bundle, or ok=false when the Policy has no PLM-eligible reference. Under
+// -plm-storage-url an apPolicy reference is fetched as a PLM bundle; apBundleSource
+// remains the HTTPS/NIM/N1C path.
+func (lbc *LoadBalancerController) effectivePLMPolicyRef(pol *conf_v1.Policy) (namespace, name string, ok bool) {
+	if !lbc.plmEnabled || pol.Spec.WAF == nil || pol.Spec.WAF.ApPolicy == "" {
+		return "", "", false
+	}
+	ns, n := parseAPRef(pol.Spec.WAF.ApPolicy, pol.Namespace)
+	return ns, n, true
+}
+
+// effectivePLMLogRef is the securityLogs counterpart of effectivePLMPolicyRef.
+func (lbc *LoadBalancerController) effectivePLMLogRef(sl *conf_v1.SecurityLog, polNamespace string) (namespace, name string, ok bool) {
+	if !lbc.plmEnabled || sl == nil || sl.ApLogConf == "" {
+		return "", "", false
+	}
+	ns, n := parseAPRef(sl.ApLogConf, polNamespace)
+	return ns, n, true
+}
+
 // hasBundleSource reports whether a Policy has any bundle source fields that require
-// fetching: either a top-level apBundleSource or any securityLogs entry with an apLogBundleSource.
-func hasBundleSource(pol *conf_v1.Policy) bool {
+// fetching: either a top-level apBundleSource or any securityLogs entry with an
+// apLogBundleSource. Under PLM, apPolicy/apLogConf references also require fetching.
+func (lbc *LoadBalancerController) hasBundleSource(pol *conf_v1.Policy) bool {
 	if pol.Spec.WAF == nil {
 		return false
 	}
 	if pol.Spec.WAF.ApBundleSource != nil {
 		return true
 	}
+	if _, _, ok := lbc.effectivePLMPolicyRef(pol); ok {
+		return true
+	}
 	for _, sl := range pol.Spec.WAF.SecurityLogs {
 		if sl != nil && sl.ApLogBundleSource != nil {
+			return true
+		}
+		if _, _, ok := lbc.effectivePLMLogRef(sl, pol.Namespace); ok {
 			return true
 		}
 	}
@@ -294,7 +331,7 @@ func (lbc *LoadBalancerController) bundleFilesReady(pol *conf_v1.Policy) bool {
 	if pol.Spec.WAF == nil || lbc.wafBundlePath == "" {
 		return true
 	}
-	if pol.Spec.WAF.ApBundleSource != nil {
+	if lbc.policyBundleExpected(pol) {
 		path := filepath.Join(lbc.wafBundlePath,
 			wafbundle.FetchedBundleFilename(pol.Namespace, pol.Name, "policy"))
 		if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -302,7 +339,7 @@ func (lbc *LoadBalancerController) bundleFilesReady(pol *conf_v1.Policy) bool {
 		}
 	}
 	for idx, sl := range pol.Spec.WAF.SecurityLogs {
-		if sl == nil || sl.ApLogBundleSource == nil {
+		if !lbc.logBundleExpected(sl, pol.Namespace) {
 			continue
 		}
 		path := filepath.Join(lbc.wafBundlePath,
@@ -314,83 +351,59 @@ func (lbc *LoadBalancerController) bundleFilesReady(pol *conf_v1.Policy) bool {
 	return true
 }
 
+// policyBundleExpected reports whether syncWAFBundleSource will fetch a policy bundle
+// for pol. Mirrors the branch selection in syncWAFBundleSource so that bundleFilesReady
+// only demands a file when one is actually being produced.
+func (lbc *LoadBalancerController) policyBundleExpected(pol *conf_v1.Policy) bool {
+	if pol.Spec.WAF == nil {
+		return false
+	}
+	if pol.Spec.WAF.ApBundleSource != nil {
+		return true
+	}
+	_, _, ok := lbc.effectivePLMPolicyRef(pol)
+	return ok
+}
+
+// logBundleExpected is the securityLogs counterpart of policyBundleExpected.
+func (lbc *LoadBalancerController) logBundleExpected(sl *conf_v1.SecurityLog, polNamespace string) bool {
+	if sl == nil {
+		return false
+	}
+	if sl.ApLogBundleSource != nil {
+		return true
+	}
+	_, _, ok := lbc.effectivePLMLogRef(sl, polNamespace)
+	return ok
+}
+
 // syncWAFBundleSource performs initial bundle fetches (if files are absent on disk)
 // and reconciles the background poller for the given WAF policy.
 // Initial fetches are performed asynchronously to avoid blocking the sync queue.
 func (lbc *LoadBalancerController) syncWAFBundleSource(pol *conf_v1.Policy) {
 	polKey := pol.Namespace + "/" + pol.Name
-	bs := pol.Spec.WAF.ApBundleSource
 
-	var auth *wafbundle.BundleAuth
-	if bs != nil {
-		var err error
-		auth, err = lbc.resolveWAFBundleAuth(bs, pol.Namespace)
-		if err != nil {
-			msg := fmt.Sprintf("WAF bundle secret resolution failed: %v", err)
-			lbc.recorder.Event(pol, api_v1.EventTypeWarning, nl.EventReasonInvalidConfiguration, msg)
-			if lbc.reportCustomResourceStatusEnabled() {
-				if updateErr := lbc.statusUpdater.UpdatePolicyStatus(pol, conf_v1.StateWarning, nl.EventReasonInvalidConfiguration, msg); updateErr != nil {
-					nl.Errorf(lbc.Logger, "Failed to update policy %s status: %v", polKey, updateErr)
-				}
-			}
-			return
-		}
-
-		// PLM: resolve the referenced APPolicy CR status. Not-ready gates the fetch;
-		// a changed checksum triggers a re-fetch (event-driven, no polling).
-		var plmStatus *wafbundle.BundleStatus
-		if bs.Type == conf_v1.BundleSourceTypePLM {
-			plmStatus = lbc.resolvePLMBundleStatus(pol, bs, wafbundle.PolicyBundle)
-			if plmStatus == nil {
-				// Status not ready or resolution failed; a warning has been recorded.
-				// Re-sync happens on the next APPolicy status change event.
-				return
-			}
-		}
-
-		policyFilename := wafbundle.FetchedBundleFilename(pol.Namespace, pol.Name, "policy")
-		policyPath := filepath.Join(lbc.wafBundlePath, policyFilename)
-		if lbc.bundleNeedsFetch(policyPath, plmStatus) {
-			lbc.fetchBundleAsync(pol, bs, auth, policyPath, wafbundle.PolicyBundle, plmStatus)
-			// Return early; re-sync will occur when fetch completes.
-			return
-		}
+	if !lbc.syncPolicyBundle(pol, polKey) {
+		return
 	}
 
 	for idx, sl := range pol.Spec.WAF.SecurityLogs {
-		if sl == nil || sl.ApLogBundleSource == nil {
-			continue
-		}
-		logAuth, logErr := lbc.resolveWAFBundleAuth(sl.ApLogBundleSource, pol.Namespace)
-		if logErr != nil {
-			msg := fmt.Sprintf("WAF log profile bundle: invalid or missing secret: %v", logErr)
-			lbc.recorder.Event(pol, api_v1.EventTypeWarning, nl.EventReasonInvalidConfiguration, msg)
-			if lbc.reportCustomResourceStatusEnabled() {
-				if updateErr := lbc.statusUpdater.UpdatePolicyStatus(pol, conf_v1.StateWarning, nl.EventReasonInvalidConfiguration, msg); updateErr != nil {
-					nl.Errorf(lbc.Logger, "Failed to update policy %s status: %v", polKey, updateErr)
-				}
-			}
-			continue
-		}
-
-		var logPLMStatus *wafbundle.BundleStatus
-		if sl.ApLogBundleSource.Type == conf_v1.BundleSourceTypePLM {
-			logPLMStatus = lbc.resolvePLMBundleStatus(pol, sl.ApLogBundleSource, wafbundle.LogProfileBundle)
-			if logPLMStatus == nil {
-				continue
-			}
-		}
-
-		logFilename := wafbundle.FetchedBundleFilename(pol.Namespace, pol.Name, fmt.Sprintf("log_%d", idx))
-		logPath := filepath.Join(lbc.wafBundlePath, logFilename)
-		if lbc.bundleNeedsFetch(logPath, logPLMStatus) {
-			lbc.fetchBundleAsync(pol, sl.ApLogBundleSource, logAuth, logPath, wafbundle.LogProfileBundle, logPLMStatus)
-			// Return early; re-sync will occur when fetch completes.
+		if !lbc.syncLogBundle(pol, polKey, sl, idx) {
 			return
 		}
 	}
 
-	sources := lbc.buildPollSources(pol, auth)
+	var policyAuth *wafbundle.BundleAuth
+	if bs := pol.Spec.WAF.ApBundleSource; bs != nil {
+		var err error
+		policyAuth, err = lbc.resolveWAFBundleAuth(bs, pol.Namespace)
+		if err != nil {
+			// Auth failure already surfaced in syncPolicyBundle; skip poller.
+			policyAuth = nil
+		}
+	}
+
+	sources := lbc.buildPollSources(pol, policyAuth)
 	if len(sources) > 0 {
 		lbc.bundlePollerMgr.ReconcilePoller(polKey, sources)
 	} else {
@@ -398,19 +411,116 @@ func (lbc *LoadBalancerController) syncWAFBundleSource(pol *conf_v1.Policy) {
 	}
 }
 
-// resolvePLMBundleStatus reads the referenced APPolicy/APLogConf CR's .status.bundle
-// for a PLM bundle source. It returns a non-nil, Ready BundleStatus on success, or nil
-// after recording a Warning event + policy status when the CR is missing, malformed, or
-// its bundle is not yet ready. A nil return means "do not fetch now"; the next APPolicy
-// status change re-enqueues the policy.
-func (lbc *LoadBalancerController) resolvePLMBundleStatus(pol *conf_v1.Policy, bs *conf_v1.BundleSource, kind wafbundle.BundleType) *wafbundle.BundleStatus {
+// syncPolicyBundle handles the top-level policy bundle for pol. It returns true when
+// processing may continue (bundle up-to-date or no bundle to fetch) and false when an
+// async fetch has been kicked off or a fatal error was recorded — in either case the
+// caller must not proceed with the securityLogs loop or poller reconciliation.
+func (lbc *LoadBalancerController) syncPolicyBundle(pol *conf_v1.Policy, polKey string) bool {
+	// PLM policy bundle: reference by APPolicy CR, cluster-wide credentials.
+	if ns, name, ok := lbc.effectivePLMPolicyRef(pol); ok {
+		status := lbc.resolvePLMBundleStatus(pol, ns, name, wafbundle.PolicyBundle)
+		if status == nil {
+			return false
+		}
+		policyPath := filepath.Join(lbc.wafBundlePath,
+			wafbundle.FetchedBundleFilename(pol.Namespace, pol.Name, "policy"))
+		if !lbc.bundleNeedsFetch(policyPath, status) {
+			return true
+		}
+		req := plmFetchRequest(ns, name, wafbundle.PolicyBundle, status)
+		lbc.fetchBundleAsyncRaw(pol, req, policyPath, wafbundle.PolicyBundle)
+		return false
+	}
+
+	// HTTPS/NIM/N1C policy bundle via apBundleSource.
+	bs := pol.Spec.WAF.ApBundleSource
+	if bs == nil {
+		return true
+	}
+	auth, err := lbc.resolveWAFBundleAuth(bs, pol.Namespace)
+	if err != nil {
+		msg := fmt.Sprintf("WAF bundle secret resolution failed: %v", err)
+		lbc.recorder.Event(pol, api_v1.EventTypeWarning, nl.EventReasonInvalidConfiguration, msg)
+		if lbc.reportCustomResourceStatusEnabled() {
+			if updateErr := lbc.statusUpdater.UpdatePolicyStatus(pol, conf_v1.StateWarning, nl.EventReasonInvalidConfiguration, msg); updateErr != nil {
+				nl.Errorf(lbc.Logger, "Failed to update policy %s status: %v", polKey, updateErr)
+			}
+		}
+		return false
+	}
+	policyPath := filepath.Join(lbc.wafBundlePath,
+		wafbundle.FetchedBundleFilename(pol.Namespace, pol.Name, "policy"))
+	if !lbc.bundleNeedsFetch(policyPath, nil) {
+		return true
+	}
+	lbc.fetchBundleAsync(pol, bs, auth, policyPath, wafbundle.PolicyBundle)
+	return false
+}
+
+// syncLogBundle handles one securityLogs entry. Same true/false semantics as syncPolicyBundle.
+func (lbc *LoadBalancerController) syncLogBundle(pol *conf_v1.Policy, polKey string, sl *conf_v1.SecurityLog, idx int) bool {
+	logFilename := wafbundle.FetchedBundleFilename(pol.Namespace, pol.Name, fmt.Sprintf("log_%d", idx))
+	logPath := filepath.Join(lbc.wafBundlePath, logFilename)
+
+	if ns, name, ok := lbc.effectivePLMLogRef(sl, pol.Namespace); ok {
+		status := lbc.resolvePLMBundleStatus(pol, ns, name, wafbundle.LogProfileBundle)
+		if status == nil {
+			return true // continue to next log entry; warning already recorded
+		}
+		if !lbc.bundleNeedsFetch(logPath, status) {
+			return true
+		}
+		req := plmFetchRequest(ns, name, wafbundle.LogProfileBundle, status)
+		lbc.fetchBundleAsyncRaw(pol, req, logPath, wafbundle.LogProfileBundle)
+		return false
+	}
+
+	if sl == nil || sl.ApLogBundleSource == nil {
+		return true
+	}
+	logAuth, logErr := lbc.resolveWAFBundleAuth(sl.ApLogBundleSource, pol.Namespace)
+	if logErr != nil {
+		msg := fmt.Sprintf("WAF log profile bundle: invalid or missing secret: %v", logErr)
+		lbc.recorder.Event(pol, api_v1.EventTypeWarning, nl.EventReasonInvalidConfiguration, msg)
+		if lbc.reportCustomResourceStatusEnabled() {
+			if updateErr := lbc.statusUpdater.UpdatePolicyStatus(pol, conf_v1.StateWarning, nl.EventReasonInvalidConfiguration, msg); updateErr != nil {
+				nl.Errorf(lbc.Logger, "Failed to update policy %s status: %v", polKey, updateErr)
+			}
+		}
+		return true // continue: mirrors previous non-PLM behavior
+	}
+	if !lbc.bundleNeedsFetch(logPath, nil) {
+		return true
+	}
+	lbc.fetchBundleAsync(pol, sl.ApLogBundleSource, logAuth, logPath, wafbundle.LogProfileBundle)
+	return false
+}
+
+// plmFetchRequest constructs a wafbundle.Request for a PLM bundle. Location and
+// checksum come from the referenced APPolicy/APLogConf's .status.bundle; the S3 config
+// (endpoint, credentials, TLS) is resolved by PLMAwareFetcher at fetch time.
+func plmFetchRequest(ns, name string, kind wafbundle.BundleType, status *wafbundle.BundleStatus) wafbundle.Request {
+	return wafbundle.Request{
+		Type:             wafbundle.SourceTypePLM,
+		BundleKind:       kind,
+		URL:              status.Location,
+		Name:             name,
+		Namespace:        ns,
+		ExpectedChecksum: status.SHA256,
+	}
+}
+
+// resolvePLMBundleStatus reads the referenced APPolicy/APLogConf CR's .status.bundle.
+// It returns a non-nil, Ready BundleStatus on success, or nil after recording a Warning
+// event + policy status when the CR is missing, malformed, or its bundle is not yet ready.
+// A nil return means "do not fetch now"; the next APPolicy status change re-enqueues the policy.
+func (lbc *LoadBalancerController) resolvePLMBundleStatus(pol *conf_v1.Policy, ns, name string, kind wafbundle.BundleType) *wafbundle.BundleStatus {
 	polKey := pol.Namespace + "/" + pol.Name
 
-	ns := bs.Namespace
 	if ns == "" {
 		ns = pol.Namespace
 	}
-	refKey := ns + "/" + bs.Name
+	refKey := ns + "/" + name
 
 	gvkKind := appprotect.PolicyGVK.Kind
 	if kind == wafbundle.LogProfileBundle {
@@ -519,8 +629,8 @@ func (lbc *LoadBalancerController) policyNeedsPLMBundleFetch(pol *conf_v1.Policy
 		return false
 	}
 
-	if bs := pol.Spec.WAF.ApBundleSource; bs != nil && bs.Type == conf_v1.BundleSourceTypePLM {
-		status := lbc.resolvePLMBundleStatus(pol, bs, wafbundle.PolicyBundle)
+	if ns, name, ok := lbc.effectivePLMPolicyRef(pol); ok {
+		status := lbc.resolvePLMBundleStatus(pol, ns, name, wafbundle.PolicyBundle)
 		path := filepath.Join(lbc.wafBundlePath, wafbundle.FetchedBundleFilename(pol.Namespace, pol.Name, "policy"))
 		if status != nil && lbc.bundleNeedsFetch(path, status) {
 			return true
@@ -528,10 +638,11 @@ func (lbc *LoadBalancerController) policyNeedsPLMBundleFetch(pol *conf_v1.Policy
 	}
 
 	for index, securityLog := range pol.Spec.WAF.SecurityLogs {
-		if securityLog == nil || securityLog.ApLogBundleSource == nil || securityLog.ApLogBundleSource.Type != conf_v1.BundleSourceTypePLM {
+		ns, name, ok := lbc.effectivePLMLogRef(securityLog, pol.Namespace)
+		if !ok {
 			continue
 		}
-		status := lbc.resolvePLMBundleStatus(pol, securityLog.ApLogBundleSource, wafbundle.LogProfileBundle)
+		status := lbc.resolvePLMBundleStatus(pol, ns, name, wafbundle.LogProfileBundle)
 		path := filepath.Join(lbc.wafBundlePath, wafbundle.FetchedBundleFilename(pol.Namespace, pol.Name, fmt.Sprintf("log_%d", index)))
 		if status != nil && lbc.bundleNeedsFetch(path, status) {
 			return true
@@ -541,20 +652,44 @@ func (lbc *LoadBalancerController) policyNeedsPLMBundleFetch(pol *conf_v1.Policy
 	return false
 }
 
-// fetchBundleAsync launches performInitialFetch in a background goroutine.
-// It re-enqueues the policy only when the fetch succeeds. Failed PLM fetches
-// retry when the referenced AP resource status or configured storage Secret changes;
-// non-PLM sources retry through their configured poller interval.
+// fetchBundleAsync launches performInitialFetch for an apBundleSource in a background
+// goroutine. It re-enqueues the policy only when the fetch succeeds; non-PLM sources
+// retry through their configured poller interval. PLM fetches use fetchBundleAsyncRaw.
 func (lbc *LoadBalancerController) fetchBundleAsync(
 	pol *conf_v1.Policy,
 	bs *conf_v1.BundleSource,
 	auth *wafbundle.BundleAuth,
 	path string,
 	kind wafbundle.BundleType,
-	plmStatus *wafbundle.BundleStatus,
+) {
+	req := lbc.buildFetchRequest(bs, auth, kind)
+	timeout := wafbundle.DefaultTimeout
+	if bs.Timeout != nil && bs.Timeout.Duration > 0 {
+		timeout = bs.Timeout.Duration
+	}
+	lbc.fetchBundleAsyncRawWithTimeout(pol, req, path, kind, timeout)
+}
+
+// fetchBundleAsyncRaw launches an async fetch from an already-constructed Request
+// (used for PLM, where the request is built from AP CR status rather than a BundleSource).
+func (lbc *LoadBalancerController) fetchBundleAsyncRaw(
+	pol *conf_v1.Policy,
+	req wafbundle.Request,
+	path string,
+	kind wafbundle.BundleType,
+) {
+	lbc.fetchBundleAsyncRawWithTimeout(pol, req, path, kind, wafbundle.DefaultTimeout)
+}
+
+func (lbc *LoadBalancerController) fetchBundleAsyncRawWithTimeout(
+	pol *conf_v1.Policy,
+	req wafbundle.Request,
+	path string,
+	kind wafbundle.BundleType,
+	timeout time.Duration,
 ) {
 	go func() {
-		if lbc.performInitialFetch(pol, bs, auth, path, kind, plmStatus) {
+		if lbc.performInitialFetch(pol, req, path, kind, timeout) {
 			lbc.AddSyncQueue(pol)
 		}
 	}()
@@ -565,22 +700,15 @@ func (lbc *LoadBalancerController) fetchBundleAsync(
 // written (or was unchanged), false when the fetch/write failed. On failure it
 // records a Warning status; PLM retries are triggered by AP resource status or
 // configured storage Secret updates, while non-PLM retries use the poller.
-// plmStatus is non-nil only for PLM sources and carries the resolved bundle location + checksum.
 func (lbc *LoadBalancerController) performInitialFetch(
 	pol *conf_v1.Policy,
-	bs *conf_v1.BundleSource,
-	auth *wafbundle.BundleAuth,
+	req wafbundle.Request,
 	destPath string,
 	kind wafbundle.BundleType,
-	plmStatus *wafbundle.BundleStatus,
+	timeout time.Duration,
 ) bool {
 	polKey := pol.Namespace + "/" + pol.Name
-	req := lbc.buildFetchRequest(bs, auth, kind, plmStatus)
 
-	timeout := wafbundle.DefaultTimeout
-	if bs.Timeout != nil && bs.Timeout.Duration > 0 {
-		timeout = bs.Timeout.Duration
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -670,25 +798,24 @@ func (lbc *LoadBalancerController) handleBundleRefreshFailure(polKey string, fet
 }
 
 // buildPollSources constructs the PollSource slice for a policy's bundle sources.
-// PLM sources are intentionally excluded: PLM updates are event-driven via the
-// APPolicy/APLogConf status watch, not polled.
+// buildPollSources constructs the PollSource slice for a policy's bundle sources.
+// PLM sources are not represented here — PLM updates are event-driven via the
+// APPolicy/APLogConf status watch, not polled — and the CRD only exposes
+// apBundleSource for HTTPS/NIM/N1C, so no PLM entries can appear.
 func (lbc *LoadBalancerController) buildPollSources(pol *conf_v1.Policy, policyAuth *wafbundle.BundleAuth) []wafbundle.PollSource {
 	var sources []wafbundle.PollSource
 
-	if bs := pol.Spec.WAF.ApBundleSource; bs != nil && bs.EnablePolling && bs.Type != conf_v1.BundleSourceTypePLM {
+	if bs := pol.Spec.WAF.ApBundleSource; bs != nil && bs.EnablePolling {
 		sources = append(sources, wafbundle.PollSource{
 			Filename: wafbundle.FetchedBundleFilename(pol.Namespace, pol.Name, "policy"),
 			Kind:     wafbundle.PolicyBundle,
-			Req:      lbc.buildFetchRequest(bs, policyAuth, wafbundle.PolicyBundle, nil),
+			Req:      lbc.buildFetchRequest(bs, policyAuth, wafbundle.PolicyBundle),
 			Interval: effectivePollInterval(bs),
 		})
 	}
 
 	for idx, sl := range pol.Spec.WAF.SecurityLogs {
 		if sl == nil || sl.ApLogBundleSource == nil || !sl.ApLogBundleSource.EnablePolling {
-			continue
-		}
-		if sl.ApLogBundleSource.Type == conf_v1.BundleSourceTypePLM {
 			continue
 		}
 		logAuth, err := lbc.resolveWAFBundleAuth(sl.ApLogBundleSource, pol.Namespace)
@@ -699,7 +826,7 @@ func (lbc *LoadBalancerController) buildPollSources(pol *conf_v1.Policy, policyA
 		sources = append(sources, wafbundle.PollSource{
 			Filename: wafbundle.FetchedBundleFilename(pol.Namespace, pol.Name, fmt.Sprintf("log_%d", idx)),
 			Kind:     wafbundle.LogProfileBundle,
-			Req:      lbc.buildFetchRequest(sl.ApLogBundleSource, logAuth, wafbundle.LogProfileBundle, nil),
+			Req:      lbc.buildFetchRequest(sl.ApLogBundleSource, logAuth, wafbundle.LogProfileBundle),
 			Interval: effectivePollInterval(sl.ApLogBundleSource),
 		})
 	}
@@ -708,17 +835,15 @@ func (lbc *LoadBalancerController) buildPollSources(pol *conf_v1.Policy, policyA
 }
 
 // buildFetchRequest constructs a wafbundle.Request from a BundleSource and resolved auth.
-// For PLM sources, plmStatus carries the bundle location + checksum resolved from the
-// referenced APPolicy/APLogConf CR's .status.bundle; it must be non-nil and Ready.
-func (lbc *LoadBalancerController) buildFetchRequest(bs *conf_v1.BundleSource, auth *wafbundle.BundleAuth, kind wafbundle.BundleType, plmStatus *wafbundle.BundleStatus) wafbundle.Request {
+// Used for HTTPS/NIM/N1C sources; PLM requests are constructed by plmFetchRequest at the
+// point where AP CR status is resolved.
+func (lbc *LoadBalancerController) buildFetchRequest(bs *conf_v1.BundleSource, auth *wafbundle.BundleAuth, kind wafbundle.BundleType) wafbundle.Request {
 	srcType := wafbundle.SourceTypeHTTPS
 	switch bs.Type {
 	case conf_v1.BundleSourceTypeN1C:
 		srcType = wafbundle.SourceTypeN1C
 	case conf_v1.BundleSourceTypeNIM:
 		srcType = wafbundle.SourceTypeNIM
-	case conf_v1.BundleSourceTypePLM:
-		srcType = wafbundle.SourceTypePLM
 	}
 	req := wafbundle.Request{
 		Type:               srcType,
@@ -730,13 +855,6 @@ func (lbc *LoadBalancerController) buildFetchRequest(bs *conf_v1.BundleSource, a
 		NAPRelease:         lbc.wafVersion,
 		InsecureSkipVerify: bs.InsecureSkipVerify,
 		VerifyChecksum:     bs.VerifyChecksum,
-	}
-	// For PLM the bundle location and checksum come from the referenced CR status,
-	// not from the BundleSource spec. The checksum is always verified against the
-	// value PLM published, independent of bs.VerifyChecksum.
-	if srcType == wafbundle.SourceTypePLM && plmStatus != nil {
-		req.URL = plmStatus.Location
-		req.ExpectedChecksum = plmStatus.SHA256
 	}
 	if auth != nil {
 		req.TLSCA = auth.TLSCA

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -1007,7 +1007,7 @@ type OIDC struct {
 }
 
 // BundleSourceType specifies the remote source backend for a WAF bundle.
-// +kubebuilder:validation:Enum=HTTPS;NIM;N1C;PLM
+// +kubebuilder:validation:Enum=HTTPS;NIM;N1C
 type BundleSourceType string
 
 const (
@@ -1017,30 +1017,21 @@ const (
 	BundleSourceTypeNIM BundleSourceType = "NIM"
 	// BundleSourceTypeN1C fetches a managed policy bundle from NGINX One Console.
 	BundleSourceTypeN1C BundleSourceType = "N1C"
-	// BundleSourceTypePLM fetches a bundle compiled by the F5 WAF Policy Controller (PLM)
-	// from its SeaweedFS S3 storage.
-	BundleSourceTypePLM BundleSourceType = "PLM"
 )
 
 // BundleSource configures fetching a pre-compiled WAF bundle from a remote source.
 //
-// Four source types are supported:
+// Three source types are supported:
 //   - HTTPS (default): fetch a pre-compiled .tgz bundle from any HTTPS server.
 //   - NIM: pull a named managed policy from NGINX Instance Manager via its API.
 //   - N1C: pull a named managed policy from NGINX One Console via its API.
-//   - PLM: fetch a bundle compiled by the F5 WAF Policy Controller from its S3 storage,
-//     referencing an APPolicy/APLogConf CR by name (+ optional namespace).
 //
-// Type-specific field requirements for HTTPS/NIM/N1C (url required; name required
-// for NIM/N1C; namespace required for N1C) are enforced by the controller's Go
-// validation layer.
-// +kubebuilder:validation:XValidation:rule="self.type != 'PLM' || !has(self.url) || size(self.url) == 0",message="url is not allowed when type is PLM; the bundle location is read from the referenced CR's status"
-// +kubebuilder:validation:XValidation:rule="self.type != 'PLM' || !has(self.secret) || size(self.secret) == 0",message="secret is not allowed when type is PLM; S3 credentials are configured cluster-wide via -plm-storage-credentials-secret"
-// +kubebuilder:validation:XValidation:rule="self.type != 'PLM' || !has(self.trustedCertSecret) || size(self.trustedCertSecret) == 0",message="trustedCertSecret is not allowed when type is PLM; TLS is configured cluster-wide via -plm-storage-ca-secret"
-// +kubebuilder:validation:XValidation:rule="self.type != 'PLM' || !has(self.verifyChecksum) || self.verifyChecksum == false",message="verifyChecksum is not allowed when type is PLM; the checksum is read from the referenced CR's status"
-// +kubebuilder:validation:XValidation:rule="self.type != 'PLM' || !has(self.enablePolling) || self.enablePolling == false",message="enablePolling is not allowed when type is PLM; PLM bundles refresh automatically when the referenced CR's status changes"
-// +kubebuilder:validation:XValidation:rule="self.type != 'PLM' || !has(self.pollInterval)",message="pollInterval is not allowed when type is PLM; PLM bundles refresh automatically when the referenced CR's status changes"
-// +kubebuilder:validation:XValidation:rule="self.type != 'PLM' || (has(self.name) && size(self.name) > 0)",message="name is required when type is PLM and must reference an APPolicy/APLogConf resource"
+// Type-specific field requirements (url required; name required for NIM/N1C;
+// namespace required for N1C) are enforced by the controller's Go validation layer.
+//
+// To reference bundles compiled by the F5 WAF Policy Controller (PLM), use the
+// apPolicy and apLogConf fields on the parent WAF resource. NIC resolves those
+// references as PLM bundles when the -plm-storage-url flag is set.
 type BundleSource struct {
 	// Type is the bundle source backend. Defaults to HTTPS.
 	// +kubebuilder:default=HTTPS
@@ -1048,7 +1039,6 @@ type BundleSource struct {
 	Type BundleSourceType `json:"type,omitempty"`
 
 	// URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://.
-	// Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle.
 	// +kubebuilder:validation:MaxLength=2083
 	// +kubebuilder:validation:Pattern=`^(https://.*)?$`
 	// +optional
@@ -1069,15 +1059,12 @@ type BundleSource struct {
 	// +optional
 	TrustedCertSecret string `json:"trustedCertSecret,omitempty"`
 
-	// Name is the policy name on the management plane (NIM/N1C), or the name of the
-	// APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS.
+	// Name is the policy name on the management plane. Required for NIM and N1C; forbidden for HTTPS.
 	// +kubebuilder:validation:MaxLength=63
 	// +optional
 	Name string `json:"name,omitempty"`
 
-	// Namespace is the namespace/tenant on the management plane (N1C), or the namespace of
-	// the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to
-	// the Policy's own namespace); forbidden otherwise.
+	// Namespace is the namespace/tenant on the management plane. Required for N1C; forbidden otherwise.
 	// +kubebuilder:validation:MaxLength=63
 	// +optional
 	Namespace string `json:"namespace,omitempty"`

--- a/pkg/apis/configuration/validation/policy.go
+++ b/pkg/apis/configuration/validation/policy.go
@@ -563,15 +563,11 @@ func validateBundleSource(bs *v1.BundleSource, fieldPath *field.Path) field.Erro
 		srcType = v1.BundleSourceTypeHTTPS
 	}
 
-	// PLM reads the bundle location from the referenced CR's .status.bundle, so no URL
-	// is required. All other source types require a URL.
-	if srcType != v1.BundleSourceTypePLM {
-		if bs.URL == "" {
-			allErrs = append(allErrs, field.Required(fieldPath.Child("url"), "url is required"))
-			return allErrs
-		}
-		allErrs = append(allErrs, validateBundleSourceURL(bs.URL, fieldPath.Child("url"))...)
+	if bs.URL == "" {
+		allErrs = append(allErrs, field.Required(fieldPath.Child("url"), "url is required"))
+		return allErrs
 	}
+	allErrs = append(allErrs, validateBundleSourceURL(bs.URL, fieldPath.Child("url"))...)
 
 	typeErrs, earlyReturn := validateBundleSourceType(bs, srcType, fieldPath)
 	allErrs = append(allErrs, typeErrs...)
@@ -635,23 +631,11 @@ func validateBundleSourceType(bs *v1.BundleSource, srcType v1.BundleSourceType, 
 		if bs.VerifyChecksum {
 			allErrs = append(allErrs, field.Invalid(fieldPath.Child("verifyChecksum"), bs.VerifyChecksum, "verifyChecksum is only supported for HTTPS type"))
 		}
-	case v1.BundleSourceTypePLM:
-		// PLM references an APPolicy/APLogConf CR by name; namespace is optional
-		// (defaults to the Policy's own namespace). The PLM structural rules (forbidden
-		// url/secret/trustedCertSecret/verifyChecksum/enablePolling/pollInterval and the
-		// required name) are enforced by CEL on the BundleSource CRD schema; here we
-		// only keep the dangerous-character screening, which CEL cannot express.
-		if ContainsDangerousChars(bs.Name) {
-			allErrs = append(allErrs, field.Invalid(fieldPath.Child("name"), bs.Name, "name contains dangerous characters"))
-		}
-		if bs.Namespace != "" && ContainsDangerousChars(bs.Namespace) {
-			allErrs = append(allErrs, field.Invalid(fieldPath.Child("namespace"), bs.Namespace, "namespace contains dangerous characters"))
-		}
 	default:
 		allErrs = append(allErrs, field.NotSupported(fieldPath.Child("type"), srcType,
 			[]string{
 				string(v1.BundleSourceTypeHTTPS), string(v1.BundleSourceTypeNIM),
-				string(v1.BundleSourceTypeN1C), string(v1.BundleSourceTypePLM),
+				string(v1.BundleSourceTypeN1C),
 			}))
 		return allErrs, true
 	}

--- a/pkg/apis/configuration/validation/policy_test.go
+++ b/pkg/apis/configuration/validation/policy_test.go
@@ -4198,14 +4198,6 @@ func TestValidateBundleSource_HTTPS_Valid(t *testing.T) {
 	}
 }
 
-func TestValidateBundleSource_PLM_ValidWithoutURL(t *testing.T) {
-	t.Parallel()
-	bs := &v1.BundleSource{Type: v1.BundleSourceTypePLM, Name: "dataguard-blocking"}
-	if errs := validateBundleSource(bs, field.NewPath("apBundleSource")); len(errs) != 0 {
-		t.Errorf("unexpected errors: %v", errs)
-	}
-}
-
 func TestValidateBundleSource_HTTPS_Name_Forbidden(t *testing.T) {
 	t.Parallel()
 	bs := &v1.BundleSource{Type: v1.BundleSourceTypeHTTPS, URL: "https://bundles.example.com/p.tgz", Name: "Foo"}

--- a/pkg/client/applyconfiguration/configuration/v1/bundlesource.go
+++ b/pkg/client/applyconfiguration/configuration/v1/bundlesource.go
@@ -12,21 +12,21 @@ import (
 //
 // BundleSource configures fetching a pre-compiled WAF bundle from a remote source.
 //
-// Four source types are supported:
+// Three source types are supported:
 // - HTTPS (default): fetch a pre-compiled .tgz bundle from any HTTPS server.
 // - NIM: pull a named managed policy from NGINX Instance Manager via its API.
 // - N1C: pull a named managed policy from NGINX One Console via its API.
-// - PLM: fetch a bundle compiled by the F5 WAF Policy Controller from its S3 storage,
-// referencing an APPolicy/APLogConf CR by name (+ optional namespace).
 //
-// Type-specific field requirements for HTTPS/NIM/N1C (url required; name required
-// for NIM/N1C; namespace required for N1C) are enforced by the controller's Go
-// validation layer.
+// Type-specific field requirements (url required; name required for NIM/N1C;
+// namespace required for N1C) are enforced by the controller's Go validation layer.
+//
+// To reference bundles compiled by the F5 WAF Policy Controller (PLM), use the
+// apPolicy and apLogConf fields on the parent WAF resource. NIC resolves those
+// references as PLM bundles when the -plm-storage-url flag is set.
 type BundleSourceApplyConfiguration struct {
 	// Type is the bundle source backend. Defaults to HTTPS.
 	Type *configurationv1.BundleSourceType `json:"type,omitempty"`
 	// URL is the full bundle URL for HTTPS type, or the API base URL for NIM/N1C. Must use https://.
-	// Not used for PLM, where the bundle location is read from the referenced CR's .status.bundle.
 	URL *string `json:"url,omitempty"`
 	// Secret is the name of a Kubernetes Secret in the same namespace as the Policy.
 	// For HTTPS: kubernetes.io/tls (tls.crt + tls.key for client mTLS; optional ca.crt for server CA).
@@ -37,12 +37,9 @@ type BundleSourceApplyConfiguration struct {
 	// for verifying the remote endpoint TLS certificate. The secret must be in the same
 	// namespace as the Policy, must be of type nginx.org/ca, and must include ca.crt.
 	TrustedCertSecret *string `json:"trustedCertSecret,omitempty"`
-	// Name is the policy name on the management plane (NIM/N1C), or the name of the
-	// APPolicy/APLogConf CR to reference (PLM). Required for NIM, N1C, and PLM; forbidden for HTTPS.
+	// Name is the policy name on the management plane. Required for NIM and N1C; forbidden for HTTPS.
 	Name *string `json:"name,omitempty"`
-	// Namespace is the namespace/tenant on the management plane (N1C), or the namespace of
-	// the referenced APPolicy/APLogConf CR (PLM). Required for N1C; optional for PLM (defaults to
-	// the Policy's own namespace); forbidden otherwise.
+	// Namespace is the namespace/tenant on the management plane. Required for N1C; forbidden otherwise.
 	Namespace *string `json:"namespace,omitempty"`
 	// EnablePolling enables background polling to automatically detect and fetch
 	// updated bundles at the configured PollInterval. Defaults to false. When


### PR DESCRIPTION
### Proposed changes

- Adds helm-chart config
- Adds example
- Update to use existing `apPolicy` and `apLogConf` spec for policies compiled by F5 WAF Policy Controller (PLM)
- Remove PLM type so no breaking changes are required during upgrade

Policy 1:
```
Spec:
  Waf:
    Ap Policy:  dataguard-blocking
    Enable:     true
Status:
  Message:  Policy default/waf-policy was added or updated
  Reason:   AddedOrUpdated
  State:    Valid
Events:
  Type    Reason          Age                    From                      Message
  ----    ------          ----                   ----                      -------
  Normal  AddedOrUpdated  3m54s (x4 over 5m12s)  nginx-ingress-controller  Policy default/waf-policy was added or updated

```

Policy 2
```
Spec:
  Waf:
    Ap Policy:  dataguard-alarm-2
    Enable:     true
    Security Logs:
      Ap Log Conf:  logconf
      Enable:       true
      Log Dest:     syslog:server=syslog-svc.default:514
Status:
  Message:  Policy default/waf-policy-2 was added or updated
  Reason:   AddedOrUpdated
  State:    Valid
Events:
  Type     Reason             Age                  From                      Message
  ----     ------             ----                 ----                      -------
  Warning  BundleFetchFailed  9m58s (x2 over 10m)  nginx-ingress-controller  WAF PLM bundle: APPolicy "default/dataguard-alarm-2" bundle state is "processing", not ready
  Normal   AddedOrUpdated     9m57s (x5 over 10m)  nginx-ingress-controller  Policy default/waf-policy-2 was added or updated
```

VS:
```
Spec:
  Host:  webapp.example.com
  Policies:
    Name:  waf-policy
  Routes:
    Action:
      Pass:  webapp
    Path:    /
  Upstreams:
    Name:     webapp
    Port:     80
    Service:  webapp-svc
Status:
  External Endpoints:
    Ip:     34.53.229.168
    Ports:  [80,443]
  Message:  Configuration for default/webapp was added or updated 
  Reason:   AddedOrUpdated
  State:    Valid
```

Ingress
```
Name:             cafe-ingress
Labels:           <none>
Namespace:        default
Address:          34.53.229.168
Ingress Class:    nginx
Default backend:  <default>
Rules:
  Host              Path  Backends
  ----              ----  --------
  cafe.example.com  
                    /tea      tea-svc:80 (10.76.0.17:80,10.76.1.23:80,10.76.2.20:80)
                    /coffee   coffee-svc:80 (10.76.1.24:80,10.76.2.19:80)
Annotations:        nginx.com/policies: waf-policy-2
Events:
  Type    Reason          Age   From                      Message
  ----    ------          ----  ----                      -------
  Normal  AddedOrUpdated  3s    nginx-ingress-controller  Configuration for default/cafe-ingress was added or updated
```

ApPolicy:
```
Status:
  Bundle:
    Compiler Version:  5.14.0
    Location:          s3://plm/bundles/dataguard-block20260810173957-dataguard-block-1-1786383597683166958.tgz
    sha256:            6c935b26c7b2e64ac43b9f4335a6cf79de40a45402360479e0bcadab1ccfe897
    Signatures:
      Attack Signatures:  2026-07-18T13:39:26Z
      Bot Signatures:     2026-07-16T07:35:37Z
      Threat Campaigns:   2026-07-13T11:56:06Z
      User Defined Signatures:
        Generation:  1
        Name:        apple
    State:           ready
  Last Good Bundle:
    Compiler Version:  5.14.0
    Location:          s3://plm/bundles/dataguard-block20260810173957-dataguard-block-1-1786383597683166958.tgz
    sha256:            6c935b26c7b2e64ac43b9f4335a6cf79de40a45402360479e0bcadab1ccfe897
    Signatures:
      Attack Signatures:  2026-07-18T13:39:26Z
      Bot Signatures:     2026-07-16T07:35:37Z
      Threat Campaigns:   2026-07-13T11:56:06Z
      User Defined Signatures:
        Generation:      1
        Name:            apple
    State:               ready
  Observed Generation:   1
  Observed Policy Name:  dataguard-alarm
  Policy Location:       s3://plm/policies/dataguard-block.json
  Processing:
    Datetime:     2026-08-10T17:40:15Z
    Is Compiled:  true
```

bundle:
```
>> keti test-release-nginx-ingress-controller-676bd4d56c-78294 -- ls -ltr /etc/app_protect/bundles       
      
Defaulted container "nginx-ingress" out of: nginx-ingress, waf-enforcer, waf-config-mgr
total 3724
-rw------- 1 nginx nginx 1902186 Aug 10 19:47 fetched_default_waf-policy-2_policy.tgz
-rw------- 1 nginx nginx    1657 Aug 10 19:47 fetched_default_waf-policy-2_log_0.tgz
-rw------- 1 nginx nginx 1899073 Aug 10 19:52 fetched_default_waf-policy_policy.tgz
-rw------- 1 nginx nginx    1657 Aug 10 19:52 fetched_default_waf-policy_log_0.tgz
```

cURL:
for VS
```
>>curl --resolve webapp.example.com:$IC_HTTP_PORT:$IC_IP -X POST -d "apple" "http://webapp.example.com:$IC_HTTP_PORT/"

<html><head><title>Request Rejected</title></head><body>The requested URL was rejected. Please consult with your administrator.<br><br>Your support ID is: 1783267987129777407<br><br><a href='javascript:history.back();'>[Go Back]</a></body></html>%    
```

for Ingress
```
>> curl --resolve cafe.example.com:$IC_HTTP_PORT:$IC_IP "http://cafe.example.com:$IC_HTTP_PORT/coffee/</script>"

<html><head><title>Request Rejected</title></head><body>The requested URL was rejected. Please consult with your administrator.<br><br>Your support IDis: 17866834002718227763<br><br><a href='javascript:history.back();'>[Go Back]</a></body></html>%    
```
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
