### PR TITLE
disable renovate on release-5.5 branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -403,7 +403,6 @@
   "automergeType": "pr",
   "baseBranchPatterns": [
     "main",
-    "release-5.5",
     "release-2026-lts"
   ],
   "commitBodyTable": true,


### PR DESCRIPTION
### Proposed changes

Removes `release-5.5` from renovates list of branches

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
