### PR TITLE
update network policy template for upgrade case

### DIFF
--- a/charts/nginx-ingress/templates/controller-networkpolicy.yaml
+++ b/charts/nginx-ingress/templates/controller-networkpolicy.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.controller.networkPolicy.enabled }}
-{{- $ingress := .Values.controller.networkPolicy.ingress }}
-{{- $egress := .Values.controller.networkPolicy.egress }}
+{{- $np := default (dict) .Values.controller.networkPolicy -}}
+{{- if $np.enabled }}
+{{- $ingress := $np.ingress }}
+{{- $egress := $np.egress }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/tests/helmunit_test.go
+++ b/charts/tests/helmunit_test.go
@@ -351,3 +351,35 @@ func TestHelmNICTemplateNegative(t *testing.T) {
 		})
 	}
 }
+
+// TestHelmNICNetworkPolicyLegacyValues renders the chart with legacy values
+// that omit controller.networkPolicy, the state a release ends up in on
+// `helm upgrade --reuse-values` from a version that predates the feature.
+func TestHelmNICNetworkPolicyLegacyValues(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../nginx-ingress")
+	if err != nil {
+		t.Fatal("Failed to open helm chart path ../nginx-ingress")
+	}
+
+	options := &helm.Options{
+		KubectlOptions: k8s.NewKubectlOptions("", "", "default"),
+		ValuesFiles:    []string{"testdata/network-policy-legacy-values.yaml"},
+	}
+
+	// The values.schema.json types networkPolicy as "object" and rejects an
+	// explicit null; the real --reuse-values path skips this check because the
+	// key is simply absent.
+	output, err := helm.RenderTemplateE(t, options, helmChartPath, "network-policy-legacy", make([]string, 0), "--skip-schema-validation")
+	if err != nil {
+		t.Fatalf("helm template must succeed when controller.networkPolicy is absent, got: %v", err)
+	}
+
+	if strings.Contains(output, "kind: NetworkPolicy") {
+		t.Fatalf("expected no NetworkPolicy resource when controller.networkPolicy is absent, rendered output:\n%s", output)
+	}
+	if strings.Contains(output, "controller-networkpolicy.yaml") {
+		t.Fatalf("expected controller-networkpolicy.yaml to render empty, rendered output:\n%s", output)
+	}
+}

--- a/charts/tests/testdata/network-policy-legacy-values.yaml
+++ b/charts/tests/testdata/network-policy-legacy-values.yaml
@@ -1,0 +1,2 @@
+controller:
+  networkPolicy: null


### PR DESCRIPTION
### Proposed changes

- PR to fix network policy template which causes helm upgrade failure when using `--reuse-values` flag as it didn't existed in last release

```
Error: UPGRADE FAILED: nginx-ingress/templates/controller-networkpolicy.yaml:1:14
  executing "nginx-ingress/templates/controller-networkpolicy.yaml" at <.Values.controller.networkPolicy.enabled>:
    nil pointer evaluating interface {}.enabled
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
