### PR TITLE
fix(helm): emit allow-empty-ingress-host when custom resources are disabled

### DIFF
--- a/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/nginx-ingress/templates/_helpers.tpl
@@ -383,15 +383,15 @@ Build the args for the service binary.
 - -enable-cert-manager={{ .Values.controller.enableCertManager }}
 - -enable-oidc={{ .Values.controller.enableOIDC }}
 - -enable-external-dns={{ .Values.controller.enableExternalDNS }}
-- -default-http-listener-port={{ .Values.controller.defaultHTTPListenerPort}}
-- -default-https-listener-port={{ .Values.controller.defaultHTTPSListenerPort}}
-- -allow-empty-ingress-host={{ .Values.controller.allowEmptyIngressHost }}
 {{- if and .Values.controller.globalConfiguration.create (not .Values.controller.globalConfiguration.customName) }}
 - -global-configuration=$(POD_NAMESPACE)/{{ include "nginx-ingress.controller.fullname" . }}
 {{- else if .Values.controller.globalConfiguration.customName }}
 - -global-configuration={{ .Values.controller.globalConfiguration.customName }}
 {{- end }}
 {{- end }}
+- -default-http-listener-port={{ .Values.controller.defaultHTTPListenerPort}}
+- -default-https-listener-port={{ .Values.controller.defaultHTTPSListenerPort}}
+- -allow-empty-ingress-host={{ .Values.controller.allowEmptyIngressHost }}
 - -ready-status={{ .Values.controller.readyStatus.enable }}
 - -ready-status-port={{ .Values.controller.readyStatus.port }}
 - -enable-latency-metrics={{ .Values.controller.enableLatencyMetrics }}

--- a/charts/tests/__snapshots__/helmunit_test.snap
+++ b/charts/tests/__snapshots__/helmunit_test.snap
@@ -448,6 +448,428 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 ---
 
+[TestHelmNICTemplate/allowEmptyIngressHostWithoutCRs - 1]
+/-/-/-/
+# Source: nginx-ingress/templates/controller-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: allow-empty-ingress-host-no-crs-nginx-ingress
+  namespace: default
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+/-/-/-/
+# Source: nginx-ingress/templates/controller-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: allow-empty-ingress-host-no-crs-nginx-ingress
+  namespace: default
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  {}
+/-/-/-/
+# Source: nginx-ingress/templates/controller-leader-election-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: allow-empty-ingress-host-no-crs-nginx-ingress-leader-election
+  namespace: default
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+/-/-/-/
+# Source: nginx-ingress/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: allow-empty-ingress-host-no-crs-nginx-ingress
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - "apps"
+  resources:
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+/-/-/-/
+# Source: nginx-ingress/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: allow-empty-ingress-host-no-crs-nginx-ingress
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+- kind: ServiceAccount
+  name: allow-empty-ingress-host-no-crs-nginx-ingress
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: allow-empty-ingress-host-no-crs-nginx-ingress
+  apiGroup: rbac.authorization.k8s.io
+/-/-/-/
+# Source: nginx-ingress/templates/controller-role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: allow-empty-ingress-host-no-crs-nginx-ingress
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - ""
+  resources:
+    - namespaces
+  verbs:
+    - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - allow-empty-ingress-host-no-crs-nginx-ingress-leader-election
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+/-/-/-/
+# Source: nginx-ingress/templates/controller-rolebinding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: allow-empty-ingress-host-no-crs-nginx-ingress
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: allow-empty-ingress-host-no-crs-nginx-ingress
+subjects:
+- kind: ServiceAccount
+  name: allow-empty-ingress-host-no-crs-nginx-ingress
+  namespace: default
+/-/-/-/
+# Source: nginx-ingress/templates/controller-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: allow-empty-ingress-host-no-crs-nginx-ingress-controller
+  namespace: default
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+    nodePort: 
+  - port: 443
+    targetPort: 443
+    protocol: TCP
+    name: https
+    nodePort: 
+  selector:
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+/-/-/-/
+# Source: nginx-ingress/templates/controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: allow-empty-ingress-host-no-crs-nginx-ingress-controller
+  namespace: default
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-ingress
+      app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-ingress
+        app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9113"
+        prometheus.io/scheme: "http"
+    spec:      
+      volumes: []
+      serviceAccountName: allow-empty-ingress-host-no-crs-nginx-ingress
+      automountServiceAccountToken: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      hostNetwork: false
+      dnsPolicy: ClusterFirst
+      containers:
+      - image: nginx/nginx-ingress:5.7.0
+        name: nginx-ingress
+        imagePullPolicy: "IfNotPresent"
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        - name: https
+          containerPort: 443
+          protocol: TCP
+        - name: prometheus
+          containerPort: 9113
+        - name: readiness-port
+          containerPort: 8081
+        readinessProbe:
+          httpGet:
+            path: /nginx-ready
+            port: readiness-port
+          periodSeconds: 1
+          initialDelaySeconds: 0
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          runAsUser: 101 #nginx
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE        
+        volumeMounts: []
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        args:
+          
+          - -nginx-plus=false
+          - -nginx-reload-timeout=60000
+          - -enable-app-protect=false
+          - -enable-app-protect-ip-intelligence=false
+          - -enable-app-protect-dos=false
+          - -nginx-configmaps=$(POD_NAMESPACE)/allow-empty-ingress-host-no-crs-nginx-ingress
+          - -ingress-class=nginx
+          - -health-status=false
+          - -health-status-uri=/nginx-health
+          - -nginx-debug=false
+          - -log-level=info
+          - -log-format=glog
+          - -enable-config-safety=false
+          - -nginx-status=true
+          - -nginx-status-port=8080
+          - -nginx-status-allow-cidrs=127.0.0.1
+          - -report-ingress-status
+          - -external-service=allow-empty-ingress-host-no-crs-nginx-ingress-controller
+          - -enable-leader-election=true
+          - -leader-election-lock-name=allow-empty-ingress-host-no-crs-nginx-ingress-leader-election
+          - -enable-prometheus-metrics=true
+          - -prometheus-metrics-listen-port=9113
+          - -prometheus-tls-secret=
+          - -enable-service-insight=false
+          - -service-insight-listen-port=9114
+          - -service-insight-tls-secret=
+          - -enable-custom-resources=false
+          - -enable-snippets=false
+          - -disable-ipv6=false
+          - -default-http-listener-port=80
+          - -default-https-listener-port=443
+          - -allow-empty-ingress-host=true
+          - -ready-status=true
+          - -ready-status-port=8081
+          - -enable-latency-metrics=false
+          - -ssl-dynamic-reload=true
+          - -enable-telemetry-reporting=true
+          - -weight-changes-dynamic-reload=false
+/-/-/-/
+# Source: nginx-ingress/templates/controller-ingress-class.yaml
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: nginx
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  controller: nginx.org/ingress-controller
+/-/-/-/
+# Source: nginx-ingress/templates/controller-configmap.yaml
+/-/-/-/
+/-/-/-/
+# Source: nginx-ingress/templates/controller-lease.yaml
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: allow-empty-ingress-host-no-crs-nginx-ingress-leader-election
+  namespace: default
+  labels:
+    helm.sh/chart: nginx-ingress-2.8.0
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/instance: allow-empty-ingress-host-no-crs
+    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/managed-by: Helm
+---
+
 [TestHelmNICTemplate/appProtectDOS - 1]
 /-/-/-/
 # Source: nginx-ingress/templates/controller-serviceaccount.yaml
