### PR TITLE
Resolve unchecked error returns and remove lint suppressions

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -873,7 +873,10 @@ func ready(lbc *k8s.LoadBalancerController) http.HandlerFunc {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "Ready")
+		if _, err := fmt.Fprintln(w, "Ready"); err != nil {
+			// Log error but don't fail the handler since status was already written
+			nl.Error(lbc.Logger, "Failed to write readiness response", err)
+		}
 	}
 }
 

--- a/internal/certmanager/cm_controller.go
+++ b/internal/certmanager/cm_controller.go
@@ -110,31 +110,38 @@ func BuildOpts(ctx context.Context, kc *rest.Config, cl kubernetes.Interface, ns
 	}
 }
 
-func (c *CmController) newNamespacedInformer(ns string) *namespacedInformer {
+func (c *CmController) newNamespacedInformer(ns string) (*namespacedInformer, error) {
 	nsi := &namespacedInformer{}
 	nsi.stopCh = make(chan struct{})
 	nsi.cmSharedInformerFactory = cm_informers.NewSharedInformerFactoryWithOptions(c.cmClient, resyncPeriod, cm_informers.WithNamespace(ns))
 	nsi.kubeSharedInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(c.kubeClient, resyncPeriod, kubeinformers.WithNamespace(ns))
 	nsi.vsSharedInformerFactory = vsinformers.NewSharedInformerFactoryWithOptions(c.vsClient, resyncPeriod, vsinformers.WithNamespace(ns))
 
-	c.addHandlers(nsi)
+	if err := c.addHandlers(nsi); err != nil {
+		return nil, fmt.Errorf("failed to add event handlers for namespace %s: %w", ns, err)
+	}
 
 	c.informerGroup[ns] = nsi
-	return nsi
+	return nsi, nil
 }
 
-func (c *CmController) addHandlers(nsi *namespacedInformer) {
+func (c *CmController) addHandlers(nsi *namespacedInformer) error {
 	nsi.vsLister = nsi.vsSharedInformerFactory.K8s().V1().VirtualServers().Lister()
-	nsi.vsSharedInformerFactory.K8s().V1().VirtualServers().Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{
+	if _, err := nsi.vsSharedInformerFactory.K8s().V1().VirtualServers().Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{
 		Queue: c.queue,
-	})
+	}); err != nil {
+		return fmt.Errorf("failed to add VirtualServer event handler: %w", err)
+	}
 	nsi.mustSync = append(nsi.mustSync, nsi.vsSharedInformerFactory.K8s().V1().VirtualServers().Informer().HasSynced)
 
-	nsi.cmSharedInformerFactory.Certmanager().V1().Certificates().Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+	if _, err := nsi.cmSharedInformerFactory.Certmanager().V1().Certificates().Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
 		WorkFunc: certificateHandler(c.queue),
-	})
+	}); err != nil {
+		return fmt.Errorf("failed to add Certificate event handler: %w", err)
+	}
 	nsi.cmLister = nsi.cmSharedInformerFactory.Certmanager().V1().Certificates().Lister()
 	nsi.mustSync = append(nsi.mustSync, nsi.cmSharedInformerFactory.Certmanager().V1().Certificates().Informer().HasSynced)
+	return nil
 }
 
 func (c *CmController) processItem(ctx context.Context, key types.NamespacedName) error {
@@ -204,9 +211,12 @@ func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.Namespa
 }
 
 // NewCmController creates a new CmController
-func NewCmController(opts *CmOpts) *CmController {
+func NewCmController(opts *CmOpts) (*CmController, error) {
 	// Create a cert-manager api client
-	intcl, _ := cm_clientset.NewForConfig(opts.kubeConfig)
+	intcl, err := cm_clientset.NewForConfig(opts.kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cert-manager client: %w", err)
+	}
 
 	ig := make(map[string]*namespacedInformer)
 
@@ -225,11 +235,13 @@ func NewCmController(opts *CmOpts) *CmController {
 			// no initial namespaces with watched label - skip creating informers for now
 			break
 		}
-		cm.newNamespacedInformer(ns)
+		if _, err := cm.newNamespacedInformer(ns); err != nil {
+			return nil, fmt.Errorf("failed to create cert-manager namespaced informer for namespace %s: %w", ns, err)
+		}
 	}
 
 	cm.register()
-	return cm
+	return cm, nil
 }
 
 // Run will set up the event handlers for types we are interested in, as well
