### PR TITLE
Fix nil pointer panic when namespace is no longer watched

### DIFF
--- a/internal/k8s/appprotect_dos.go
+++ b/internal/k8s/appprotect_dos.go
@@ -134,7 +134,11 @@ func (lbc *LoadBalancerController) syncAppProtectDosPolicy(task task) {
 	var polExists bool
 	var err error
 
-	obj, polExists, err = lbc.getNamespacedInformer(ns).appProtectDosPolicyLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, polExists, err = nsi.appProtectDosPolicyLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return
@@ -164,7 +168,11 @@ func (lbc *LoadBalancerController) syncAppProtectDosLogConf(task task) {
 	var confExists bool
 	var err error
 
-	obj, confExists, err = lbc.getNamespacedInformer(ns).appProtectDosLogConfLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, confExists, err = nsi.appProtectDosLogConfLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return
@@ -194,7 +202,11 @@ func (lbc *LoadBalancerController) syncDosProtectedResource(task task) {
 	var confExists bool
 	var err error
 
-	obj, confExists, err = lbc.getNamespacedInformer(ns).appProtectDosProtectedLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, confExists, err = nsi.appProtectDosProtectedLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return

--- a/internal/k8s/appprotect_dos_test.go
+++ b/internal/k8s/appprotect_dos_test.go
@@ -1,0 +1,49 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	nl "github.com/nginx/kubernetes-ingress/internal/logger"
+)
+
+// TestAppProtectDosSyncNamespaceNotWatched guards against a nil pointer dereference
+// panic (see getNamespacedInformer) when an AppProtectDos-related task for a namespace
+// that is no longer watched (e.g. its watch-namespace-label was removed) is processed.
+func TestAppProtectDosSyncNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sync func(lbc *LoadBalancerController, key string)
+	}{
+		{
+			name: "AppProtectDosPolicy",
+			sync: func(lbc *LoadBalancerController, key string) {
+				lbc.syncAppProtectDosPolicy(task{Kind: appProtectDosPolicy, Key: key})
+			},
+		},
+		{
+			name: "AppProtectDosLogConf",
+			sync: func(lbc *LoadBalancerController, key string) {
+				lbc.syncAppProtectDosLogConf(task{Kind: appProtectDosLogConf, Key: key})
+			},
+		},
+		{
+			name: "DosProtectedResource",
+			sync: func(lbc *LoadBalancerController, key string) {
+				lbc.syncDosProtectedResource(task{Kind: appProtectDosProtectedResource, Key: key})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lbc := &LoadBalancerController{
+				namespacedInformers: map[string]*namespacedInformer{},
+				Logger:              nl.LoggerFromContext(context.Background()),
+			}
+			tc.sync(lbc, "not-watched/some-resource")
+		})
+	}
+}