@@ -5635,6 +6057,9 @@ spec:
           - -enable-custom-resources=false
           - -enable-snippets=false
           - -disable-ipv6=false
+          - -default-http-listener-port=80
+          - -default-https-listener-port=443
+          - -allow-empty-ingress-host=false
           - -ready-status=true
           - -ready-status-port=8081
           - -enable-latency-metrics=false
@@ -8388,10 +8813,10 @@ spec:
           - -enable-cert-manager=false
           - -enable-oidc=false
           - -enable-external-dns=false
+          - -global-configuration=$(POD_NAMESPACE)/global-configuration-nginx-ingress-controller
           - -default-http-listener-port=80
           - -default-https-listener-port=443
           - -allow-empty-ingress-host=false
-          - -global-configuration=$(POD_NAMESPACE)/global-configuration-nginx-ingress-controller
           - -ready-status=true
           - -ready-status-port=8081
           - -enable-latency-metrics=false
@@ -8857,10 +9282,10 @@ spec:
           - -enable-cert-manager=false
           - -enable-oidc=false
           - -enable-external-dns=false
+          - -global-configuration=test-namespace/my-custom-global-config
           - -default-http-listener-port=80
           - -default-https-listener-port=443
           - -allow-empty-ingress-host=false
-          - -global-configuration=test-namespace/my-custom-global-config
           - -ready-status=true
           - -ready-status-port=8081
           - -enable-latency-metrics=false

--- a/charts/tests/helmunit_test.go
+++ b/charts/tests/helmunit_test.go
@@ -226,6 +226,11 @@ func TestHelmNICTemplate(t *testing.T) {
 			releaseName: "allow-empty-ingress-host",
 			namespace:   "default",
 		},
+		"allowEmptyIngressHostWithoutCRs": {
+			valuesFile:  "testdata/allow-empty-ingress-host-no-crs.yaml",
+			releaseName: "allow-empty-ingress-host-no-crs",
+			namespace:   "default",
+		},
 	}
 
 	// Path to the helm chart we will test

--- a/charts/tests/testdata/allow-empty-ingress-host-no-crs.yaml
+++ b/charts/tests/testdata/allow-empty-ingress-host-no-crs.yaml
@@ -1,0 +1,3 @@
+controller:
+  enableCustomResources: false
+  allowEmptyIngressHost: true


### PR DESCRIPTION
### Proposed changes

Helm chart `_helpers.tpl` nested `-allow-empty-ingress-host` inside `controller.enableCustomResources`. When CRDs are off (`enableCustomResources: false`) and a user sets `allowEmptyIngressHost: true`, the Deployment arg was silently omitted.

That CLI flag applies to Ingress host validation, not VirtualServer CRDs:

- `values.yaml` documents `allowEmptyIngressHost` with no CR requirement (unlike TLS passthrough, cert-manager, OIDC, external-dns, and GlobalConfiguration).
- The controller flag in `cmd/nginx-ingress/flags.go` has the same independent semantics.

This PR moves **only** `-allow-empty-ingress-host` out of the CR block so it is always emitted. Default HTTP/HTTPS listener-port flags stay gated on custom resources here and are split into a follow-up PR.

The existing CR-enabled `allowEmptyIngressHost` helm unit case is unchanged; a new regression covers `enableCustomResources: false` + `allowEmptyIngressHost: true`.

Fixes https://github.com/nginx/kubernetes-ingress/issues/10831

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork