### PR TITLE
fix dos-nap image destination path

### DIFF
--- a/.github/config/config-prep-nginx-test
+++ b/.github/config/config-prep-nginx-test
@@ -1,18 +1,8 @@
 export TARGET_REGISTRY=docker-mgmt-test.nginx.com
-
-## Image prefixes are deliberately left at their defaults so that the prepped
-## images in docker-mgmt-test mirror the dev/release GCR layout. The publish
-## stage reads them back using the same defaults, so any prefix override here
-## must be matched by a SOURCE_* override in every publish config.
-declare -a OSS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine")
+export TARGET_NAP_WAF_DOS_IMAGE_PREFIX="nginx-ic-nap-dos/nginx-plus-ingress"
 declare -a PLUS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine" "-alpine-fips")
-declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "-alpine-fips" "-agent" "-ubi-agent" "-alpine-fips-agent")
-declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "-alpine-fips" "-agent" "-ubi-agent" "-alpine-fips-agent")
+declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "-alpine-fips"  "-agent" "-ubi-agent" "-alpine-fips-agent")
+declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "-alpine-fips"  "-agent" "-ubi-agent" "-alpine-fips-agent")
 declare -a NAP_DOS_TAG_POSTFIX_LIST=("" "-ubi")
 declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-agent" "-ubi-agent")
-
-export PUBLISH_OSS=true
-export PUBLISH_PLUS=true
-export PUBLISH_WAF=true
-export PUBLISH_DOS=true
-export PUBLISH_WAF_DOS=true
+export PUBLISH_OSS=false


### PR DESCRIPTION
### Proposed changes

Staging is currently storing our WAF+DOS images under `nginx-ic-dos-nap/...`. This change ensures the staging registry matches the production location of `nginx-ic-nap-dos/...`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