@@ -312,7 +324,12 @@ func (c *CmController) AddNewNamespacedInformer(ns string) {
 	nl.Debugf(l, "Adding or Updating cert-manager Watchers for Namespace: %v", ns)
 	nsi := getNamespacedInformer(ns, c.informerGroup)
 	if nsi == nil {
-		nsi = c.newNamespacedInformer(ns)
+		var err error
+		nsi, err = c.newNamespacedInformer(ns)
+		if err != nil {
+			nl.Errorf(l, "Failed to create cert-manager namespaced informer for namespace %s: %v", ns, err)
+			return
+		}
 		nsi.start()
 	}
 	if !cache.WaitForCacheSync(nsi.stopCh, nsi.mustSync...) {

--- a/internal/certmanager/cm_controller_test.go
+++ b/internal/certmanager/cm_controller_test.go
@@ -156,7 +156,9 @@ func Test_controller_Register(t *testing.T) {
 				vsClient:      b.VSClient,
 			}
 
-			cm.addHandlers(nsi)
+			if err := cm.addHandlers(nsi); err != nil {
+				t.Fatalf("Failed to add handlers: %v", err)
+			}
 
 			queue := cm.register()
 

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -2,6 +2,7 @@ package version1
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"regexp"
 	"strconv"
@@ -21,7 +22,11 @@ func TestMain(m *testing.M) {
 	v := m.Run()
 
 	// After all tests have run `go-snaps` will sort snapshots
-	snaps.Clean(m, snaps.CleanOpts{Sort: true})
+	_, err := snaps.Clean(m, snaps.CleanOpts{Sort: true})
+	if err != nil {
+		// Log but don't fail - this is cleanup
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to clean snapshots: %v\n", err)
+	}
 
 	os.Exit(v)
 }

--- a/internal/configs/version2/templates_test.go
+++ b/internal/configs/version2/templates_test.go
@@ -15,7 +15,11 @@ func TestMain(m *testing.M) {
 	v := m.Run()
 
 	// After all tests have run `go-snaps` will sort snapshots
-	snaps.Clean(m, snaps.CleanOpts{Sort: true})
+	_, err := snaps.Clean(m, snaps.CleanOpts{Sort: true})
+	if err != nil {
+		// Log but don't fail - this is cleanup
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to clean snapshots: %v\n", err)
+	}
 
 	os.Exit(v)
 }

--- a/internal/externaldns/controller.go
+++ b/internal/externaldns/controller.go
@@ -59,7 +59,7 @@ type ExtDNSOpts struct {
 }
 
 // NewController takes external dns config and return a new External DNS Controller.
-func NewController(opts *ExtDNSOpts) *ExtDNSController {
+func NewController(opts *ExtDNSOpts) (*ExtDNSController, error) {
 	ig := make(map[string]*namespacedInformer)
 
 	rateLimiter := workqueue.DefaultTypedControllerRateLimiter[types.NamespacedName]()
@@ -80,28 +80,34 @@ func NewController(opts *ExtDNSOpts) *ExtDNSController {
 			// no initial namespaces with watched label - skip creating informers for now
 			break
 		}
-		c.newNamespacedInformer(ns)
+		if _, err := c.newNamespacedInformer(ns); err != nil {
+			return nil, fmt.Errorf("failed to create external-dns namespaced informer for namespace %s: %w", ns, err)
+		}
 	}
 
 	c.sync = SyncFnFor(c.recorder, c.client, c.informerGroup)
-	return c
+	return c, nil
 }
 
-func (c *ExtDNSController) newNamespacedInformer(ns string) *namespacedInformer {
+func (c *ExtDNSController) newNamespacedInformer(ns string) (*namespacedInformer, error) {
 	nsi := &namespacedInformer{sharedInformerFactory: k8s_nginx_informers.NewSharedInformerFactoryWithOptions(c.client, c.resync, k8s_nginx_informers.WithNamespace(ns))}
 	nsi.stopCh = make(chan struct{})
 	nsi.vsLister = nsi.sharedInformerFactory.K8s().V1().VirtualServers().Lister()
 	nsi.extdnslister = nsi.sharedInformerFactory.Externaldns().V1().DNSEndpoints().Lister()
 
-	nsi.sharedInformerFactory.K8s().V1().VirtualServers().Informer().AddEventHandler( //nolint:errcheck,gosec
+	if _, err := nsi.sharedInformerFactory.K8s().V1().VirtualServers().Informer().AddEventHandler(
 		&QueuingEventHandler{
 			Queue: c.queue,
 		},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to add VirtualServer event handler: %w", err)
+	}
 
-	nsi.sharedInformerFactory.Externaldns().V1().DNSEndpoints().Informer().AddEventHandler(&BlockingEventHandler{ //nolint:errcheck,gosec
+	if _, err := nsi.sharedInformerFactory.Externaldns().V1().DNSEndpoints().Informer().AddEventHandler(&BlockingEventHandler{
 		WorkFunc: externalDNSHandler(c.queue),
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("failed to add DNSEndpoint event handler: %w", err)
+	}
 
 	nsi.mustSync = append(
 		nsi.mustSync,
@@ -109,7 +115,7 @@ func (c *ExtDNSController) newNamespacedInformer(ns string) *namespacedInformer 
 		nsi.sharedInformerFactory.Externaldns().V1().DNSEndpoints().Informer().HasSynced,
 	)
 	c.informerGroup[ns] = nsi
-	return nsi
+	return nsi, nil
 }
 
 // Run sets up the event handlers for types we are interested in, as well
@@ -260,10 +266,15 @@ func getNamespacedInformer(ns string, ig map[string]*namespacedInformer) *namesp
 // AddNewNamespacedInformer adds watchers for a new namespace
 func (c *ExtDNSController) AddNewNamespacedInformer(ns string) {
 	l := nl.LoggerFromContext(c.ctx)
-	nl.Debugf(l, "Adding or Updating cert-manager Watchers for Namespace: %v", ns)
+	nl.Debugf(l, "Adding or Updating external-dns Watchers for Namespace: %v", ns)
 	nsi := getNamespacedInformer(ns, c.informerGroup)
 	if nsi == nil {
-		nsi = c.newNamespacedInformer(ns)
+		var err error
+		nsi, err = c.newNamespacedInformer(ns)
+		if err != nil {
+			nl.Errorf(l, "Failed to create external-dns namespaced informer for namespace %s: %v", ns, err)
+			return
+		}
 		nsi.start()
 	}
 	if !cache.WaitForCacheSync(nsi.stopCh, nsi.mustSync...) {
@@ -274,7 +285,7 @@ func (c *ExtDNSController) AddNewNamespacedInformer(ns string) {
 // RemoveNamespacedInformer removes watchers for a namespace we are no longer watching
 func (c *ExtDNSController) RemoveNamespacedInformer(ns string) {
 	l := nl.LoggerFromContext(c.ctx)
-	nl.Debugf(l, "Deleting cert-manager Watchers for Deleted Namespace: %v", ns)
+	nl.Debugf(l, "Deleting external-dns Watchers for Deleted Namespace: %v", ns)
 	nsi := getNamespacedInformer(ns, c.informerGroup)
 	if nsi != nil {
 		nsi.lock.Lock()

--- a/internal/externaldns/controller_test.go
+++ b/internal/externaldns/controller_test.go
@@ -1,0 +1,57 @@
+package externaldns
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	vsfake "github.com/nginx/kubernetes-ingress/pkg/client/clientset/versioned/fake"
+	"k8s.io/client-go/tools/record"
+)
+
+func TestNewController_NoNamespaces(t *testing.T) {
+	t.Parallel()
+	opts := BuildOpts(context.Background(), nil, &record.FakeRecorder{}, vsfake.NewSimpleClientset(), 0, false)
+
+	c, err := NewController(opts)
+	if err != nil {
+		t.Errorf("expected nil error with no namespaces, got %v", err)
+	}
+	if c == nil {
+		t.Error("expected non-nil controller")
+	}
+}
+
+func TestNewController_DynamicNsSkipsEmptyNamespace(t *testing.T) {
+	t.Parallel()
+	// With isDynamicNs=true and a single empty-string namespace, the loop
+	// should break immediately without creating any informers.
+	opts := BuildOpts(context.Background(), []string{""}, &record.FakeRecorder{}, vsfake.NewSimpleClientset(), 0, true)
+
+	c, err := NewController(opts)
+	if err != nil {
+		t.Fatalf("expected nil error when dynamic ns skips empty namespace, got %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil controller")
+	}
+	if len(c.informerGroup) != 0 {
+		t.Errorf("expected empty informerGroup when namespace skipped, got %d entries", len(c.informerGroup))
+	}
+}
+
+func TestNewController_WithNamespace(t *testing.T) {
+	t.Parallel()
+	opts := BuildOpts(context.Background(), []string{"default"}, &record.FakeRecorder{}, vsfake.NewSimpleClientset(), time.Duration(0), false)
+
+	c, err := NewController(opts)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil controller")
+	}
+	if _, ok := c.informerGroup["default"]; !ok {
+		t.Error("expected informerGroup to contain entry for 'default' namespace")
+	}
+}

--- a/internal/k8s/appprotect_dos.go
+++ b/internal/k8s/appprotect_dos.go
@@ -90,30 +90,39 @@ func createAppProtectDosProtectedResourceHandlers(lbc *LoadBalancerController) c
 }
 
 // addAppProtectDosPolicyHandler creates dynamic informers for custom appprotectdos policy resource
-func (nsi *namespacedInformer) addAppProtectDosPolicyHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addAppProtectDosPolicyHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.dynInformerFactory.ForResource(appprotectdos.DosPolicyGVR).Informer()
-	informer.AddEventHandler(handlers) //nolint:errcheck,gosec
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add AppProtectDosPolicy event handler: %w", err)
+	}
 	nsi.appProtectDosPolicyLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 // addAppProtectDosLogConfHandler creates dynamic informer for custom appprotectdos logging config resource
-func (nsi *namespacedInformer) addAppProtectDosLogConfHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addAppProtectDosLogConfHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.dynInformerFactory.ForResource(appprotectdos.DosLogConfGVR).Informer()
-	informer.AddEventHandler(handlers) //nolint:errcheck,gosec
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add AppProtectDosLogConf event handler: %w", err)
+	}
 	nsi.appProtectDosLogConfLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
-// addAppProtectDosLogConfHandler creates dynamic informers for custom appprotectdos logging config resource
-func (nsi *namespacedInformer) addAppProtectDosProtectedResourceHandler(handlers cache.ResourceEventHandlerFuncs) {
+// addAppProtectDosProtectedResourceHandler creates dynamic informers for custom appprotectdos protected resource
+func (nsi *namespacedInformer) addAppProtectDosProtectedResourceHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.confSharedInformerFactory.Appprotectdos().V1beta1().DosProtectedResources().Informer()
-	informer.AddEventHandler(handlers) //nolint:errcheck,gosec
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add AppProtectDosProtectedResource event handler: %w", err)
+	}
 	nsi.appProtectDosProtectedLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 func (lbc *LoadBalancerController) syncAppProtectDosPolicy(task task) {

--- a/internal/k8s/appprotect_waf.go
+++ b/internal/k8s/appprotect_waf.go
@@ -98,30 +98,39 @@ func createAppProtectUserSigHandlers(lbc *LoadBalancerController) cache.Resource
 }
 
 // addAppProtectPolicyHandler creates dynamic informers for custom appprotect policy resource
-func (nsi *namespacedInformer) addAppProtectPolicyHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addAppProtectPolicyHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.dynInformerFactory.ForResource(appprotect.PolicyGVR).Informer()
-	informer.AddEventHandler(handlers) //nolint:errcheck,gosec
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add AppProtectPolicy event handler: %w", err)
+	}
 	nsi.appProtectPolicyLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 // addAppProtectLogConfHandler creates dynamic informer for custom appprotect logging config resource
-func (nsi *namespacedInformer) addAppProtectLogConfHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addAppProtectLogConfHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.dynInformerFactory.ForResource(appprotect.LogConfGVR).Informer()
-	informer.AddEventHandler(handlers) //nolint:errcheck,gosec
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add AppProtectLogConf event handler: %w", err)
+	}
 	nsi.appProtectLogConfLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 // addAppProtectUserSigHandler creates dynamic informer for custom appprotect user defined signature resource
-func (nsi *namespacedInformer) addAppProtectUserSigHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addAppProtectUserSigHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.dynInformerFactory.ForResource(appprotect.UserSigGVR).Informer()
-	informer.AddEventHandler(handlers) //nolint:errcheck,gosec
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add AppProtectUserSig event handler: %w", err)
+	}
 	nsi.appProtectUserSigLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 func (lbc *LoadBalancerController) syncAppProtectPolicy(task task) {

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -305,15 +305,25 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 	isDynamicNs := input.WatchNamespaceLabel != ""
 
 	if isDynamicNs {
-		lbc.addNamespaceHandler(createNamespaceHandlers(lbc), input.WatchNamespaceLabel)
+		if err := lbc.addNamespaceHandler(createNamespaceHandlers(lbc), input.WatchNamespaceLabel); err != nil {
+			nl.Fatalf(lbc.Logger, "Failed to add namespace handler: %v", err)
+		}
 	}
 
 	if input.CertManagerEnabled {
-		lbc.certManagerController = cm_controller.NewCmController(cm_controller.BuildOpts(input.LoggerContext, lbc.restConfig, lbc.client, lbc.namespaceList, lbc.recorder, lbc.confClient, isDynamicNs))
+		var cmErr error
+		lbc.certManagerController, cmErr = cm_controller.NewCmController(cm_controller.BuildOpts(input.LoggerContext, lbc.restConfig, lbc.client, lbc.namespaceList, lbc.recorder, lbc.confClient, isDynamicNs))
+		if cmErr != nil {
+			nl.Fatalf(lbc.Logger, "Failed to create cert-manager controller: %v", cmErr)
+		}
 	}
 
 	if input.ExternalDNSEnabled {
-		lbc.externalDNSController = ed_controller.NewController(ed_controller.BuildOpts(input.LoggerContext, lbc.namespaceList, lbc.recorder, lbc.confClient, input.ResyncPeriod, isDynamicNs))
+		var edErr error
+		lbc.externalDNSController, edErr = ed_controller.NewController(ed_controller.BuildOpts(input.LoggerContext, lbc.namespaceList, lbc.recorder, lbc.confClient, input.ResyncPeriod, isDynamicNs))
+		if edErr != nil {
+			nl.Fatalf(lbc.Logger, "Failed to create external-dns controller: %v", edErr)
+		}
 	}
 
 	nl.Debugf(lbc.Logger, "Nginx Ingress Controller has class: %v", input.IngressClass)
@@ -324,7 +334,9 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 			// no initial namespaces with watched label - skip creating informers for now
 			break
 		}
-		lbc.newNamespacedInformer(ns)
+		if _, err := lbc.newNamespacedInformer(ns); err != nil {
+			nl.Fatalf(lbc.Logger, "Failed to create namespaced informer for namespace %s: %v", ns, err)
+		}
 	}
 
 	if lbc.areCustomResourcesEnabled {
@@ -357,7 +369,9 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 
 	if input.IngressLink != "" {
 		lbc.watchIngressLink = true
-		lbc.addIngressLinkHandler(createIngressLinkHandlers(lbc), input.IngressLink)
+		if err := lbc.addIngressLinkHandler(createIngressLinkHandlers(lbc), input.IngressLink); err != nil {
+			nl.Fatalf(lbc.Logger, "Failed to add ingress link handler: %v", err)
+		}
 	}
 
 	if input.IsLeaderElectionEnabled {
@@ -476,16 +490,22 @@ type namespacedInformer struct {
 	cacheSyncs                   []cache.InformerSynced
 }
 
-func (lbc *LoadBalancerController) newNamespacedInformer(ns string) *namespacedInformer {
+func (lbc *LoadBalancerController) newNamespacedInformer(ns string) (*namespacedInformer, error) {
 	nsi := &namespacedInformer{}
 	nsi.stopCh = make(chan struct{})
 	nsi.namespace = ns
 	nsi.sharedInformerFactory = informers.NewSharedInformerFactoryWithOptions(lbc.client, lbc.resync, informers.WithNamespace(ns))
 
 	// create handlers for resources we care about
-	nsi.addIngressHandler(createIngressHandlers(lbc))
-	nsi.addServiceHandler(createServiceHandlers(lbc))
-	nsi.addEndpointSliceHandler(createEndpointSliceHandlers(lbc))
+	if err := nsi.addIngressHandler(createIngressHandlers(lbc)); err != nil {
+		return nil, fmt.Errorf("failed to add ingress handler for namespace %s: %w", ns, err)
+	}
+	if err := nsi.addServiceHandler(createServiceHandlers(lbc)); err != nil {
+		return nil, fmt.Errorf("failed to add service handler for namespace %s: %w", ns, err)
+	}
+	if err := nsi.addEndpointSliceHandler(createEndpointSliceHandlers(lbc)); err != nil {
+		return nil, fmt.Errorf("failed to add endpoint slice handler for namespace %s: %w", ns, err)
+	}
 	nsi.addPodHandler()
 
 	secretsTweakListOptionsFunc := func(options *meta_v1.ListOptions) {
@@ -505,41 +525,81 @@ func (lbc *LoadBalancerController) newNamespacedInformer(ns string) *namespacedI
 		if v == "" || v == ns {
 			nsi.isSecretsEnabledNamespace = true
 			nsi.secretInformerFactory = informers.NewSharedInformerFactoryWithOptions(lbc.client, lbc.resync, informers.WithNamespace(ns), informers.WithTweakListOptions(secretsTweakListOptionsFunc))
-			nsi.addSecretHandler(createSecretHandlers(lbc))
+			if err := nsi.addSecretHandler(createSecretHandlers(lbc)); err != nil {
+				return nil, fmt.Errorf("failed to add secret handler for namespace %s: %w", ns, err)
+			}
 			break
 		}
 	}
 
-	if lbc.areCustomResourcesEnabled {
-		nsi.areCustomResourcesEnabled = true
-		nsi.confSharedInformerFactory = k8s_nginx_informers.NewSharedInformerFactoryWithOptions(lbc.confClient, lbc.resync, k8s_nginx_informers.WithNamespace(ns))
-
-		nsi.addVirtualServerHandler(createVirtualServerHandlers(lbc))
-		nsi.addVirtualServerRouteHandler(createVirtualServerRouteHandlers(lbc))
-		nsi.addTransportServerHandler(createTransportServerHandlers(lbc))
-		nsi.addPolicyHandler(createPolicyHandlers(lbc))
-
+	if err := lbc.addCustomResourceHandlers(nsi, ns); err != nil {
+		return nil, err
 	}
 
-	if lbc.appProtectEnabled || lbc.appProtectDosEnabled {
-		nsi.dynInformerFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(lbc.dynClient, 0, ns, nil)
-		if lbc.appProtectEnabled {
-			nsi.appProtectEnabled = true
-			nsi.addAppProtectPolicyHandler(createAppProtectPolicyHandlers(lbc))
-			nsi.addAppProtectLogConfHandler(createAppProtectLogConfHandlers(lbc))
-			nsi.addAppProtectUserSigHandler(createAppProtectUserSigHandlers(lbc))
-		}
-
-		if lbc.appProtectDosEnabled {
-			nsi.appProtectDosEnabled = true
-			nsi.addAppProtectDosPolicyHandler(createAppProtectDosPolicyHandlers(lbc))
-			nsi.addAppProtectDosLogConfHandler(createAppProtectDosLogConfHandlers(lbc))
-			nsi.addAppProtectDosProtectedResourceHandler(createAppProtectDosProtectedResourceHandlers(lbc))
-		}
+	if err := lbc.addAppProtectHandlers(nsi, ns); err != nil {
+		return nil, err
 	}
 
 	lbc.namespacedInformers[ns] = nsi
-	return nsi
+	return nsi, nil
+}
+
+// addCustomResourceHandlers sets up informers and event handlers for custom resources (VirtualServer,
+// VirtualServerRoute, TransportServer, Policy) when custom resources are enabled.
+func (lbc *LoadBalancerController) addCustomResourceHandlers(nsi *namespacedInformer, ns string) error {
+	if !lbc.areCustomResourcesEnabled {
+		return nil
+	}
+	nsi.areCustomResourcesEnabled = true
+	nsi.confSharedInformerFactory = k8s_nginx_informers.NewSharedInformerFactoryWithOptions(lbc.confClient, lbc.resync, k8s_nginx_informers.WithNamespace(ns))
+
+	if err := nsi.addVirtualServerHandler(createVirtualServerHandlers(lbc)); err != nil {
+		return fmt.Errorf("failed to add virtual server handler for namespace %s: %w", ns, err)
+	}
+	if err := nsi.addVirtualServerRouteHandler(createVirtualServerRouteHandlers(lbc)); err != nil {
+		return fmt.Errorf("failed to add virtual server route handler for namespace %s: %w", ns, err)
+	}
+	if err := nsi.addTransportServerHandler(createTransportServerHandlers(lbc)); err != nil {
+		return fmt.Errorf("failed to add transport server handler for namespace %s: %w", ns, err)
+	}
+	if err := nsi.addPolicyHandler(createPolicyHandlers(lbc)); err != nil {
+		return fmt.Errorf("failed to add policy handler for namespace %s: %w", ns, err)
+	}
+	return nil
+}
+
+// addAppProtectHandlers sets up informers and event handlers for App Protect and App Protect DoS
+// when the respective features are enabled.
+func (lbc *LoadBalancerController) addAppProtectHandlers(nsi *namespacedInformer, ns string) error {
+	if !lbc.appProtectEnabled && !lbc.appProtectDosEnabled {
+		return nil
+	}
+	nsi.dynInformerFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(lbc.dynClient, 0, ns, nil)
+	if lbc.appProtectEnabled {
+		nsi.appProtectEnabled = true
+		if err := nsi.addAppProtectPolicyHandler(createAppProtectPolicyHandlers(lbc)); err != nil {
+			return fmt.Errorf("failed to add app protect policy handler for namespace %s: %w", ns, err)
+		}
+		if err := nsi.addAppProtectLogConfHandler(createAppProtectLogConfHandlers(lbc)); err != nil {
+			return fmt.Errorf("failed to add app protect log conf handler for namespace %s: %w", ns, err)
+		}
+		if err := nsi.addAppProtectUserSigHandler(createAppProtectUserSigHandlers(lbc)); err != nil {
+			return fmt.Errorf("failed to add app protect user sig handler for namespace %s: %w", ns, err)
+		}
+	}
+	if lbc.appProtectDosEnabled {
+		nsi.appProtectDosEnabled = true
+		if err := nsi.addAppProtectDosPolicyHandler(createAppProtectDosPolicyHandlers(lbc)); err != nil {
+			return fmt.Errorf("failed to add app protect dos policy handler for namespace %s: %w", ns, err)
+		}
+		if err := nsi.addAppProtectDosLogConfHandler(createAppProtectDosLogConfHandlers(lbc)); err != nil {
+			return fmt.Errorf("failed to add app protect dos log conf handler for namespace %s: %w", ns, err)
+		}
+		if err := nsi.addAppProtectDosProtectedResourceHandler(createAppProtectDosProtectedResourceHandlers(lbc)); err != nil {
+			return fmt.Errorf("failed to add app protect dos protected resource handler for namespace %s: %w", ns, err)
+		}
+	}
+	return nil
 }
 
 // AddSyncQueue enqueues the provided item on the sync queue
@@ -548,21 +608,27 @@ func (lbc *LoadBalancerController) AddSyncQueue(item interface{}) {
 }
 
 // addSecretHandler adds the handler for secrets to the controller
-func (nsi *namespacedInformer) addSecretHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addSecretHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.secretInformerFactory.Core().V1().Secrets().Informer()
-	informer.AddEventHandler(handlers)
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add Secret event handler: %w", err)
+	}
 	nsi.secretLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 // addIngressHandler adds the handler for ingresses to the controller
-func (nsi *namespacedInformer) addIngressHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addIngressHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.sharedInformerFactory.Networking().V1().Ingresses().Informer()
-	informer.AddEventHandler(handlers)
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add Ingress event handler: %w", err)
+	}
 	nsi.ingressLister = storeToIngressLister{Store: informer.GetStore()}
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 func (nsi *namespacedInformer) addPodHandler() {
@@ -572,20 +638,26 @@ func (nsi *namespacedInformer) addPodHandler() {
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
 }
 
-func (nsi *namespacedInformer) addVirtualServerHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addVirtualServerHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.confSharedInformerFactory.K8s().V1().VirtualServers().Informer()
-	informer.AddEventHandler(handlers)
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add VirtualServer event handler: %w", err)
+	}
 	nsi.virtualServerLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
-func (nsi *namespacedInformer) addVirtualServerRouteHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addVirtualServerRouteHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.confSharedInformerFactory.K8s().V1().VirtualServerRoutes().Informer()
-	informer.AddEventHandler(handlers)
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add VirtualServerRoute event handler: %w", err)
+	}
 	nsi.virtualServerRouteLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 // Run starts the loadbalancer controller

--- a/internal/k8s/namespace.go
+++ b/internal/k8s/namespace.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	nl "github.com/nginx/kubernetes-ingress/internal/logger"
@@ -45,16 +46,19 @@ func createNamespaceHandlers(lbc *LoadBalancerController) cache.ResourceEventHan
 	}
 }
 
-func (lbc *LoadBalancerController) addNamespaceHandler(handlers cache.ResourceEventHandlerFuncs, nsLabel string) {
+func (lbc *LoadBalancerController) addNamespaceHandler(handlers cache.ResourceEventHandlerFuncs, nsLabel string) error {
 	optionsModifier := func(options *meta_v1.ListOptions) {
 		options.LabelSelector = nsLabel
 	}
 	nsInformer := informers.NewSharedInformerFactoryWithOptions(lbc.client, lbc.resync, informers.WithTweakListOptions(optionsModifier)).Core().V1().Namespaces().Informer()
-	nsInformer.AddEventHandler(handlers) //nolint:errcheck,gosec
+	if _, err := nsInformer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add Namespace event handler: %w", err)
+	}
 	lbc.namespaceLabeledLister = nsInformer.GetStore()
 	lbc.namespaceWatcherController = nsInformer
 
 	lbc.cacheSyncs = append(lbc.cacheSyncs, nsInformer.HasSynced)
+	return nil
 }
 
 func (lbc *LoadBalancerController) syncNamespace(task task) {
@@ -102,7 +106,13 @@ func (lbc *LoadBalancerController) syncNamespace(task task) {
 		nsi := lbc.getNamespacedInformer(key)
 		if nsi == nil {
 			nl.Infof(lbc.Logger, "Adding New Watched Namespace: %v", key)
-			nsi = lbc.newNamespacedInformer(key)
+			var err error
+			nsi, err = lbc.newNamespacedInformer(key)
+			if err != nil {
+				nl.Errorf(lbc.Logger, "Failed to create namespaced informer for namespace %s: %v", key, err)
+				lbc.syncQueue.Requeue(task, err)
+				return
+			}
 			nsi.start()
 		}
 		if lbc.certManagerController != nil {

--- a/internal/k8s/namespaced_informer_test.go
+++ b/internal/k8s/namespaced_informer_test.go
@@ -1,0 +1,190 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	nl "github.com/nginx/kubernetes-ingress/internal/logger"
+	k8s_nginx_fake "github.com/nginx/kubernetes-ingress/pkg/client/clientset/versioned/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestAddCustomResourceHandlers_Disabled(t *testing.T) {
+	t.Parallel()
+	lbc := &LoadBalancerController{areCustomResourcesEnabled: false}
+	nsi := &namespacedInformer{}
+
+	err := lbc.addCustomResourceHandlers(nsi, "test-ns")
+	if err != nil {
+		t.Errorf("expected nil error when custom resources disabled, got %v", err)
+	}
+	if nsi.areCustomResourcesEnabled {
+		t.Error("expected nsi.areCustomResourcesEnabled to remain false")
+	}
+	if nsi.confSharedInformerFactory != nil {
+		t.Error("expected nsi.confSharedInformerFactory to remain nil")
+	}
+	if len(nsi.cacheSyncs) != 0 {
+		t.Errorf("expected no cacheSyncs when disabled, got %d", len(nsi.cacheSyncs))
+	}
+}
+
+func TestAddCustomResourceHandlers_Enabled(t *testing.T) {
+	t.Parallel()
+	lbc := &LoadBalancerController{
+		areCustomResourcesEnabled: true,
+		confClient:                k8s_nginx_fake.NewSimpleClientset(),
+		Logger:                    nl.LoggerFromContext(context.Background()),
+	}
+	nsi := &namespacedInformer{}
+
+	err := lbc.addCustomResourceHandlers(nsi, "test-ns")
+	if err != nil {
+		t.Errorf("expected nil error when custom resources enabled, got %v", err)
+	}
+	if !nsi.areCustomResourcesEnabled {
+		t.Error("expected nsi.areCustomResourcesEnabled to be true")
+	}
+	if nsi.confSharedInformerFactory == nil {
+		t.Error("expected nsi.confSharedInformerFactory to be set")
+	}
+	// VS, VSR, TransportServer, Policy
+	const wantCacheSyncs = 4
+	if len(nsi.cacheSyncs) != wantCacheSyncs {
+		t.Errorf("expected %d cacheSyncs, got %d", wantCacheSyncs, len(nsi.cacheSyncs))
+	}
+}
+
+func TestAddAppProtectHandlers_Disabled(t *testing.T) {
+	t.Parallel()
+	lbc := &LoadBalancerController{
+		appProtectEnabled:    false,
+		appProtectDosEnabled: false,
+	}
+	nsi := &namespacedInformer{}
+
+	err := lbc.addAppProtectHandlers(nsi, "test-ns")
+	if err != nil {
+		t.Errorf("expected nil error when app protect disabled, got %v", err)
+	}
+	if nsi.appProtectEnabled {
+		t.Error("expected nsi.appProtectEnabled to remain false")
+	}
+	if nsi.appProtectDosEnabled {
+		t.Error("expected nsi.appProtectDosEnabled to remain false")
+	}
+	if nsi.dynInformerFactory != nil {
+		t.Error("expected nsi.dynInformerFactory to remain nil")
+	}
+	if len(nsi.cacheSyncs) != 0 {
+		t.Errorf("expected no cacheSyncs when disabled, got %d", len(nsi.cacheSyncs))
+	}
+}
+
+func TestAddAppProtectHandlers_AppProtectEnabled(t *testing.T) {
+	t.Parallel()
+	lbc := &LoadBalancerController{
+		appProtectEnabled:    true,
+		appProtectDosEnabled: false,
+		dynClient:            dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		Logger:               nl.LoggerFromContext(context.Background()),
+	}
+	nsi := &namespacedInformer{}
+
+	err := lbc.addAppProtectHandlers(nsi, "test-ns")
+	if err != nil {
+		t.Errorf("expected nil error when app protect enabled, got %v", err)
+	}
+	if !nsi.appProtectEnabled {
+		t.Error("expected nsi.appProtectEnabled to be true")
+	}
+	if nsi.appProtectDosEnabled {
+		t.Error("expected nsi.appProtectDosEnabled to remain false")
+	}
+	if nsi.dynInformerFactory == nil {
+		t.Error("expected nsi.dynInformerFactory to be set")
+	}
+	// Policy, LogConf, UserSig
+	const wantCacheSyncs = 3
+	if len(nsi.cacheSyncs) != wantCacheSyncs {
+		t.Errorf("expected %d cacheSyncs for app protect, got %d", wantCacheSyncs, len(nsi.cacheSyncs))
+	}
+}
+
+func TestAddAppProtectHandlers_AppProtectDosEnabled(t *testing.T) {
+	t.Parallel()
+	fakeVsClient := k8s_nginx_fake.NewSimpleClientset()
+	lbc := &LoadBalancerController{
+		appProtectEnabled:         false,
+		appProtectDosEnabled:      true,
+		areCustomResourcesEnabled: true,
+		confClient:                fakeVsClient,
+		dynClient:                 dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		Logger:                    nl.LoggerFromContext(context.Background()),
+	}
+	nsi := &namespacedInformer{}
+
+	// addAppProtectDosProtectedResourceHandler depends on confSharedInformerFactory
+	// which is set by addCustomResourceHandlers — mirror the production call order.
+	if err := lbc.addCustomResourceHandlers(nsi, "test-ns"); err != nil {
+		t.Fatalf("addCustomResourceHandlers failed: %v", err)
+	}
+	initialCacheSyncs := len(nsi.cacheSyncs)
+
+	err := lbc.addAppProtectHandlers(nsi, "test-ns")
+	if err != nil {
+		t.Errorf("expected nil error when app protect dos enabled, got %v", err)
+	}
+	if nsi.appProtectEnabled {
+		t.Error("expected nsi.appProtectEnabled to remain false")
+	}
+	if !nsi.appProtectDosEnabled {
+		t.Error("expected nsi.appProtectDosEnabled to be true")
+	}
+	if nsi.dynInformerFactory == nil {
+		t.Error("expected nsi.dynInformerFactory to be set")
+	}
+	// DosPolicy, DosLogConf, DosProtectedResource
+	const wantAdditionalCacheSyncs = 3
+	if got := len(nsi.cacheSyncs) - initialCacheSyncs; got != wantAdditionalCacheSyncs {
+		t.Errorf("expected %d additional cacheSyncs for app protect dos, got %d", wantAdditionalCacheSyncs, got)
+	}
+}
+
+func TestAddAppProtectHandlers_BothEnabled(t *testing.T) {
+	t.Parallel()
+	fakeVsClient := k8s_nginx_fake.NewSimpleClientset()
+	lbc := &LoadBalancerController{
+		appProtectEnabled:         true,
+		appProtectDosEnabled:      true,
+		areCustomResourcesEnabled: true,
+		confClient:                fakeVsClient,
+		dynClient:                 dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		Logger:                    nl.LoggerFromContext(context.Background()),
+	}
+	nsi := &namespacedInformer{}
+
+	// addAppProtectDosProtectedResourceHandler depends on confSharedInformerFactory
+	// which is set by addCustomResourceHandlers — mirror the production call order.
+	if err := lbc.addCustomResourceHandlers(nsi, "test-ns"); err != nil {
+		t.Fatalf("addCustomResourceHandlers failed: %v", err)
+	}
+	initialCacheSyncs := len(nsi.cacheSyncs)
+
+	err := lbc.addAppProtectHandlers(nsi, "test-ns")
+	if err != nil {
+		t.Errorf("expected nil error when both app protect features enabled, got %v", err)
+	}
+	if !nsi.appProtectEnabled {
+		t.Error("expected nsi.appProtectEnabled to be true")
+	}
+	if !nsi.appProtectDosEnabled {
+		t.Error("expected nsi.appProtectDosEnabled to be true")
+	}
+	// Policy, LogConf, UserSig + DosPolicy, DosLogConf, DosProtectedResource
+	const wantAdditionalCacheSyncs = 6
+	if got := len(nsi.cacheSyncs) - initialCacheSyncs; got != wantAdditionalCacheSyncs {
+		t.Errorf("expected %d additional cacheSyncs when both enabled, got %d", wantAdditionalCacheSyncs, got)
+	}
+}

--- a/internal/k8s/policy.go
+++ b/internal/k8s/policy.go
@@ -47,12 +47,15 @@ func createPolicyHandlers(lbc *LoadBalancerController) cache.ResourceEventHandle
 	}
 }
 
-func (nsi *namespacedInformer) addPolicyHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addPolicyHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.confSharedInformerFactory.K8s().V1().Policies().Informer()
-	informer.AddEventHandler(handlers) //nolint:errcheck,gosec
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add Policy event handler: %w", err)
+	}
 	nsi.policyLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 func (lbc *LoadBalancerController) syncPolicy(task task) {

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -129,12 +129,15 @@ func (a portSort) Less(i, j int) bool {
 }
 
 // addServiceHandler adds the handler for services to the controller
-func (nsi *namespacedInformer) addServiceHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addServiceHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.sharedInformerFactory.Core().V1().Services().Informer()
-	informer.AddEventHandler(handlers) //nolint:errcheck,gosec
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add Service event handler: %w", err)
+	}
 	nsi.svcLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 func (lbc *LoadBalancerController) syncZoneSyncHeadlessService(svcName string) error {

--- a/internal/k8s/transport_server.go
+++ b/internal/k8s/transport_server.go
@@ -49,12 +49,15 @@ func createTransportServerHandlers(lbc *LoadBalancerController) cache.ResourceEv
 	}
 }
 
-func (nsi *namespacedInformer) addTransportServerHandler(handlers cache.ResourceEventHandlerFuncs) {
+func (nsi *namespacedInformer) addTransportServerHandler(handlers cache.ResourceEventHandlerFuncs) error {
 	informer := nsi.confSharedInformerFactory.K8s().V1().TransportServers().Informer()
-	informer.AddEventHandler(handlers) //nolint:errcheck,gosec
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return fmt.Errorf("failed to add TransportServer event handler: %w", err)
+	}
 	nsi.transportServerLister = informer.GetStore()
 
 	nsi.cacheSyncs = append(nsi.cacheSyncs, informer.HasSynced)
+	return nil
 }
 
 func (lbc *LoadBalancerController) syncTransportServer(task task) {


### PR DESCRIPTION
* fix: resolve unchecked error returns and remove lint suppressions

- Fix all Priority 1 errcheck lint issues (9 total)
- Remove //nolint:errcheck,gosec suppressions and replace with proper error handling
- Update event handler methods to return errors consistently:
  - addServiceHandler, addEndpointSliceHandler, addTransportServerHandler
  - addPolicyHandler, addAppProtectPolicyHandler, addAppProtectLogConfHandler
  - addAppProtectUserSigHandler, addAppProtectDosPolicyHandler, addAppProtectDosLogConfHandler
  - addAppProtectDosProtectedResourceHandler, addNamespaceHandler, addIngressLinkHandler
- Update function signatures and all callers to handle error returns
- Add proper error context and logging for failed event handler registrations
- Fix HTTP readiness handler to check fmt.Fprintln error return
- Fix test cleanup in template tests to handle snaps.Clean errors
- Add missing fmt imports where needed
- Ensure consistent error handling across all Kubernetes informer registrations
- Properly handle cases when event handler registration fails, preventing silent failures
- Note: Increased cyclomatic complexity in newNamespacedInformer from 22→24 due to proper error handling

* fix: enhance error handling in controllers and informers

* test: add unit tests for LoadBalancerController and namespacedInformer functionality

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
