### PR TITLE
Refactor weight-only updates for VirtualServer and VirtualServerRoute

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -19,6 +19,7 @@ ignores:
   - "docs/**" # Ignore developer docs folder
   - "vendor/**" # Ignore vendor folder
   - "**/.venv/**"
+  - "**/venv/**"
   - ".local/**"
   - ".opencode/**"
 

--- a/internal/k8s/configuration.go
+++ b/internal/k8s/configuration.go
@@ -728,6 +728,22 @@ func (c *Configuration) DeleteVirtualServerRoute(key string) ([]ResourceChange, 
 	return c.rebuildHosts()
 }
 
+// GetVirtualServer returns the last-applied VirtualServer tracked under key,
+// or nil if none is tracked. Safe to call from any goroutine.
+func (c *Configuration) GetVirtualServer(key string) *conf_v1.VirtualServer {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.virtualServers[key]
+}
+
+// GetVirtualServerRoute returns the last-applied VirtualServerRoute tracked
+// under key, or nil if none is tracked. Safe to call from any goroutine.
+func (c *Configuration) GetVirtualServerRoute(key string) *conf_v1.VirtualServerRoute {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.virtualServerRoutes[key]
+}
+
 // AddOrUpdateGlobalConfiguration adds or updates the GlobalConfiguration.
 func (c *Configuration) AddOrUpdateGlobalConfiguration(gc *conf_v1.GlobalConfiguration) ([]ResourceChange, []ConfigurationProblem, error) {
 	c.lock.Lock()

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -2106,6 +2106,7 @@ func (lbc *LoadBalancerController) syncVirtualServerWeightUpdate(t task) {
 		return
 	}
 
+	// Checked on curVs (not prevVs): prevVs != nil already implies last apply succeeded.
 	if curVs.Status.State == conf_v1.StateInvalid {
 		lbc.AddSyncQueue(curVs)
 		return
@@ -2167,6 +2168,7 @@ func (lbc *LoadBalancerController) syncVirtualServerRouteWeightUpdate(t task) {
 		return
 	}
 
+	// Checked on curVsr (not prevVsr): prevVsr != nil already implies last apply succeeded.
 	if curVsr.Status.State == conf_v1.StateInvalid {
 		lbc.AddSyncQueue(curVsr)
 		return
@@ -2216,42 +2218,7 @@ func isWeightOnlyVSRDiff(prev, cur *conf_v1.VirtualServerRoute) bool {
 // returns one WeightUpdate per changed 2-way split. Caller must ensure prev
 // and cur have identical route/match/split structure (see isWeightOnlyVSDiff).
 func computeVSWeightUpdates(prev, cur *conf_v1.VirtualServer) []configs.WeightUpdate {
-	var updates []configs.WeightUpdate
-	var splitClientsIndex int
-	variableNamer := configs.NewVSVariableNamer(cur)
-
-	for i, routeNew := range cur.Spec.Routes {
-		routeOld := prev.Spec.Routes[i]
-		for j, matchNew := range routeNew.Matches {
-			matchOld := routeOld.Matches[j]
-			if len(matchNew.Splits) == 2 {
-				if matchNew.Splits[0].Weight != matchOld.Splits[0].Weight || matchNew.Splits[1].Weight != matchOld.Splits[1].Weight {
-					updates = append(updates, configs.WeightUpdate{
-						Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
-						Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
-						Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, matchNew.Splits[0].Weight, matchNew.Splits[1].Weight),
-					})
-				}
-				splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
-			} else if len(matchNew.Splits) > 0 {
-				splitClientsIndex++
-			}
-		}
-		if len(routeNew.Splits) == 2 {
-			if routeNew.Splits[0].Weight != routeOld.Splits[0].Weight || routeNew.Splits[1].Weight != routeOld.Splits[1].Weight {
-				updates = append(updates, configs.WeightUpdate{
-					Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
-					Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
-					Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, routeNew.Splits[0].Weight, routeNew.Splits[1].Weight),
-				})
-				splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
-			}
-			splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
-		} else if len(routeNew.Splits) > 0 {
-			splitClientsIndex++
-		}
-	}
-	return updates
+	return appendRouteWeightUpdates(nil, prev.Spec.Routes, cur.Spec.Routes, configs.NewVSVariableNamer(cur), 0)
 }
 
 // computeVSRWeightUpdates walks matching subroutes/matches in prev and cur and
@@ -2259,20 +2226,24 @@ func computeVSWeightUpdates(prev, cur *conf_v1.VirtualServer) []configs.WeightUp
 // splitClientsIndex offset into the enclosing VS keyval namespace and must
 // come from getStartingSplitClientsIndex for the same vsEx/vsr pair.
 func computeVSRWeightUpdates(vsEx *configs.VirtualServerEx, prev, cur *conf_v1.VirtualServerRoute, startingIndex int) []configs.WeightUpdate {
-	var updates []configs.WeightUpdate
-	splitClientsIndex := startingIndex
-	variableNamer := configs.NewVSVariableNamer(vsEx.VirtualServer)
+	return appendRouteWeightUpdates(nil, prev.Spec.Subroutes, cur.Spec.Subroutes, configs.NewVSVariableNamer(vsEx.VirtualServer), startingIndex)
+}
 
-	for i, routeNew := range cur.Spec.Subroutes {
-		routeOld := prev.Spec.Subroutes[i]
+// appendRouteWeightUpdates walks paired route slices and appends one
+// WeightUpdate per changed 2-way split, advancing splitClientsIndex exactly as
+// the VS config generator does. Callers must ensure prevRoutes and curRoutes
+// have identical route/match/split structure.
+func appendRouteWeightUpdates(updates []configs.WeightUpdate, prevRoutes, curRoutes []conf_v1.Route, namer *configs.VariableNamer, splitClientsIndex int) []configs.WeightUpdate {
+	for i, routeNew := range curRoutes {
+		routeOld := prevRoutes[i]
 		for j, matchNew := range routeNew.Matches {
 			matchOld := routeOld.Matches[j]
 			if len(matchNew.Splits) == 2 {
 				if matchNew.Splits[0].Weight != matchOld.Splits[0].Weight || matchNew.Splits[1].Weight != matchOld.Splits[1].Weight {
 					updates = append(updates, configs.WeightUpdate{
-						Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
-						Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
-						Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, matchNew.Splits[0].Weight, matchNew.Splits[1].Weight),
+						Zone:  namer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
+						Key:   namer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
+						Value: namer.GetNameOfKeyOfMapForWeights(splitClientsIndex, matchNew.Splits[0].Weight, matchNew.Splits[1].Weight),
 					})
 				}
 				splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
@@ -2283,10 +2254,11 @@ func computeVSRWeightUpdates(vsEx *configs.VirtualServerEx, prev, cur *conf_v1.V
 		if len(routeNew.Splits) == 2 {
 			if routeNew.Splits[0].Weight != routeOld.Splits[0].Weight || routeNew.Splits[1].Weight != routeOld.Splits[1].Weight {
 				updates = append(updates, configs.WeightUpdate{
-					Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
-					Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
-					Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, routeNew.Splits[0].Weight, routeNew.Splits[1].Weight),
+					Zone:  namer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
+					Key:   namer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
+					Value: namer.GetNameOfKeyOfMapForWeights(splitClientsIndex, routeNew.Splits[0].Weight, routeNew.Splits[1].Weight),
 				})
+				splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
 			}
 			splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
 		} else if len(routeNew.Splits) > 0 {

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -1264,8 +1265,11 @@ func (lbc *LoadBalancerController) sync(task task) {
 		nl.Debugf(lbc.Logger, "Batch processing %v items", lbc.syncQueue.Len())
 	}
 	nl.Debugf(lbc.Logger, "Syncing %v", task.Key)
-	if lbc.batchSyncEnabled && task.Kind != endpointslice {
-		nl.Debug(lbc.Logger, "Task is not endpointslice - enabling batch reload")
+	if lbc.batchSyncEnabled &&
+		task.Kind != endpointslice &&
+		task.Kind != virtualServerWeightUpdate &&
+		task.Kind != virtualServerRouteWeightUpdate {
+		nl.Debug(lbc.Logger, "Task is not endpointslice or a weight-only update - enabling batch reload")
 		lbc.enableBatchReload = true
 	}
 	switch task.Kind {
@@ -1294,8 +1298,14 @@ func (lbc *LoadBalancerController) sync(task task) {
 		lbc.syncVirtualServer(task)
 		lbc.updateVirtualServerMetrics()
 		lbc.updateTransportServerMetrics()
+	case virtualServerWeightUpdate:
+		lbc.syncVirtualServerWeightUpdate(task)
+		lbc.updateVirtualServerMetrics()
 	case virtualServerRoute:
 		lbc.syncVirtualServerRoute(task)
+		lbc.updateVirtualServerMetrics()
+	case virtualServerRouteWeightUpdate:
+		lbc.syncVirtualServerRouteWeightUpdate(task)
 		lbc.updateVirtualServerMetrics()
 	case globalConfiguration:
 		lbc.syncGlobalConfiguration(task)
@@ -2056,6 +2066,234 @@ func (lbc *LoadBalancerController) syncVirtualServerRoute(task task) {
 
 	lbc.processChanges(changes)
 	lbc.processProblems(problems)
+}
+
+// syncVirtualServerWeightUpdate applies a weight-only VirtualServer change via
+// the NGINX Plus keyval API, skipping template regeneration and reload. It
+// falls back to a full reconcile via AddSyncQueue when the informer state has
+// diverged from the last-applied baseline in a non-weight-only way.
+func (lbc *LoadBalancerController) syncVirtualServerWeightUpdate(t task) {
+	key := t.Key
+	ns, n, _ := cache.SplitMetaNamespaceKey(key)
+	l := lbc.Logger.With(logNamespaceKey, ns, logKindKey, virtualServerKind, logNameKey, n)
+
+	obj, exists, err := lbc.getNamespacedInformer(ns).virtualServerLister.GetByKey(key)
+	if err != nil {
+		lbc.syncQueue.Requeue(t, err)
+		return
+	}
+	if !exists {
+		nl.Debugf(l, "VirtualServer %v no longer in informer; weight-update fast lane is a no-op", key)
+		return
+	}
+	curVs := obj.(*conf_v1.VirtualServer)
+
+	prevVs := lbc.configuration.GetVirtualServer(key)
+	if prevVs == nil {
+		nl.Debugf(l, "No baseline for VirtualServer %v; falling back to full reconcile", key)
+		lbc.AddSyncQueue(curVs)
+		return
+	}
+
+	if !isWeightOnlyVSDiff(prevVs, curVs) {
+		nl.Debugf(l, "VirtualServer %v changed beyond weights; falling back to full reconcile", key)
+		lbc.AddSyncQueue(curVs)
+		return
+	}
+
+	weightUpdates := computeVSWeightUpdates(prevVs, curVs)
+	if len(weightUpdates) == 0 {
+		return
+	}
+
+	if curVs.Status.State == conf_v1.StateInvalid {
+		lbc.AddSyncQueue(curVs)
+		return
+	}
+
+	changes, problems := lbc.configuration.AddOrUpdateVirtualServer(curVs)
+	lbc.processProblems(problems)
+	for _, c := range changes {
+		if c.Op != AddOrUpdate {
+			continue
+		}
+		impl, ok := c.Resource.(*VirtualServerConfiguration)
+		if !ok {
+			continue
+		}
+		lbc.updateVirtualServerStatusAndEvents(impl, configs.Warnings{}, nil)
+	}
+
+	for _, w := range weightUpdates {
+		lbc.configurator.UpsertSplitClientsKeyVal(w.Zone, w.Key, w.Value)
+	}
+}
+
+// syncVirtualServerRouteWeightUpdate is the VSR counterpart to
+// syncVirtualServerWeightUpdate. It iterates every referencing VirtualServer
+// returned by AddOrUpdateVirtualServerRoute so hostless VSR fan-out works
+// naturally: each affected VS gets its own keyval writes computed against its
+// own splitClientsIndex baseline.
+func (lbc *LoadBalancerController) syncVirtualServerRouteWeightUpdate(t task) {
+	key := t.Key
+	ns, n, _ := cache.SplitMetaNamespaceKey(key)
+	l := lbc.Logger.With(logNamespaceKey, ns, logKindKey, virtualServerRouteKind, logNameKey, n)
+
+	obj, exists, err := lbc.getNamespacedInformer(ns).virtualServerRouteLister.GetByKey(key)
+	if err != nil {
+		lbc.syncQueue.Requeue(t, err)
+		return
+	}
+	if !exists {
+		nl.Debugf(l, "VirtualServerRoute %v no longer in informer; weight-update fast lane is a no-op", key)
+		return
+	}
+	curVsr := obj.(*conf_v1.VirtualServerRoute)
+
+	prevVsr := lbc.configuration.GetVirtualServerRoute(key)
+	if prevVsr == nil {
+		nl.Debugf(l, "No baseline for VirtualServerRoute %v; falling back to full reconcile", key)
+		lbc.AddSyncQueue(curVsr)
+		return
+	}
+
+	if !isWeightOnlyVSRDiff(prevVsr, curVsr) {
+		nl.Debugf(l, "VirtualServerRoute %v changed beyond weights; falling back to full reconcile", key)
+		lbc.AddSyncQueue(curVsr)
+		return
+	}
+
+	if !lbc.vsrHasWeightChanges(prevVsr, curVsr) {
+		return
+	}
+
+	if curVsr.Status.State == conf_v1.StateInvalid {
+		lbc.AddSyncQueue(curVsr)
+		return
+	}
+
+	changes, problems := lbc.configuration.AddOrUpdateVirtualServerRoute(curVsr)
+	lbc.processProblems(problems)
+
+	for _, c := range changes {
+		if c.Op != AddOrUpdate {
+			continue
+		}
+		impl, ok := c.Resource.(*VirtualServerConfiguration)
+		if !ok {
+			continue
+		}
+		vsEx := lbc.createVirtualServerEx(impl.VirtualServer, impl.VirtualServerRoutes, impl.VirtualServerRouteSelectors)
+		weightUpdates := computeVSRWeightUpdates(vsEx, prevVsr, curVsr, lbc.getStartingSplitClientsIndex(curVsr, vsEx))
+		lbc.updateVirtualServerStatusAndEvents(impl, configs.Warnings{}, nil)
+		for _, w := range weightUpdates {
+			lbc.configurator.UpsertSplitClientsKeyVal(w.Zone, w.Key, w.Value)
+		}
+	}
+}
+
+// isWeightOnlyVSDiff reports whether the difference between prev and cur is
+// confined to split weights. It mirrors the informer-side check so the sync
+// handler is safe against informer-cache drift between enqueue and dispatch.
+func isWeightOnlyVSDiff(prev, cur *conf_v1.VirtualServer) bool {
+	prevZeroed := prev.DeepCopy()
+	curZeroed := cur.DeepCopy()
+	zeroOutVirtualServerSplitWeights(prevZeroed)
+	zeroOutVirtualServerSplitWeights(curZeroed)
+	return reflect.DeepEqual(prevZeroed.Spec, curZeroed.Spec)
+}
+
+// isWeightOnlyVSRDiff is the VSR counterpart to isWeightOnlyVSDiff.
+func isWeightOnlyVSRDiff(prev, cur *conf_v1.VirtualServerRoute) bool {
+	prevZeroed := prev.DeepCopy()
+	curZeroed := cur.DeepCopy()
+	zeroOutVirtualServerRouteSplitWeights(prevZeroed)
+	zeroOutVirtualServerRouteSplitWeights(curZeroed)
+	return reflect.DeepEqual(prevZeroed.Spec, curZeroed.Spec)
+}
+
+// computeVSWeightUpdates walks matching routes/matches in prev and cur and
+// returns one WeightUpdate per changed 2-way split. Caller must ensure prev
+// and cur have identical route/match/split structure (see isWeightOnlyVSDiff).
+func computeVSWeightUpdates(prev, cur *conf_v1.VirtualServer) []configs.WeightUpdate {
+	var updates []configs.WeightUpdate
+	var splitClientsIndex int
+	variableNamer := configs.NewVSVariableNamer(cur)
+
+	for i, routeNew := range cur.Spec.Routes {
+		routeOld := prev.Spec.Routes[i]
+		for j, matchNew := range routeNew.Matches {
+			matchOld := routeOld.Matches[j]
+			if len(matchNew.Splits) == 2 {
+				if matchNew.Splits[0].Weight != matchOld.Splits[0].Weight || matchNew.Splits[1].Weight != matchOld.Splits[1].Weight {
+					updates = append(updates, configs.WeightUpdate{
+						Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
+						Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
+						Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, matchNew.Splits[0].Weight, matchNew.Splits[1].Weight),
+					})
+				}
+				splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
+			} else if len(matchNew.Splits) > 0 {
+				splitClientsIndex++
+			}
+		}
+		if len(routeNew.Splits) == 2 {
+			if routeNew.Splits[0].Weight != routeOld.Splits[0].Weight || routeNew.Splits[1].Weight != routeOld.Splits[1].Weight {
+				updates = append(updates, configs.WeightUpdate{
+					Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
+					Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
+					Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, routeNew.Splits[0].Weight, routeNew.Splits[1].Weight),
+				})
+				splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
+			}
+			splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
+		} else if len(routeNew.Splits) > 0 {
+			splitClientsIndex++
+		}
+	}
+	return updates
+}
+
+// computeVSRWeightUpdates walks matching subroutes/matches in prev and cur and
+// returns one WeightUpdate per changed 2-way split. startingIndex is the
+// splitClientsIndex offset into the enclosing VS keyval namespace and must
+// come from getStartingSplitClientsIndex for the same vsEx/vsr pair.
+func computeVSRWeightUpdates(vsEx *configs.VirtualServerEx, prev, cur *conf_v1.VirtualServerRoute, startingIndex int) []configs.WeightUpdate {
+	var updates []configs.WeightUpdate
+	splitClientsIndex := startingIndex
+	variableNamer := configs.NewVSVariableNamer(vsEx.VirtualServer)
+
+	for i, routeNew := range cur.Spec.Subroutes {
+		routeOld := prev.Spec.Subroutes[i]
+		for j, matchNew := range routeNew.Matches {
+			matchOld := routeOld.Matches[j]
+			if len(matchNew.Splits) == 2 {
+				if matchNew.Splits[0].Weight != matchOld.Splits[0].Weight || matchNew.Splits[1].Weight != matchOld.Splits[1].Weight {
+					updates = append(updates, configs.WeightUpdate{
+						Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
+						Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
+						Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, matchNew.Splits[0].Weight, matchNew.Splits[1].Weight),
+					})
+				}
+				splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
+			} else if len(matchNew.Splits) > 0 {
+				splitClientsIndex++
+			}
+		}
+		if len(routeNew.Splits) == 2 {
+			if routeNew.Splits[0].Weight != routeOld.Splits[0].Weight || routeNew.Splits[1].Weight != routeOld.Splits[1].Weight {
+				updates = append(updates, configs.WeightUpdate{
+					Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
+					Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
+					Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, routeNew.Splits[0].Weight, routeNew.Splits[1].Weight),
+				})
+			}
+			splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
+		} else if len(routeNew.Splits) > 0 {
+			splitClientsIndex++
+		}
+	}
+	return updates
 }
 
 func (lbc *LoadBalancerController) syncIngress(task task) {
@@ -4417,124 +4655,6 @@ func (lbc *LoadBalancerController) IsNginxReady() bool {
 	return lbc.isNginxReady
 }
 
-func (lbc *LoadBalancerController) processVSWeightChangesDynamicReload(vsOld *conf_v1.VirtualServer, vsNew *conf_v1.VirtualServer) {
-	var weightUpdates []configs.WeightUpdate
-	var splitClientsIndex int
-	variableNamer := configs.NewVSVariableNamer(vsNew)
-
-	for i, routeNew := range vsNew.Spec.Routes {
-		routeOld := vsOld.Spec.Routes[i]
-		for j, matchNew := range routeNew.Matches {
-			matchOld := routeOld.Matches[j]
-			if len(matchNew.Splits) == 2 {
-				if matchNew.Splits[0].Weight != matchOld.Splits[0].Weight || matchNew.Splits[1].Weight != matchOld.Splits[1].Weight {
-					weightUpdates = append(weightUpdates, configs.WeightUpdate{
-						Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
-						Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
-						Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, matchNew.Splits[0].Weight, matchNew.Splits[1].Weight),
-					})
-				}
-				splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
-			} else if len(matchNew.Splits) > 0 {
-				splitClientsIndex++
-			}
-		}
-		if len(routeNew.Splits) == 2 {
-			if routeNew.Splits[0].Weight != routeOld.Splits[0].Weight || routeNew.Splits[1].Weight != routeOld.Splits[1].Weight {
-				weightUpdates = append(weightUpdates, configs.WeightUpdate{
-					Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
-					Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
-					Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, routeNew.Splits[0].Weight, routeNew.Splits[1].Weight),
-				})
-				splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
-			}
-			splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
-		} else if len(routeNew.Splits) > 0 {
-			splitClientsIndex++
-		}
-	}
-
-	if len(weightUpdates) == 0 {
-		return
-	}
-
-	if vsOld.Status.State == conf_v1.StateInvalid {
-		lbc.AddSyncQueue(vsNew)
-		return
-	}
-
-	if lbc.haltIfVSConfigInvalid(vsNew) {
-		return
-	}
-
-	for _, weight := range weightUpdates {
-		lbc.configurator.UpsertSplitClientsKeyVal(weight.Zone, weight.Key, weight.Value)
-	}
-}
-
-func (lbc *LoadBalancerController) processVSRWeightChangesDynamicReload(vsrOld *conf_v1.VirtualServerRoute, vsrNew *conf_v1.VirtualServerRoute) {
-	if !lbc.vsrHasWeightChanges(vsrOld, vsrNew) {
-		return
-	}
-
-	if vsrOld.Status.State == conf_v1.StateInvalid {
-		changes, problems := lbc.configuration.AddOrUpdateVirtualServerRoute(vsrNew)
-		lbc.processProblems(problems)
-		lbc.processChanges(changes)
-		return
-	}
-
-	halt, vsEx := lbc.haltIfVSRConfigInvalid(vsrNew)
-	if vsEx == nil {
-		return
-	}
-
-	var weightUpdates []configs.WeightUpdate
-
-	splitClientsIndex := lbc.getStartingSplitClientsIndex(vsrNew, vsEx)
-
-	variableNamer := configs.NewVSVariableNamer(vsEx.VirtualServer)
-
-	for i, routeNew := range vsrNew.Spec.Subroutes {
-		routeOld := vsrOld.Spec.Subroutes[i]
-		for j, matchNew := range routeNew.Matches {
-			matchOld := routeOld.Matches[j]
-			if len(matchNew.Splits) == 2 {
-				if matchNew.Splits[0].Weight != matchOld.Splits[0].Weight || matchNew.Splits[1].Weight != matchOld.Splits[1].Weight {
-					weightUpdates = append(weightUpdates, configs.WeightUpdate{
-						Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
-						Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
-						Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, matchNew.Splits[0].Weight, matchNew.Splits[1].Weight),
-					})
-				}
-				splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
-			} else if len(matchNew.Splits) > 0 {
-				splitClientsIndex++
-			}
-		}
-		if len(routeNew.Splits) == 2 {
-			if routeNew.Splits[0].Weight != routeOld.Splits[0].Weight || routeNew.Splits[1].Weight != routeOld.Splits[1].Weight {
-				weightUpdates = append(weightUpdates, configs.WeightUpdate{
-					Zone:  variableNamer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
-					Key:   variableNamer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
-					Value: variableNamer.GetNameOfKeyOfMapForWeights(splitClientsIndex, routeNew.Splits[0].Weight, routeNew.Splits[1].Weight),
-				})
-			}
-			splitClientsIndex += splitClientAmountWhenWeightChangesDynamicReload
-		} else if len(routeNew.Splits) > 0 {
-			splitClientsIndex++
-		}
-	}
-
-	if halt {
-		return
-	}
-
-	for _, weight := range weightUpdates {
-		lbc.configurator.UpsertSplitClientsKeyVal(weight.Zone, weight.Key, weight.Value)
-	}
-}
-
 func (lbc *LoadBalancerController) getStartingSplitClientsIndex(vsr *conf_v1.VirtualServerRoute, vsEx *configs.VirtualServerEx) int {
 	var startingSplitClientsIndex int
 
@@ -4575,121 +4695,6 @@ func (lbc *LoadBalancerController) getStartingSplitClientsIndex(vsr *conf_v1.Vir
 	}
 
 	return startingSplitClientsIndex
-}
-
-func (lbc *LoadBalancerController) haltIfVSConfigInvalid(vsNew *conf_v1.VirtualServer) bool {
-	lbc.configuration.lock.Lock()
-	defer lbc.configuration.lock.Unlock()
-	key := getResourceKey(&vsNew.ObjectMeta)
-	validationError := lbc.configuration.virtualServerValidator.ValidateVirtualServer(vsNew)
-	if validationError != nil {
-		delete(lbc.configuration.virtualServers, key)
-	} else {
-		lbc.configuration.virtualServers[key] = vsNew
-	}
-
-	changes, problems := lbc.configuration.rebuildHosts()
-
-	if validationError != nil {
-
-		kind := getResourceKeyWithKind(virtualServerKind, &vsNew.ObjectMeta)
-		for i := range changes {
-			k := changes[i].Resource.GetKeyWithKind()
-
-			if k == kind {
-				changes[i].Error = validationError.Error()
-			}
-		}
-		p := ConfigurationProblem{
-			Object:  vsNew,
-			IsError: true,
-			Reason:  nl.EventReasonRejected,
-			Message: fmt.Sprintf("VirtualServer %s was rejected with error: %s", getResourceKey(&vsNew.ObjectMeta), validationError.Error()),
-		}
-		problems = append(problems, p)
-	}
-
-	if len(problems) > 0 {
-		lbc.processProblems(problems)
-	}
-
-	if len(changes) == 0 {
-		return true
-	}
-
-	for _, c := range changes {
-		if c.Op == AddOrUpdate {
-			switch impl := c.Resource.(type) {
-			case *VirtualServerConfiguration:
-				lbc.updateVirtualServerStatusAndEvents(impl, configs.Warnings{}, nil)
-			}
-		} else if c.Op == Delete {
-			switch impl := c.Resource.(type) {
-			case *VirtualServerConfiguration:
-				key := getResourceKey(&impl.VirtualServer.ObjectMeta)
-				ns, n, _ := cache.SplitMetaNamespaceKey(key)
-				l := lbc.Logger.With(logNamespaceKey, ns, logKindKey, virtualServerKind, logNameKey, n)
-				deleteErr := lbc.configurator.DeleteVirtualServer(key, false)
-				if deleteErr != nil {
-					nl.Errorf(l, "Error when deleting configuration for VirtualServer %v: %v", key, deleteErr)
-				}
-
-				var vsExists bool
-				var err error
-
-				_, vsExists, err = lbc.getNamespacedInformer(ns).virtualServerLister.GetByKey(key)
-				if err != nil {
-					nl.Errorf(l, "Error when getting VirtualServer for %v: %v", key, err)
-				}
-
-				if vsExists {
-					lbc.UpdateVirtualServerStatusAndEventsOnDelete(impl, c.Error, deleteErr)
-				}
-			}
-		}
-	}
-
-	lbc.configuration.virtualServers[key] = vsNew
-	return len(problems) > 0
-}
-
-func (lbc *LoadBalancerController) haltIfVSRConfigInvalid(vsrNew *conf_v1.VirtualServerRoute) (bool, *configs.VirtualServerEx) {
-	lbc.configuration.lock.Lock()
-	defer lbc.configuration.lock.Unlock()
-	key := getResourceKey(&vsrNew.ObjectMeta)
-	var vsEx *configs.VirtualServerEx
-
-	validationError := lbc.configuration.virtualServerValidator.ValidateVirtualServerRoute(vsrNew)
-	if validationError != nil {
-		lbc.AddSyncQueue(vsrNew)
-		return true, nil
-	} else {
-		lbc.configuration.virtualServerRoutes[key] = vsrNew
-	}
-
-	changes, _ := lbc.configuration.rebuildHosts()
-
-	if len(changes) == 0 {
-		return true, nil
-	}
-
-	for _, c := range changes {
-		if c.Op == AddOrUpdate {
-			switch impl := c.Resource.(type) {
-			case *VirtualServerConfiguration:
-				vsEx = lbc.createVirtualServerEx(impl.VirtualServer, impl.VirtualServerRoutes, impl.VirtualServerRouteSelectors)
-				lbc.updateVirtualServerStatusAndEvents(impl, configs.Warnings{}, nil)
-			}
-		}
-	}
-
-	if vsEx == nil {
-		nl.Debugf(lbc.Logger, "VirtualServerRoute %s does not have a corresponding VirtualServer", vsrNew.Name)
-		return true, nil
-	}
-
-	lbc.configuration.virtualServerRoutes[key] = vsrNew
-	return false, vsEx
 }
 
 func (lbc *LoadBalancerController) vsrHasWeightChanges(vsrOld *conf_v1.VirtualServerRoute, vsrNew *conf_v1.VirtualServerRoute) bool {

--- a/internal/k8s/handlers.go
+++ b/internal/k8s/handlers.go
@@ -187,7 +187,7 @@ func createVirtualServerHandlers(lbc *LoadBalancerController) cache.ResourceEven
 				zeroOutVirtualServerSplitWeights(&oldVsCopy)
 
 				if reflect.DeepEqual(oldVsCopy.Spec, curVsCopy.Spec) {
-					lbc.processVSWeightChangesDynamicReload(oldVs, curVs)
+					lbc.syncQueue.EnqueueWithKind(curVs, virtualServerWeightUpdate)
 					return
 				}
 
@@ -249,7 +249,7 @@ func createVirtualServerRouteHandlers(lbc *LoadBalancerController) cache.Resourc
 				zeroOutVirtualServerRouteSplitWeights(&oldVsrCopy)
 
 				if reflect.DeepEqual(oldVsrCopy.Spec, curVsrCopy.Spec) {
-					lbc.processVSRWeightChangesDynamicReload(oldVsr, curVsr)
+					lbc.syncQueue.EnqueueWithKind(curVsr, virtualServerRouteWeightUpdate)
 					return
 				}
 

--- a/internal/k8s/task_queue.go
+++ b/internal/k8s/task_queue.go
@@ -66,6 +66,19 @@ func (tq *taskQueue) Enqueue(obj interface{}) {
 	tq.queue.Add(task)
 }
 
+// EnqueueWithKind adds a task with an explicit kind override. Used by the
+// dynamic-weight-change fast lane where the resource's Go type alone doesn't
+// determine the desired task kind.
+func (tq *taskQueue) EnqueueWithKind(obj interface{}, k kind) {
+	key, err := keyFunc(obj)
+	if err != nil {
+		nl.Debugf(tq.logger, "Couldn't get key for object %v: %v", obj, err)
+		return
+	}
+	nl.Debugf(tq.logger, "Adding an element with a key: %v (kind=%d)", key, k)
+	tq.queue.Add(task{Kind: k, Key: key})
+}
+
 // Requeue adds the task to the queue again and logs the given error
 func (tq *taskQueue) Requeue(task task, err error) {
 	nl.Errorf(tq.logger, "Requeuing %v, err %v", task.Key, err)
@@ -130,6 +143,11 @@ const (
 	appProtectDosLogConf
 	appProtectDosProtectedResource
 	ingressLink
+	// virtualServerWeightUpdate / virtualServerRouteWeightUpdate are fast-lane kinds for
+	// dynamic weight-only updates. They are only ever constructed via EnqueueWithKind;
+	// newTask does not derive them from the Go type of the object.
+	virtualServerWeightUpdate
+	virtualServerRouteWeightUpdate
 )
 
 // task is an element of a taskQueue

--- a/internal/k8s/weight_update_test.go
+++ b/internal/k8s/weight_update_test.go
@@ -1,0 +1,568 @@
+package k8s
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/nginx/kubernetes-ingress/internal/configs"
+	nic_glog "github.com/nginx/kubernetes-ingress/internal/logger/glog"
+	"github.com/nginx/kubernetes-ingress/internal/logger/levels"
+	conf_v1 "github.com/nginx/kubernetes-ingress/pkg/apis/configuration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// vsWithRouteSplits returns a VirtualServer whose single route has one
+// top-level 2-way split with the given weights.
+func vsWithRouteSplits(w0, w1 int) *conf_v1.VirtualServer {
+	return &conf_v1.VirtualServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "vs", Namespace: "default"},
+		Spec: conf_v1.VirtualServerSpec{
+			Host: "example.com",
+			Routes: []conf_v1.Route{{
+				Path: "/",
+				Splits: []conf_v1.Split{
+					{Weight: w0, Action: &conf_v1.Action{Pass: "u1"}},
+					{Weight: w1, Action: &conf_v1.Action{Pass: "u2"}},
+				},
+			}},
+		},
+	}
+}
+
+// vsWithMatchSplits returns a VirtualServer whose single route has one match
+// with one 2-way split with the given weights.
+func vsWithMatchSplits(w0, w1 int) *conf_v1.VirtualServer {
+	return &conf_v1.VirtualServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "vs", Namespace: "default"},
+		Spec: conf_v1.VirtualServerSpec{
+			Host: "example.com",
+			Routes: []conf_v1.Route{{
+				Path: "/",
+				Matches: []conf_v1.Match{{
+					Conditions: []conf_v1.Condition{{Header: "x-test", Value: "1"}},
+					Splits: []conf_v1.Split{
+						{Weight: w0, Action: &conf_v1.Action{Pass: "u1"}},
+						{Weight: w1, Action: &conf_v1.Action{Pass: "u2"}},
+					},
+				}},
+			}},
+		},
+	}
+}
+
+func TestComputeVSWeightUpdates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		prev, cur    *conf_v1.VirtualServer
+		wantNumZones int
+	}{
+		{
+			name:         "no diff yields no updates",
+			prev:         vsWithRouteSplits(50, 50),
+			cur:          vsWithRouteSplits(50, 50),
+			wantNumZones: 0,
+		},
+		{
+			name:         "route split weight change",
+			prev:         vsWithRouteSplits(50, 50),
+			cur:          vsWithRouteSplits(70, 30),
+			wantNumZones: 1,
+		},
+		{
+			name:         "match split weight change",
+			prev:         vsWithMatchSplits(50, 50),
+			cur:          vsWithMatchSplits(10, 90),
+			wantNumZones: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := computeVSWeightUpdates(tc.prev, tc.cur)
+			if len(got) != tc.wantNumZones {
+				t.Fatalf("computeVSWeightUpdates() returned %d updates, want %d: %+v", len(got), tc.wantNumZones, got)
+			}
+			for _, w := range got {
+				if w.Zone == "" || w.Key == "" || w.Value == "" {
+					t.Errorf("computeVSWeightUpdates() produced empty field in %+v", w)
+				}
+			}
+		})
+	}
+}
+
+func TestComputeVSWeightUpdates_ValueEncodesWeights(t *testing.T) {
+	t.Parallel()
+
+	prev := vsWithRouteSplits(50, 50)
+	cur := vsWithRouteSplits(70, 30)
+	got := computeVSWeightUpdates(prev, cur)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 weight update, got %d", len(got))
+	}
+	// The value is derived from the new weights via NewVSVariableNamer; regenerating
+	// it here proves the compute helper wires the namer to cur (not prev).
+	namer := configs.NewVSVariableNamer(cur)
+	wantValue := namer.GetNameOfKeyOfMapForWeights(0, 70, 30)
+	if got[0].Value != wantValue {
+		t.Errorf("update value = %q, want %q", got[0].Value, wantValue)
+	}
+}
+
+// vsrWithSubrouteSplits returns a VirtualServerRoute whose single subroute has
+// one top-level 2-way split with the given weights.
+func vsrWithSubrouteSplits(w0, w1 int) *conf_v1.VirtualServerRoute {
+	return &conf_v1.VirtualServerRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "vsr", Namespace: "default"},
+		Spec: conf_v1.VirtualServerRouteSpec{
+			Host: "example.com",
+			Subroutes: []conf_v1.Route{{
+				Path: "/coffee",
+				Splits: []conf_v1.Split{
+					{Weight: w0, Action: &conf_v1.Action{Pass: "u1"}},
+					{Weight: w1, Action: &conf_v1.Action{Pass: "u2"}},
+				},
+			}},
+		},
+	}
+}
+
+func TestComputeVSRWeightUpdates(t *testing.T) {
+	t.Parallel()
+
+	// Parent VS carries no splits so startingIndex is 0 for the VSR under test.
+	parentVS := &conf_v1.VirtualServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "vs", Namespace: "default"},
+		Spec:       conf_v1.VirtualServerSpec{Host: "example.com"},
+	}
+	prev := vsrWithSubrouteSplits(60, 40)
+	cur := vsrWithSubrouteSplits(90, 10)
+
+	vsEx := &configs.VirtualServerEx{
+		VirtualServer:       parentVS,
+		VirtualServerRoutes: []*conf_v1.VirtualServerRoute{cur},
+	}
+	got := computeVSRWeightUpdates(vsEx, prev, cur, 0)
+	if len(got) != 1 {
+		t.Fatalf("computeVSRWeightUpdates() returned %d updates, want 1: %+v", len(got), got)
+	}
+	namer := configs.NewVSVariableNamer(parentVS)
+	if want := namer.GetNameOfKeyOfMapForWeights(0, 90, 10); got[0].Value != want {
+		t.Errorf("update value = %q, want %q", got[0].Value, want)
+	}
+}
+
+func TestComputeVSRWeightUpdates_NoDiffYieldsNothing(t *testing.T) {
+	t.Parallel()
+
+	parentVS := &conf_v1.VirtualServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "vs", Namespace: "default"},
+		Spec:       conf_v1.VirtualServerSpec{Host: "example.com"},
+	}
+	same := vsrWithSubrouteSplits(50, 50)
+	vsEx := &configs.VirtualServerEx{
+		VirtualServer:       parentVS,
+		VirtualServerRoutes: []*conf_v1.VirtualServerRoute{same},
+	}
+	if got := computeVSRWeightUpdates(vsEx, same, same, 0); len(got) != 0 {
+		t.Errorf("computeVSRWeightUpdates() with identical prev/cur returned %d updates, want 0", len(got))
+	}
+}
+
+func TestIsWeightOnlyVSDiff(t *testing.T) {
+	t.Parallel()
+
+	base := vsWithRouteSplits(50, 50)
+
+	tests := []struct {
+		name string
+		prev *conf_v1.VirtualServer
+		cur  *conf_v1.VirtualServer
+		want bool
+	}{
+		{
+			name: "identical specs",
+			prev: base,
+			cur:  base.DeepCopy(),
+			want: true,
+		},
+		{
+			name: "weight-only diff",
+			prev: base,
+			cur:  vsWithRouteSplits(70, 30),
+			want: true,
+		},
+		{
+			name: "host change is not weight-only",
+			prev: base,
+			cur: func() *conf_v1.VirtualServer {
+				c := base.DeepCopy()
+				c.Spec.Host = "other.example.com"
+				return c
+			}(),
+			want: false,
+		},
+		{
+			name: "added route is not weight-only",
+			prev: base,
+			cur: func() *conf_v1.VirtualServer {
+				c := base.DeepCopy()
+				c.Spec.Routes = append(c.Spec.Routes, conf_v1.Route{Path: "/tea"})
+				return c
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isWeightOnlyVSDiff(tc.prev, tc.cur); got != tc.want {
+				t.Errorf("isWeightOnlyVSDiff() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsWeightOnlyVSRDiff(t *testing.T) {
+	t.Parallel()
+
+	base := vsrWithSubrouteSplits(50, 50)
+
+	tests := []struct {
+		name string
+		prev *conf_v1.VirtualServerRoute
+		cur  *conf_v1.VirtualServerRoute
+		want bool
+	}{
+		{
+			name: "identical specs",
+			prev: base,
+			cur:  base.DeepCopy(),
+			want: true,
+		},
+		{
+			name: "weight-only diff",
+			prev: base,
+			cur:  vsrWithSubrouteSplits(90, 10),
+			want: true,
+		},
+		{
+			name: "host change is not weight-only",
+			prev: base,
+			cur: func() *conf_v1.VirtualServerRoute {
+				c := base.DeepCopy()
+				c.Spec.Host = "other.example.com"
+				return c
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isWeightOnlyVSRDiff(tc.prev, tc.cur); got != tc.want {
+				t.Errorf("isWeightOnlyVSRDiff() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// newLBCForWeightUpdateFallbackTest builds a minimal LoadBalancerController
+// wired for the syncVirtualServerWeightUpdate fallback-only paths. syncQueue
+// consumes nothing so enqueued tasks accumulate for inspection via Len().
+func newLBCForWeightUpdateFallbackTest(t *testing.T, store cache.Store) *LoadBalancerController {
+	t.Helper()
+	l := slog.New(nic_glog.New(io.Discard, &nic_glog.Options{Level: levels.LevelInfo}))
+	nsi := map[string]*namespacedInformer{
+		"default": {virtualServerLister: store},
+	}
+	return &LoadBalancerController{
+		Logger:              l,
+		configuration:       createTestConfiguration(),
+		namespacedInformers: nsi,
+		syncQueue:           newTaskQueue(l, func(task) {}),
+	}
+}
+
+func TestSyncVirtualServerWeightUpdate_FallsBackWhenBaselineMissing(t *testing.T) {
+	t.Parallel()
+
+	curVs := vsWithRouteSplits(70, 30)
+	store := &fakeStore{cache.FakeCustomStore{
+		GetByKeyFunc: func(key string) (interface{}, bool, error) {
+			if key == "default/vs" {
+				return curVs, true, nil
+			}
+			return nil, false, nil
+		},
+	}}
+	lbc := newLBCForWeightUpdateFallbackTest(t, store)
+
+	lbc.syncVirtualServerWeightUpdate(task{Kind: virtualServerWeightUpdate, Key: "default/vs"})
+
+	if got := lbc.syncQueue.Len(); got != 1 {
+		t.Errorf("expected AddSyncQueue fallback (queue len 1), got %d", got)
+	}
+}
+
+func TestSyncVirtualServerWeightUpdate_NoOpWhenInformerReturnsMissing(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{cache.FakeCustomStore{
+		GetByKeyFunc: func(_ string) (interface{}, bool, error) {
+			return nil, false, nil
+		},
+	}}
+	lbc := newLBCForWeightUpdateFallbackTest(t, store)
+
+	lbc.syncVirtualServerWeightUpdate(task{Kind: virtualServerWeightUpdate, Key: "default/vs"})
+
+	if got := lbc.syncQueue.Len(); got != 0 {
+		t.Errorf("expected no enqueue when VS is gone, got queue len %d", got)
+	}
+}
+
+func TestSyncVirtualServerRouteWeightUpdate_FallsBackWhenBaselineMissing(t *testing.T) {
+	t.Parallel()
+
+	curVsr := vsrWithSubrouteSplits(70, 30)
+	store := &fakeStore{cache.FakeCustomStore{
+		GetByKeyFunc: func(key string) (interface{}, bool, error) {
+			if key == "default/vsr" {
+				return curVsr, true, nil
+			}
+			return nil, false, nil
+		},
+	}}
+	l := slog.New(nic_glog.New(io.Discard, &nic_glog.Options{Level: levels.LevelInfo}))
+	nsi := map[string]*namespacedInformer{
+		"default": {virtualServerRouteLister: store},
+	}
+	lbc := &LoadBalancerController{
+		Logger:              l,
+		configuration:       createTestConfiguration(),
+		namespacedInformers: nsi,
+		syncQueue:           newTaskQueue(l, func(task) {}),
+	}
+
+	lbc.syncVirtualServerRouteWeightUpdate(task{Kind: virtualServerRouteWeightUpdate, Key: "default/vsr"})
+
+	if got := lbc.syncQueue.Len(); got != 1 {
+		t.Errorf("expected AddSyncQueue fallback (queue len 1), got %d", got)
+	}
+}
+
+// TestZeroOutVirtualServerSplitWeights_IsPureAndPreservesStructure exists so
+// that the isWeightOnlyVSDiff / isWeightOnlyVSRDiff helpers, which rely on the
+// zero-out being idempotent and structure-preserving, don't silently regress
+// if the zero-out helpers are later moved or rewritten.
+func TestZeroOutVirtualServerSplitWeights_IsPureAndPreservesStructure(t *testing.T) {
+	t.Parallel()
+
+	original := vsWithRouteSplits(70, 30)
+	clone := original.DeepCopy()
+
+	zeroOutVirtualServerSplitWeights(clone)
+
+	// Original untouched.
+	if diff := cmp.Diff(vsWithRouteSplits(70, 30), original); diff != "" {
+		t.Errorf("zeroOutVirtualServerSplitWeights mutated an alias (-want +got):\n%s", diff)
+	}
+	// Structure preserved on clone.
+	if len(clone.Spec.Routes) != 1 || len(clone.Spec.Routes[0].Splits) != 2 {
+		t.Errorf("zeroOutVirtualServerSplitWeights damaged split structure: %+v", clone.Spec.Routes)
+	}
+	if clone.Spec.Routes[0].Splits[0].Weight != 0 || clone.Spec.Routes[0].Splits[1].Weight != 0 {
+		t.Errorf("zeroOutVirtualServerSplitWeights did not zero all weights: %+v", clone.Spec.Routes[0].Splits)
+	}
+}
+
+// seedVSBaseline writes vs directly into the Configuration's tracked map,
+// bypassing validation and ingress-class filtering. Only safe in fallback
+// tests where the sync handler returns before AddOrUpdateVirtualServer is
+// called; anything past that point relies on rebuildHosts state that this
+// shortcut does not populate.
+func seedVSBaseline(c *Configuration, vs *conf_v1.VirtualServer) {
+	key := vs.Namespace + "/" + vs.Name
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.virtualServers[key] = vs
+}
+
+func TestSyncVirtualServerWeightUpdate_FallsBackOnNonWeightOnlyDiff(t *testing.T) {
+	t.Parallel()
+
+	baseline := vsWithRouteSplits(50, 50)
+	// Same route/split shape, weights unchanged — but Host differs, so the
+	// diff is not weight-only.
+	curVs := baseline.DeepCopy()
+	curVs.Spec.Host = "other.example.com"
+
+	store := &fakeStore{cache.FakeCustomStore{
+		GetByKeyFunc: func(key string) (interface{}, bool, error) {
+			if key == "default/vs" {
+				return curVs, true, nil
+			}
+			return nil, false, nil
+		},
+	}}
+	lbc := newLBCForWeightUpdateFallbackTest(t, store)
+	seedVSBaseline(lbc.configuration, baseline)
+
+	lbc.syncVirtualServerWeightUpdate(task{Kind: virtualServerWeightUpdate, Key: "default/vs"})
+
+	if got := lbc.syncQueue.Len(); got != 1 {
+		t.Errorf("expected AddSyncQueue fallback (queue len 1), got %d", got)
+	}
+}
+
+func TestSyncVirtualServerWeightUpdate_FallsBackOnStateInvalid(t *testing.T) {
+	t.Parallel()
+
+	baseline := vsWithRouteSplits(50, 50)
+	curVs := vsWithRouteSplits(70, 30)
+	curVs.Status.State = conf_v1.StateInvalid
+
+	store := &fakeStore{cache.FakeCustomStore{
+		GetByKeyFunc: func(key string) (interface{}, bool, error) {
+			if key == "default/vs" {
+				return curVs, true, nil
+			}
+			return nil, false, nil
+		},
+	}}
+	lbc := newLBCForWeightUpdateFallbackTest(t, store)
+	seedVSBaseline(lbc.configuration, baseline)
+
+	lbc.syncVirtualServerWeightUpdate(task{Kind: virtualServerWeightUpdate, Key: "default/vs"})
+
+	if got := lbc.syncQueue.Len(); got != 1 {
+		t.Errorf("expected AddSyncQueue fallback (queue len 1), got %d", got)
+	}
+}
+
+// vsWith2WayRouteSplitAcrossRoutes returns a VS with n routes, each carrying a
+// 2-way top-level split. Used to build predictable startingSplitClientsIndex
+// offsets for getStartingSplitClientsIndex tests.
+func vsWith2WayRouteSplitAcrossRoutes(n int) *conf_v1.VirtualServer {
+	vs := &conf_v1.VirtualServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "vs", Namespace: "default"},
+		Spec:       conf_v1.VirtualServerSpec{Host: "example.com"},
+	}
+	for i := 0; i < n; i++ {
+		vs.Spec.Routes = append(vs.Spec.Routes, conf_v1.Route{
+			Path: "/",
+			Splits: []conf_v1.Split{
+				{Weight: 50, Action: &conf_v1.Action{Pass: "u1"}},
+				{Weight: 50, Action: &conf_v1.Action{Pass: "u2"}},
+			},
+		})
+	}
+	return vs
+}
+
+// vsrWith2WaySubrouteSplits returns a VSR with the given name and n
+// 2-way-split subroutes.
+func vsrWith2WaySubrouteSplits(name string, n int) *conf_v1.VirtualServerRoute {
+	vsr := &conf_v1.VirtualServerRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       conf_v1.VirtualServerRouteSpec{Host: "example.com"},
+	}
+	for i := 0; i < n; i++ {
+		vsr.Spec.Subroutes = append(vsr.Spec.Subroutes, conf_v1.Route{
+			Path: "/coffee",
+			Splits: []conf_v1.Split{
+				{Weight: 50, Action: &conf_v1.Action{Pass: "u1"}},
+				{Weight: 50, Action: &conf_v1.Action{Pass: "u2"}},
+			},
+		})
+	}
+	return vsr
+}
+
+func TestGetStartingSplitClientsIndex(t *testing.T) {
+	t.Parallel()
+
+	target := vsrWith2WaySubrouteSplits("target", 1)
+
+	tests := []struct {
+		name string
+		vsEx *configs.VirtualServerEx
+		vsr  *conf_v1.VirtualServerRoute
+		want int
+	}{
+		{
+			name: "no parent VS splits, target VSR is first",
+			vsEx: &configs.VirtualServerEx{
+				VirtualServer:       vsWith2WayRouteSplitAcrossRoutes(0),
+				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{target},
+			},
+			vsr:  target,
+			want: 0,
+		},
+		{
+			name: "one 2-way split on parent VS pushes offset by splitClientAmount",
+			vsEx: &configs.VirtualServerEx{
+				VirtualServer:       vsWith2WayRouteSplitAcrossRoutes(1),
+				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{target},
+			},
+			vsr:  target,
+			want: splitClientAmountWhenWeightChangesDynamicReload,
+		},
+		{
+			name: "three 2-way splits on parent VS multiply the offset",
+			vsEx: &configs.VirtualServerEx{
+				VirtualServer:       vsWith2WayRouteSplitAcrossRoutes(3),
+				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{target},
+			},
+			vsr:  target,
+			want: 3 * splitClientAmountWhenWeightChangesDynamicReload,
+		},
+		{
+			name: "preceding VSR with two 2-way subroute splits contributes to the offset",
+			vsEx: &configs.VirtualServerEx{
+				VirtualServer: vsWith2WayRouteSplitAcrossRoutes(0),
+				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{
+					vsrWith2WaySubrouteSplits("prev", 2),
+					target,
+				},
+			},
+			vsr:  target,
+			want: 2 * splitClientAmountWhenWeightChangesDynamicReload,
+		},
+		{
+			name: "parent VS splits combine with preceding VSR splits",
+			vsEx: &configs.VirtualServerEx{
+				VirtualServer: vsWith2WayRouteSplitAcrossRoutes(1),
+				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{
+					vsrWith2WaySubrouteSplits("prev", 1),
+					target,
+				},
+			},
+			vsr:  target,
+			want: 2 * splitClientAmountWhenWeightChangesDynamicReload,
+		},
+	}
+
+	lbc := &LoadBalancerController{}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := lbc.getStartingSplitClientsIndex(tc.vsr, tc.vsEx); got != tc.want {
+				t.Errorf("getStartingSplitClientsIndex() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Introduced `syncVirtualServerWeightUpdate` and `syncVirtualServerRouteWeightUpdate` methods to handle weight-only changes without full reloads.
- Enhanced task queue to support explicit kind overrides for dynamic weight changes.
- Updated handlers to enqueue tasks for weight-only updates instead of processing them directly.
- Added utility functions to compute weight updates and check for weight-only differences.
- Created comprehensive tests for weight update logic, ensuring correct behavior for various scenarios.
- Removed deprecated methods related to dynamic weight changes.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