--- a/internal/k8s/appprotect_waf.go
+++ b/internal/k8s/appprotect_waf.go
@@ -160,7 +160,11 @@ func (lbc *LoadBalancerController) syncAppProtectPolicy(task task) {
 
 	ns, n, _ := cache.SplitMetaNamespaceKey(key)
 	logger := lbc.Logger.With(logNamespaceKey, ns, logKindKey, appProtectKind, logNameKey, n)
-	obj, polExists, err = lbc.getNamespacedInformer(ns).appProtectPolicyLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, polExists, err = nsi.appProtectPolicyLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return
@@ -197,7 +201,11 @@ func (lbc *LoadBalancerController) syncAppProtectLogConf(task task) {
 
 	ns, n, _ := cache.SplitMetaNamespaceKey(key)
 	logger := lbc.Logger.With(logNamespaceKey, ns, logKindKey, appProtectLogConfKind, logNameKey, n)
-	obj, confExists, err = lbc.getNamespacedInformer(ns).appProtectLogConfLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, confExists, err = nsi.appProtectLogConfLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return
@@ -234,7 +242,11 @@ func (lbc *LoadBalancerController) syncAppProtectUserSig(task task) {
 
 	ns, n, _ := cache.SplitMetaNamespaceKey(key)
 	logger := lbc.Logger.With(logNamespaceKey, ns, logKindKey, appProtectUserSigKind, logNameKey, n)
-	obj, sigExists, err = lbc.getNamespacedInformer(ns).appProtectUserSigLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, sigExists, err = nsi.appProtectUserSigLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return

--- a/internal/k8s/appprotect_waf_test.go
+++ b/internal/k8s/appprotect_waf_test.go
@@ -16,6 +16,47 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// TestAppProtectSyncNamespaceNotWatched guards against a nil pointer dereference
+// panic (see getNamespacedInformer) when an AppProtect-related task for a namespace
+// that is no longer watched (e.g. its watch-namespace-label was removed) is processed.
+func TestAppProtectSyncNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sync func(lbc *LoadBalancerController, key string)
+	}{
+		{
+			name: "AppProtectPolicy",
+			sync: func(lbc *LoadBalancerController, key string) {
+				lbc.syncAppProtectPolicy(task{Kind: appProtectPolicy, Key: key})
+			},
+		},
+		{
+			name: "AppProtectLogConf",
+			sync: func(lbc *LoadBalancerController, key string) {
+				lbc.syncAppProtectLogConf(task{Kind: appProtectLogConf, Key: key})
+			},
+		},
+		{
+			name: "AppProtectUserSig",
+			sync: func(lbc *LoadBalancerController, key string) {
+				lbc.syncAppProtectUserSig(task{Kind: appProtectUserSig, Key: key})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(_ *testing.T) {
+			lbc := &LoadBalancerController{
+				namespacedInformers: map[string]*namespacedInformer{},
+				Logger:              nl.LoggerFromContext(context.Background()),
+			}
+			tc.sync(lbc, "not-watched/some-resource")
+		})
+	}
+}
+
 func TestAddWAFPolicyRefs(t *testing.T) {
 	t.Parallel()
 	apPol := &unstructured.Unstructured{

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1525,7 +1525,11 @@ func (lbc *LoadBalancerController) syncVirtualServer(task task) {
 
 	ns, n, _ := cache.SplitMetaNamespaceKey(key)
 	l := lbc.Logger.With(logNamespaceKey, ns, logKindKey, virtualServerKind, logNameKey, n)
-	obj, vsExists, err = lbc.getNamespacedInformer(ns).virtualServerLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, vsExists, err = nsi.virtualServerLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return
@@ -1654,9 +1658,11 @@ func (lbc *LoadBalancerController) processDelete(c ResourceChange) {
 		var vsExists bool
 		var err error
 
-		_, vsExists, err = lbc.getNamespacedInformer(ns).virtualServerLister.GetByKey(key)
-		if err != nil {
-			nl.Errorf(l, "Error when getting VirtualServer for %v: %v", key, err)
+		if nsi := lbc.getNamespacedInformer(ns); nsi != nil {
+			_, vsExists, err = nsi.virtualServerLister.GetByKey(key)
+			if err != nil {
+				nl.Errorf(l, "Error when getting VirtualServer for %v: %v", key, err)
+			}
 		}
 
 		if vsExists {
@@ -1677,9 +1683,11 @@ func (lbc *LoadBalancerController) processDelete(c ResourceChange) {
 		var ingExists bool
 		var err error
 
-		_, ingExists, err = lbc.getNamespacedInformer(ns).ingressLister.GetByKeySafe(key)
-		if err != nil {
-			nl.Errorf(l, "Error when getting Ingress for %v: %v", key, err)
+		if nsi := lbc.getNamespacedInformer(ns); nsi != nil {
+			_, ingExists, err = nsi.ingressLister.GetByKeySafe(key)
+			if err != nil {
+				nl.Errorf(l, "Error when getting Ingress for %v: %v", key, err)
+			}
 		}
 
 		if ingExists {
@@ -1699,9 +1707,11 @@ func (lbc *LoadBalancerController) processDelete(c ResourceChange) {
 		var tsExists bool
 		var err error
 
-		_, tsExists, err = lbc.getNamespacedInformer(ns).transportServerLister.GetByKey(key)
-		if err != nil {
-			nl.Errorf(l, "Error when getting TransportServer for %v: %v", key, err)
+		if nsi := lbc.getNamespacedInformer(ns); nsi != nil {
+			_, tsExists, err = nsi.transportServerLister.GetByKey(key)
+			if err != nil {
+				nl.Errorf(l, "Error when getting TransportServer for %v: %v", key, err)
+			}
 		}
 		if tsExists {
 			lbc.updateTransportServerStatusAndEventsOnDelete(impl, c.Error, deleteErr)
@@ -2034,7 +2044,11 @@ func (lbc *LoadBalancerController) syncVirtualServerRoute(task task) {
 
 	ns, n, _ := cache.SplitMetaNamespaceKey(key)
 	l := lbc.Logger.With(logNamespaceKey, ns, logKindKey, virtualServerRouteKind, logNameKey, n)
-	obj, exists, err = lbc.getNamespacedInformer(ns).virtualServerRouteLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, exists, err = nsi.virtualServerRouteLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return
@@ -2066,7 +2080,11 @@ func (lbc *LoadBalancerController) syncIngress(task task) {
 
 	ns, n, _ := cache.SplitMetaNamespaceKey(key)
 	l := lbc.Logger.With(logNamespaceKey, ns, logKindKey, ingressKind, logNameKey, n)
-	ing, ingExists, err = lbc.getNamespacedInformer(ns).ingressLister.GetByKeySafe(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	ing, ingExists, err = nsi.ingressLister.GetByKeySafe(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return
@@ -2323,7 +2341,11 @@ func (lbc *LoadBalancerController) syncSecret(task task) {
 		return
 	}
 	l := lbc.Logger.With(logNamespaceKey, namespace, logKindKey, secretKind, logNameKey, name)
-	obj, secretWatched, err = lbc.getNamespacedInformer(namespace).secretLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(namespace)
+	if nsi == nil {
+		return
+	}
+	obj, secretWatched, err = nsi.secretLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return
@@ -4178,7 +4200,12 @@ func (lbc *LoadBalancerController) getExternalEndpointsForIngressBackend(backend
 
 func (lbc *LoadBalancerController) getEndpointsForIngressBackend(backend *networking.IngressBackend, svc *api_v1.Service) (result []podEndpoint, isExternal bool, err error) {
 	var endpointSlices []discovery_v1.EndpointSlice
-	endpointSlices, err = lbc.getNamespacedInformer(svc.Namespace).endpointSliceLister.GetServiceEndpointSlices(svc)
+	nsi := lbc.getNamespacedInformer(svc.Namespace)
+	if nsi == nil {
+		err = fmt.Errorf("namespace %s is not watched", svc.Namespace)
+	} else {
+		endpointSlices, err = nsi.endpointSliceLister.GetServiceEndpointSlices(svc)
+	}
 	if err != nil {
 		if svc.Spec.Type == api_v1.ServiceTypeExternalName {
 			if !lbc.isNginxPlus {
@@ -4250,7 +4277,11 @@ func (lbc *LoadBalancerController) getPodOwnerTypeAndNameFromAddress(ns, name st
 	var exists bool
 	var err error
 
-	obj, exists, err = lbc.getNamespacedInformer(ns).podLister.GetByKey(fmt.Sprintf("%s/%s", ns, name))
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return "", ""
+	}
+	obj, exists, err = nsi.podLister.GetByKey(fmt.Sprintf("%s/%s", ns, name))
 	if err != nil {
 		nl.Warnf(lbc.Logger, "could not get pod by key %s/%s: %v", ns, name, err)
 		return "", ""
@@ -4298,7 +4329,11 @@ func (lbc *LoadBalancerController) getTargetPort(svcPort api_v1.ServicePort, svc
 
 	var pods []*api_v1.Pod
 	var err error
-	pods, err = lbc.getNamespacedInformer(svc.Namespace).podLister.ListByNamespace(svc.Namespace, labels.Set(svc.Spec.Selector).AsSelector())
+	nsi := lbc.getNamespacedInformer(svc.Namespace)
+	if nsi == nil {
+		return 0, fmt.Errorf("namespace %s is not watched", svc.Namespace)
+	}
+	pods, err = nsi.podLister.ListByNamespace(svc.Namespace, labels.Set(svc.Spec.Selector).AsSelector())
 	if err != nil {
 		return 0, fmt.Errorf("error getting pod information: %w", err)
 	}
@@ -4335,7 +4370,11 @@ func (lbc *LoadBalancerController) getServiceForIngressBackend(backend *networki
 	var svcExists bool
 	var err error
 
-	svcObj, svcExists, err = lbc.getNamespacedInformer(namespace).svcLister.GetByKey(svcKey)
+	nsi := lbc.getNamespacedInformer(namespace)
+	if nsi == nil {
+		return nil, fmt.Errorf("service %s doesn't exist", svcKey)
+	}
+	svcObj, svcExists, err = nsi.svcLister.GetByKey(svcKey)
 	if err != nil {
 		return nil, err
 	}
@@ -4637,9 +4676,11 @@ func (lbc *LoadBalancerController) haltIfVSConfigInvalid(vsNew *conf_v1.VirtualS
 				var vsExists bool
 				var err error
 
-				_, vsExists, err = lbc.getNamespacedInformer(ns).virtualServerLister.GetByKey(key)
-				if err != nil {
-					nl.Errorf(l, "Error when getting VirtualServer for %v: %v", key, err)
+				if nsi := lbc.getNamespacedInformer(ns); nsi != nil {
+					_, vsExists, err = nsi.virtualServerLister.GetByKey(key)
+					if err != nil {
+						nl.Errorf(l, "Error when getting VirtualServer for %v: %v", key, err)
+					}
 				}
 
 				if vsExists {

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -2681,6 +2681,179 @@ func TestProcessChangesDispatchesDelete(t *testing.T) {
 	})
 }
 
+// The following tests guard against a nil pointer dereference panic (see
+// getNamespacedInformer) when a resource for a namespace that is no longer watched
+// (e.g. its watch-namespace-label was removed) is processed.
+
+func TestProcessDeleteNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	newLBC := func(t *testing.T) *LoadBalancerController {
+		t.Helper()
+		manager := nginx.NewFakeManager("/etc/nginx")
+		return &LoadBalancerController{
+			configurator:        createTestPolicySyncConfigurator(t, manager),
+			recorder:            record.NewFakeRecorder(100),
+			secretStore:         secrets.NewEmptyFakeSecretsStore(),
+			namespacedInformers: map[string]*namespacedInformer{},
+			Logger:              nl.LoggerFromContext(context.Background()),
+		}
+	}
+
+	t.Run("Ingress", func(t *testing.T) {
+		t.Parallel()
+		lbc := newLBC(t)
+		ing := createTestIngress("not-watched-ingress", "example.com")
+		lbc.processDelete(ResourceChange{Op: Delete, Resource: NewRegularIngressConfiguration(ing)})
+	})
+
+	t.Run("VirtualServer", func(t *testing.T) {
+		t.Parallel()
+		lbc := newLBC(t)
+		vs := createTestVirtualServer("not-watched-vs", "example.com")
+		lbc.processDelete(ResourceChange{
+			Op: Delete,
+			Resource: &VirtualServerConfiguration{
+				VirtualServer:               vs,
+				VirtualServerRouteSelectors: map[string][]string{},
+			},
+		})
+	})
+
+	t.Run("TransportServer", func(t *testing.T) {
+		t.Parallel()
+		lbc := newLBC(t)
+		ts := createTestTLSPassthroughTransportServer("not-watched-ts", "example.com")
+		lbc.processDelete(ResourceChange{
+			Op:       Delete,
+			Resource: &TransportServerConfiguration{TransportServer: ts},
+		})
+	})
+}
+
+func TestSyncVirtualServerNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+	lbc.syncVirtualServer(task{Kind: virtualserver, Key: "not-watched/some-vs"})
+}
+
+func TestSyncVirtualServerRouteNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+	lbc.syncVirtualServerRoute(task{Kind: virtualServerRoute, Key: "not-watched/some-vsr"})
+}
+
+func TestSyncIngressNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+	lbc.syncIngress(task{Kind: ingress, Key: "not-watched/some-ingress"})
+}
+
+func TestSyncSecretNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+	lbc.syncSecret(task{Kind: secret, Key: "not-watched/some-secret"})
+}
+
+func TestGetServiceForIngressBackendNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+
+	backend := &networking.IngressBackend{
+		Service: &networking.IngressServiceBackend{Name: "some-service"},
+	}
+	svc, err := lbc.getServiceForIngressBackend(backend, "not-watched")
+	if svc != nil {
+		t.Errorf("getServiceForIngressBackend() returned %v, expected nil", svc)
+	}
+	if err == nil {
+		t.Error("getServiceForIngressBackend() returned nil error, expected an error for an unwatched namespace")
+	}
+}
+
+func TestGetEndpointsForIngressBackendNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+
+	backend := &networking.IngressBackend{
+		Service: &networking.IngressServiceBackend{Name: "some-service"},
+	}
+	svc := &api_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "some-service", Namespace: "not-watched"},
+	}
+	result, isExternal, err := lbc.getEndpointsForIngressBackend(backend, svc)
+	if result != nil {
+		t.Errorf("getEndpointsForIngressBackend() returned %v, expected nil", result)
+	}
+	if isExternal {
+		t.Error("getEndpointsForIngressBackend() returned isExternal=true, expected false for an unwatched namespace")
+	}
+	if err == nil {
+		t.Error("getEndpointsForIngressBackend() returned nil error, expected an error for an unwatched namespace")
+	}
+}
+
+func TestGetTargetPortNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+
+	svcPort := api_v1.ServicePort{
+		TargetPort: intstr.FromString("http"),
+	}
+	svc := &api_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "some-service", Namespace: "not-watched"},
+	}
+	port, err := lbc.getTargetPort(svcPort, svc)
+	if port != 0 {
+		t.Errorf("getTargetPort() returned port %v, expected 0", port)
+	}
+	if err == nil {
+		t.Error("getTargetPort() returned nil error, expected an error for an unwatched namespace")
+	}
+}
+
+func TestGetPodOwnerTypeAndNameFromAddressNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+
+	parentType, parentName := lbc.getPodOwnerTypeAndNameFromAddress("not-watched", "some-pod")
+	if parentType != "" || parentName != "" {
+		t.Errorf("getPodOwnerTypeAndNameFromAddress() returned (%q, %q), expected (\"\", \"\") for an unwatched namespace", parentType, parentName)
+	}
+}
+
 func TestGetPodOwnerTypeAndName(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/k8s/endpoint_slice.go
+++ b/internal/k8s/endpoint_slice.go
@@ -67,7 +67,11 @@ func (lbc *LoadBalancerController) syncEndpointSlices(task task) bool {
 	var resourcesFound bool
 
 	ns, n, _ := cache.SplitMetaNamespaceKey(key)
-	obj, endpointSliceExists, err = lbc.getNamespacedInformer(ns).endpointSliceLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return false
+	}
+	obj, endpointSliceExists, err = nsi.endpointSliceLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return false

--- a/internal/k8s/endpoint_slice_test.go
+++ b/internal/k8s/endpoint_slice_test.go
@@ -1,0 +1,25 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	nl "github.com/nginx/kubernetes-ingress/internal/logger"
+)
+
+// TestSyncEndpointSlicesNamespaceNotWatched guards against a nil pointer dereference
+// panic (see getNamespacedInformer) when an EndpointSlice task for a namespace that is
+// no longer watched (e.g. its watch-namespace-label was removed) is processed.
+func TestSyncEndpointSlicesNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+
+	result := lbc.syncEndpointSlices(task{Kind: endpointslice, Key: "not-watched/some-endpointslice"})
+	if result {
+		t.Errorf("syncEndpointSlices() = %v, expected false for an unwatched namespace", result)
+	}
+}

--- a/internal/k8s/policy.go
+++ b/internal/k8s/policy.go
@@ -76,7 +76,11 @@ func (lbc *LoadBalancerController) syncPolicy(task task) {
 
 	ns, n, _ := cache.SplitMetaNamespaceKey(key)
 	l := lbc.Logger.With(logNamespaceKey, ns, logKindKey, policyKind, logNameKey, n)
-	obj, polExists, err = lbc.getNamespacedInformer(ns).policyLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, polExists, err = nsi.policyLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return

--- a/internal/k8s/policy_test.go
+++ b/internal/k8s/policy_test.go
@@ -71,3 +71,17 @@ func TestBundleNeedsFetch(t *testing.T) {
 		})
 	}
 }
+
+// TestSyncPolicyNamespaceNotWatched guards against a nil pointer dereference panic
+// (see getNamespacedInformer) when a Policy task for a namespace that is no longer
+// watched (e.g. its watch-namespace-label was removed) is processed.
+func TestSyncPolicyNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+
+	lbc.syncPolicy(task{Kind: policy, Key: "not-watched/some-policy"})
+}

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -210,7 +210,11 @@ func (lbc *LoadBalancerController) syncService(task task) {
 
 	ns, n, _ := cache.SplitMetaNamespaceKey(key)
 	l := lbc.Logger.With(logNamespaceKey, ns, logKindKey, serviceKind, logNameKey, n)
-	obj, exists, err = lbc.getNamespacedInformer(ns).svcLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, exists, err = nsi.svcLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return

--- a/internal/k8s/service_test.go
+++ b/internal/k8s/service_test.go
@@ -1,11 +1,27 @@
 package k8s
 
 import (
+	"context"
 	"testing"
 
+	nl "github.com/nginx/kubernetes-ingress/internal/logger"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+// TestSyncServiceNamespaceNotWatched guards against a nil pointer dereference panic
+// (see getNamespacedInformer) when a Service task for a namespace that is no longer
+// watched (e.g. its watch-namespace-label was removed) is processed.
+func TestSyncServiceNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+
+	lbc.syncService(task{Kind: service, Key: "not-watched/some-service"})
+}
 
 func TestHasServicePortChanges(t *testing.T) {
 	t.Parallel()

--- a/internal/k8s/status.go
+++ b/internal/k8s/status.go
@@ -140,7 +140,11 @@ func (su *statusUpdater) updateIngressWithStatus(ing networking.Ingress, status 
 	ns, _, _ := cache.SplitMetaNamespaceKey(key)
 	var ingCopy *networking.Ingress
 	var exists bool
-	ingCopy, exists, err = su.getNamespacedInformer(ns).ingressLister.GetByKeySafe(key)
+	nsi := su.getNamespacedInformer(ns)
+	if nsi == nil {
+		return nil
+	}
+	ingCopy, exists, err = nsi.ingressLister.GetByKeySafe(key)
 	if err != nil {
 		nl.Infof(l, "error getting ing from Store by key: %v", err)
 		return err
@@ -435,7 +439,12 @@ func (su *statusUpdater) UpdateTransportServerStatus(ts *conf_v1.TransportServer
 	var err error
 
 	l := su.logger.With(logNamespaceKey, ts.Namespace, logKindKey, transportServerKind, logNameKey, ts.Name)
-	tsLatest, exists, err = su.getNamespacedInformer(ts.Namespace).transportServerLister.Get(ts)
+	nsi := su.getNamespacedInformer(ts.Namespace)
+	if nsi == nil {
+		nl.Infof(l, "TransportServer doesn't exist in Store")
+		return nil
+	}
+	tsLatest, exists, err = nsi.transportServerLister.Get(ts)
 	if err != nil {
 		nl.Infof(l, "error getting TransportServer from Store: %v", err)
 		return err
@@ -483,7 +492,12 @@ func (su *statusUpdater) UpdateVirtualServerStatus(vs *conf_v1.VirtualServer, st
 	var err error
 
 	l := su.logger.With(logNamespaceKey, vs.Namespace, logKindKey, virtualServerKind, logNameKey, vs.Name)
-	vsLatest, exists, err = su.getNamespacedInformer(vs.Namespace).virtualServerLister.Get(vs)
+	nsi := su.getNamespacedInformer(vs.Namespace)
+	if nsi == nil {
+		nl.Infof(l, "VirtualServer doesn't exist in Store")
+		return nil
+	}
+	vsLatest, exists, err = nsi.virtualServerLister.Get(vs)
 	if err != nil {
 		nl.Infof(l, "error getting VirtualServer from Store: %v", err)
 		return err
@@ -550,7 +564,12 @@ func (su *statusUpdater) UpdateVirtualServerRouteStatusWithReferencedBy(vsr *con
 	var err error
 
 	l := su.logger.With(logNamespaceKey, vsr.Namespace, logKindKey, virtualServerRouteKind, logNameKey, vsr.Name)
-	vsrLatest, exists, err = su.getNamespacedInformer(vsr.Namespace).virtualServerRouteLister.Get(vsr)
+	nsi := su.getNamespacedInformer(vsr.Namespace)
+	if nsi == nil {
+		nl.Infof(l, "VirtualServerRoute doesn't exist in Store")
+		return nil
+	}
+	vsrLatest, exists, err = nsi.virtualServerRouteLister.Get(vsr)
 	if err != nil {
 		nl.Infof(l, "error getting VirtualServerRoute from Store: %v", err)
 		return err
@@ -590,7 +609,12 @@ func (su *statusUpdater) UpdateVirtualServerRouteStatus(vsr *conf_v1.VirtualServ
 	var err error
 
 	l := su.logger.With(logNamespaceKey, vsr.Namespace, logKindKey, virtualServerRouteKind, logNameKey, vsr.Name)
-	vsrLatest, exists, err = su.getNamespacedInformer(vsr.Namespace).virtualServerRouteLister.Get(vsr)
+	nsi := su.getNamespacedInformer(vsr.Namespace)
+	if nsi == nil {
+		nl.Infof(l, "VirtualServerRoute doesn't exist in Store")
+		return nil
+	}
+	vsrLatest, exists, err = nsi.virtualServerRouteLister.Get(vsr)
 	if err != nil {
 		nl.Infof(l, "error getting VirtualServerRoute from Store: %v", err)
 		return err
@@ -626,7 +650,12 @@ func (su *statusUpdater) updateVirtualServerExternalEndpoints(vs *conf_v1.Virtua
 	var err error
 
 	l := su.logger.With(logNamespaceKey, vs.Namespace, logKindKey, virtualServerKind, logNameKey, vs.Name)
-	vsLatest, exists, err = su.getNamespacedInformer(vs.Namespace).virtualServerLister.Get(vs)
+	nsi := su.getNamespacedInformer(vs.Namespace)
+	if nsi == nil {
+		nl.Infof(l, "VirtualServer doesn't exist in Store")
+		return nil
+	}
+	vsLatest, exists, err = nsi.virtualServerLister.Get(vs)
 	if err != nil {
 		nl.Infof(l, "error getting VirtualServer from Store: %v", err)
 		return err
@@ -654,7 +683,12 @@ func (su *statusUpdater) updateVirtualServerRouteExternalEndpoints(vsr *conf_v1.
 	var err error
 
 	l := su.logger.With(logNamespaceKey, vsr.Namespace, logKindKey, virtualServerRouteKind, logNameKey, vsr.Name)
-	vsrLatest, exists, err = su.getNamespacedInformer(vsr.Namespace).virtualServerRouteLister.Get(vsr)
+	nsi := su.getNamespacedInformer(vsr.Namespace)
+	if nsi == nil {
+		nl.Infof(l, "VirtualServerRoute doesn't exist in Store")
+		return nil
+	}
+	vsrLatest, exists, err = nsi.virtualServerRouteLister.Get(vsr)
 	if err != nil {
 		nl.Infof(l, "error getting VirtualServerRoute from Store: %v", err)
 		return err
@@ -702,7 +736,12 @@ func (su *statusUpdater) UpdatePolicyStatus(pol *conf_v1.Policy, state string, r
 	var err error
 
 	l := su.logger.With(logNamespaceKey, pol.Namespace, logKindKey, policyKind, logNameKey, pol.Name)
-	polLatest, exists, err = su.getNamespacedInformer(pol.Namespace).policyLister.Get(pol)
+	nsi := su.getNamespacedInformer(pol.Namespace)
+	if nsi == nil {
+		nl.Infof(l, "Policy doesn't exist in Store")
+		return nil
+	}
+	polLatest, exists, err = nsi.policyLister.Get(pol)
 	if err != nil {
 		nl.Infof(l, "error getting policy from Store: %v", err)
 		return err

--- a/internal/k8s/status_test.go
+++ b/internal/k8s/status_test.go
@@ -206,6 +206,114 @@ func TestUpdateTransportServerStatusMissingTransportServer(t *testing.T) {
 	}
 }
 
+// The following tests guard against a nil pointer dereference panic (see
+// getNamespacedInformer) when a status update is requested for a resource whose
+// namespace is no longer watched (e.g. its watch-namespace-label was removed).
+
+func newTestStatusUpdater() statusUpdater {
+	return statusUpdater{
+		namespacedInformers: map[string]*namespacedInformer{},
+		keyFunc:             cache.DeletionHandlingMetaNamespaceKeyFunc,
+		logger:              slog.New(nic_glog.New(io.Discard, &nic_glog.Options{Level: levels.LevelInfo})),
+	}
+}
+
+func TestUpdateIngressWithStatusNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+	su := newTestStatusUpdater()
+
+	ing := networking.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "ing-1", Namespace: "not-watched"},
+	}
+	if err := su.updateIngressWithStatus(ing, nil); err != nil {
+		t.Errorf("updateIngressWithStatus() returned unexpected error: %v", err)
+	}
+}
+
+func TestUpdateTransportServerStatusNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+	su := newTestStatusUpdater()
+
+	ts := &conf_v1.TransportServer{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "ts-1", Namespace: "not-watched"},
+	}
+	if err := su.UpdateTransportServerStatus(ts, "state", "reason", "message"); err != nil {
+		t.Errorf("UpdateTransportServerStatus() returned unexpected error: %v", err)
+	}
+}
+
+func TestUpdateVirtualServerStatusNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+	su := newTestStatusUpdater()
+
+	vs := &conf_v1.VirtualServer{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "vs-1", Namespace: "not-watched"},
+	}
+	if err := su.UpdateVirtualServerStatus(vs, "state", "reason", "message"); err != nil {
+		t.Errorf("UpdateVirtualServerStatus() returned unexpected error: %v", err)
+	}
+}
+
+func TestUpdateVirtualServerRouteStatusWithReferencedByNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+	su := newTestStatusUpdater()
+
+	vsr := &conf_v1.VirtualServerRoute{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "vsr-1", Namespace: "not-watched"},
+	}
+	if err := su.UpdateVirtualServerRouteStatusWithReferencedBy(vsr, "state", "reason", "message", nil); err != nil {
+		t.Errorf("UpdateVirtualServerRouteStatusWithReferencedBy() returned unexpected error: %v", err)
+	}
+}
+
+func TestUpdateVirtualServerRouteStatusNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+	su := newTestStatusUpdater()
+
+	vsr := &conf_v1.VirtualServerRoute{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "vsr-1", Namespace: "not-watched"},
+	}
+	if err := su.UpdateVirtualServerRouteStatus(vsr, "state", "reason", "message"); err != nil {
+		t.Errorf("UpdateVirtualServerRouteStatus() returned unexpected error: %v", err)
+	}
+}
+
+func TestUpdateVirtualServerExternalEndpointsNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+	su := newTestStatusUpdater()
+
+	vs := &conf_v1.VirtualServer{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "vs-1", Namespace: "not-watched"},
+	}
+	if err := su.updateVirtualServerExternalEndpoints(vs); err != nil {
+		t.Errorf("updateVirtualServerExternalEndpoints() returned unexpected error: %v", err)
+	}
+}
+
+func TestUpdateVirtualServerRouteExternalEndpointsNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+	su := newTestStatusUpdater()
+
+	vsr := &conf_v1.VirtualServerRoute{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "vsr-1", Namespace: "not-watched"},
+	}
+	if err := su.updateVirtualServerRouteExternalEndpoints(vsr); err != nil {
+		t.Errorf("updateVirtualServerRouteExternalEndpoints() returned unexpected error: %v", err)
+	}
+}
+
+func TestUpdatePolicyStatusNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+	su := newTestStatusUpdater()
+
+	pol := &conf_v1.Policy{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "pol-1", Namespace: "not-watched"},
+	}
+	if err := su.UpdatePolicyStatus(pol, "state", "reason", "message"); err != nil {
+		t.Errorf("UpdatePolicyStatus() returned unexpected error: %v", err)
+	}
+}
+
 func TestStatusUpdateWithExternalStatusAndExternalService(t *testing.T) {
 	t.Parallel()
 	ing := networking.Ingress{

--- a/internal/k8s/transport_server.go
+++ b/internal/k8s/transport_server.go
@@ -68,7 +68,11 @@ func (lbc *LoadBalancerController) syncTransportServer(task task) {
 
 	ns, n, _ := cache.SplitMetaNamespaceKey(key)
 	l := lbc.Logger.With(logNamespaceKey, ns, logKindKey, transportServerKind, logNameKey, n)
-	obj, tsExists, err = lbc.getNamespacedInformer(ns).transportServerLister.GetByKey(key)
+	nsi := lbc.getNamespacedInformer(ns)
+	if nsi == nil {
+		return
+	}
+	obj, tsExists, err = nsi.transportServerLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return

--- a/internal/k8s/transport_server_test.go
+++ b/internal/k8s/transport_server_test.go
@@ -1,0 +1,22 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	nl "github.com/nginx/kubernetes-ingress/internal/logger"
+)
+
+// TestSyncTransportServerNamespaceNotWatched guards against a nil pointer dereference
+// panic (see getNamespacedInformer) when a TransportServer task for a namespace that is
+// no longer watched (e.g. its watch-namespace-label was removed) is processed.
+func TestSyncTransportServerNamespaceNotWatched(t *testing.T) {
+	t.Parallel()
+
+	lbc := &LoadBalancerController{
+		namespacedInformers: map[string]*namespacedInformer{},
+		Logger:              nl.LoggerFromContext(context.Background()),
+	}
+
+	lbc.syncTransportServer(task{Kind: transportserver, Key: "not-watched/some-transportserver"})
+}


### PR DESCRIPTION
### Proposed changes

Fixes https://github.com/nginx/kubernetes-ingress/issues/10734

**Context**
* When a namespace becomes unwatched, the cleanup process involves the deletion of the namespace informer
* Tasks in worker queues related to that namespace are not cleaned up
* These tasks expect the namespace informer to exist when they are picked up
* This results in a panic nil pointer error as we attempt to call methods like `endpointSliceLister` on the namespace informer, which is `nil` in these cases

**Fix**
* In all cases I've found where this can occur I've added a nil check on the namespace informer
* Where it is nil I've returned early from the task or returned an err as appropriate
* This avoids a panic that crashes the controller, instead allowing the tasks to fail gracefully as we no longer need to complete the task for an unwatched namespace

**Testing** 
* To recreate this issue I've used a `kind` cluster and used the `watch-namespace-label` flag when deploying the controller
* I've then run a loop to add and remove a label from a namespace in that cluster, switching that namespace between being watched and unwatched by the controller
* At the same time I've run a loop to recreate events and enqueue tasks for each area that has been fixed, e.g scaling up and down a deployment to create endpointslice update events
* For each case I've recreated the bug without this fix and confirmed that the controller does not crash with this fix
* In our real setup the issue we were hitting was around endpoint slices but I've done my best to ensure this is fixed in all other areas it appears and tested the fix to the best of my understanding 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
