### PR TITLE
Chore/weight update pabel

### DIFF
--- a/internal/configs/virtualserver_routing_test.go
+++ b/internal/configs/virtualserver_routing_test.go
@@ -4741,3 +4741,200 @@ func TestGenerateVirtualServerConfigForVSRWithMultipleRegexSubroutes(t *testing.
 		t.Errorf("GenerateVirtualServerConfig returned unexpected warnings: %v", warnings)
 	}
 }
+
+// TestGenerateVirtualServerConfigSplitClientsIndexSequence pins the
+// split_clients index sequence the generator assigns when
+// DynamicWeightChangesReload is enabled.
+//
+// This is the ground truth for the index walk in k8s.computeVSWeightUpdates,
+// which re-derives these indices from two VirtualServer specs in order to push
+// NGINX Plus keyval updates without a reload. The two walks must agree
+// exactly; if they drift, weight updates land on the wrong split's keyval zone
+// or past the end of the generated zones, where they are silently dropped.
+//
+// There are four accounting branches and all of them must be pinned, because
+// the k8s-side walk reimplements each one:
+//
+//	route-level 2-way split      -> += splitClientAmountWhenWeightChangesDynamicReload
+//	route-level non-2-way split  -> += 1
+//	match-level 2-way split      -> += splitClientAmountWhenWeightChangesDynamicReload
+//	match-level non-2-way split  -> += 1
+//
+// A route carrying both matches and route-level splits accounts the matches
+// first, then the route-level splits, sharing one counter.
+//
+// The k8s-side walk cannot be called from this package, and the generator
+// cannot be driven from internal/k8s because virtualServerConfigurator is
+// unexported, so the contract is pinned from both sides with the same literal
+// indices instead of compared directly. TestComputeVSWeightUpdates in
+// internal/k8s carries matching cases; if the expectations here change, they
+// must change there too.
+func TestGenerateVirtualServerConfigSplitClientsIndexSequence(t *testing.T) {
+	t.Parallel()
+
+	twoWay := func() []conf_v1.Split {
+		return []conf_v1.Split{
+			{Weight: 50, Action: &conf_v1.Action{Pass: "tea-v1"}},
+			{Weight: 50, Action: &conf_v1.Action{Pass: "tea-v2"}},
+		}
+	}
+	threeWay := func() []conf_v1.Split {
+		return []conf_v1.Split{
+			{Weight: 34, Action: &conf_v1.Action{Pass: "tea-v1"}},
+			{Weight: 33, Action: &conf_v1.Action{Pass: "tea-v2"}},
+			{Weight: 33, Action: &conf_v1.Action{Pass: "tea-v3"}},
+		}
+	}
+	conditions := []conf_v1.Condition{{Header: "x-version", Value: "canary"}}
+
+	// Deliberately a literal, not splitClientAmountWhenWeightChangesDynamicReload.
+	// That constant is declared twice — internal/configs/virtualserver.go and
+	// internal/k8s/controller.go — with nothing tying the two together, so a
+	// test derived from either copy would follow a change to it and stay
+	// green while the other package drifted. Both sides pin 101 independently.
+	const step = 101
+
+	tests := []struct {
+		name string
+		// comment on each route records the index it should be assigned and
+		// how much it advances the counter.
+		routes []conf_v1.Route
+		// wantTwoWayIndexes is the SplitClientsIndex of every 2-way split, in
+		// generation order. Non-2-way splits produce no TwoWaySplitClients
+		// entry but still advance the counter.
+		wantTwoWayIndexes []int
+		// wantSplitClientBlocks is the total number of split_clients blocks
+		// emitted. Any index at or beyond this has no zone behind it.
+		wantSplitClientBlocks int
+	}{
+		{
+			name: "consecutive route-level two-way splits",
+			routes: []conf_v1.Route{
+				{Path: "/a", Splits: twoWay()}, // index 0,   +101
+				{Path: "/b", Splits: twoWay()}, // index 101, +101
+				{Path: "/c", Splits: twoWay()}, // index 202, +101
+			},
+			wantTwoWayIndexes:     []int{0, step, 2 * step},
+			wantSplitClientBlocks: 3 * step,
+		},
+		{
+			// Exercises all four accounting branches plus a route that
+			// carries both matches and route-level splits. A change to any
+			// one generator branch moves these indices.
+			name: "mixed match-level, non-two-way and route-level splits",
+			routes: []conf_v1.Route{
+				{
+					Path: "/a",
+					Matches: []conf_v1.Match{
+						{Conditions: conditions, Splits: twoWay()},   // index 0,   +101
+						{Conditions: conditions, Splits: threeWay()}, // index 101, +1
+					},
+					Splits: twoWay(), // index 102, +101
+				},
+				{Path: "/b", Splits: threeWay()}, // index 203, +1
+				{Path: "/c", Splits: twoWay()},   // index 204, +101
+			},
+			wantTwoWayIndexes:     []int{0, step + 1, 2*step + 2},
+			wantSplitClientBlocks: 3*step + 2,
+		},
+		{
+			// Non-2-way splits alone: the counter must advance by 1 each
+			// time, so the trailing 2-way split sits at index 2.
+			name: "non-two-way splits advance the counter by one each",
+			routes: []conf_v1.Route{
+				{Path: "/a", Splits: threeWay()}, // index 0, +1
+				{Path: "/b", Splits: threeWay()}, // index 1, +1
+				{Path: "/c", Splits: twoWay()},   // index 2, +101
+			},
+			wantTwoWayIndexes:     []int{2},
+			wantSplitClientBlocks: step + 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			virtualServerEx := VirtualServerEx{
+				VirtualServer: &conf_v1.VirtualServer{
+					ObjectMeta: meta_v1.ObjectMeta{Name: "cafe", Namespace: "default"},
+					Spec: conf_v1.VirtualServerSpec{
+						Host: "cafe.example.com",
+						Upstreams: []conf_v1.Upstream{
+							{Name: "tea-v1", Service: "tea-v1-svc", Port: 80},
+							{Name: "tea-v2", Service: "tea-v2-svc", Port: 80},
+							{Name: "tea-v3", Service: "tea-v3-svc", Port: 80},
+						},
+						Routes: test.routes,
+					},
+				},
+				Endpoints: map[string][]string{
+					"default/tea-v1-svc:80": {"10.0.0.20:80"},
+					"default/tea-v2-svc:80": {"10.0.0.21:80"},
+					"default/tea-v3-svc:80": {"10.0.0.22:80"},
+				},
+			}
+
+			vsc := newVirtualServerConfigurator(
+				&baseCfgParams, true, false, &StaticConfigParams{DynamicWeightChangesReload: true}, false, &fakeBV,
+			)
+
+			result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
+			if len(warnings) != 0 {
+				t.Fatalf("GenerateVirtualServerConfig() returned unexpected warnings: %v", warnings)
+			}
+
+			var gotIndexes []int
+			for _, twsc := range result.TwoWaySplitClients {
+				gotIndexes = append(gotIndexes, twsc.SplitClientsIndex)
+			}
+			if diff := cmp.Diff(test.wantTwoWayIndexes, gotIndexes); diff != "" {
+				t.Errorf("split_clients index sequence mismatch (-want +got):\n%s", diff)
+			}
+
+			if got := len(result.SplitClients); got != test.wantSplitClientBlocks {
+				t.Errorf("generated %d split_clients blocks, want %d", got, test.wantSplitClientBlocks)
+			}
+
+			// Every 2-way index must address a real zone. A walk that
+			// overshoots yields an index with nothing behind it, which the
+			// keyval API accepts and silently drops.
+			for _, idx := range gotIndexes {
+				if idx >= test.wantSplitClientBlocks {
+					t.Errorf("split_clients index %d is beyond the %d generated blocks", idx, test.wantSplitClientBlocks)
+				}
+			}
+
+			// generateMatchesConfig walks the matches twice: once to build the
+			// main map's parameters (advancing by the
+			// splitClientAmountWhenWeightChangesDynamicReload constant) and
+			// once to generate the split_clients themselves (advancing by the
+			// number of blocks actually emitted). Those two walks are
+			// independent, and only the second one determines the indices
+			// asserted above, so a drift between them leaves the assertions
+			// green while the rendered config points a match at a map variable
+			// that was never defined.
+			//
+			// Catch that by requiring every variable a map parameter resolves
+			// to to have actually been generated.
+			defined := make(map[string]struct{})
+			for _, m := range result.Maps {
+				defined[m.Variable] = struct{}{}
+			}
+			for _, sc := range result.SplitClients {
+				defined[sc.Variable] = struct{}{}
+			}
+			for _, m := range result.Maps {
+				for _, p := range m.Parameters {
+					if !strings.HasPrefix(p.Result, "$") {
+						continue // a location path or a literal, not a variable
+					}
+					if _, ok := defined[p.Result]; !ok {
+						t.Errorf("map %q parameter %q resolves to undefined variable %q",
+							m.Variable, p.Value, p.Result)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1545,36 +1545,75 @@ func (lbc *LoadBalancerController) syncVirtualServer(task task) {
 
 		vs := obj.(*conf_v1.VirtualServer)
 
+		// Must run before AddOrUpdateVirtualServer, which overwrites the
+		// baseline this compares against.
+		var weightUpdates []configs.WeightUpdate
 		if lbc.weightChangesDynamicReload {
-			prevVs := lbc.configuration.GetVirtualServer(key)
-			if prevVs != nil && isWeightOnlyVSDiff(prevVs, vs) && vs.Status.State != conf_v1.StateInvalid {
-				weightUpdates := computeVSWeightUpdates(prevVs, vs)
-				if len(weightUpdates) > 0 {
-					changes, problems = lbc.configuration.AddOrUpdateVirtualServer(vs)
-					lbc.processProblems(problems)
-					if len(problems) > 0 {
-						return
-					}
-					for _, c := range changes {
-						if c.Op == AddOrUpdate {
-							if impl, ok := c.Resource.(*VirtualServerConfiguration); ok {
-								lbc.updateVirtualServerStatusAndEvents(impl, configs.Warnings{}, nil)
-							}
-						}
-					}
-					for _, w := range weightUpdates {
-						lbc.configurator.UpsertSplitClientsKeyVal(w.Zone, w.Key, w.Value)
-					}
-					return
-				}
+			if prevVs := lbc.configuration.GetVirtualServer(key); vsWeightOnlyEligible(prevVs, vs) {
+				weightUpdates = computeVSWeightUpdates(prevVs, vs)
 			}
 		}
 
 		changes, problems = lbc.configuration.AddOrUpdateVirtualServer(vs)
+
+		if len(weightUpdates) > 0 {
+			lbc.processProblems(problems)
+			// A rejected update halts here rather than falling back to
+			// processChanges, matching the pre-fast-lane behavior of
+			// haltIfVSConfigInvalid: NGINX keeps serving the last valid
+			// config and the resource gets a fresh sync on its next event.
+			if len(problems) > 0 {
+				return
+			}
+			if lbc.applyWeightOnlyVSChanges(key, changes, weightUpdates) {
+				return
+			}
+		}
 	}
 
 	lbc.processChanges(changes)
 	lbc.processProblems(problems)
+}
+
+// vsWeightOnlyEligible reports whether curVs's spec differs from prevVs's
+// spec only in 2-way split weights, which is the precondition for applying
+// the change in place via the keyval API instead of regenerating the config
+// and reloading NGINX. prevVs is nil when Configuration has no baseline yet,
+// which is never eligible.
+//
+// Unlike vsrWeightOnlyEligible this needs no label check: a VirtualServer's
+// own labels take no part in resource selection.
+func vsWeightOnlyEligible(prevVs, curVs *conf_v1.VirtualServer) bool {
+	if prevVs == nil || curVs.Status.State == conf_v1.StateInvalid {
+		return false
+	}
+	return isWeightOnlyVSDiff(prevVs, curVs)
+}
+
+// applyWeightOnlyVSChanges pushes weightUpdates to NGINX via the keyval API
+// and emits the usual status and events, skipping template regeneration and
+// the reload.
+//
+// It returns false, without side effects, unless changes is exactly a single
+// AddOrUpdate of the VirtualServer identified by key. Any other shape -- a
+// Delete, a cascade to another resource, or a rejected spec -- means the
+// caller must fall back to processChanges, which is correct for all of them.
+func (lbc *LoadBalancerController) applyWeightOnlyVSChanges(key string, changes []ResourceChange, weightUpdates []configs.WeightUpdate) bool {
+	if len(changes) != 1 || changes[0].Op != AddOrUpdate {
+		return false
+	}
+
+	impl, ok := changes[0].Resource.(*VirtualServerConfiguration)
+	if !ok || getResourceKey(&impl.VirtualServer.ObjectMeta) != key {
+		return false
+	}
+
+	lbc.updateVirtualServerStatusAndEvents(impl, configs.Warnings{}, nil)
+	for _, w := range weightUpdates {
+		lbc.configurator.UpsertSplitClientsKeyVal(w.Zone, w.Key, w.Value)
+	}
+
+	return true
 }
 
 func (lbc *LoadBalancerController) processProblems(problems []ConfigurationProblem) {
@@ -2080,40 +2119,117 @@ func (lbc *LoadBalancerController) syncVirtualServerRoute(task task) {
 
 		vsr := obj.(*conf_v1.VirtualServerRoute)
 
+		// Must run before AddOrUpdateVirtualServerRoute, which overwrites the
+		// baseline this compares against.
+		var prevVsr *conf_v1.VirtualServerRoute
+		var weightOnly bool
 		if lbc.weightChangesDynamicReload {
-			prevVsr := lbc.configuration.GetVirtualServerRoute(key)
-			if prevVsr != nil && isWeightOnlyVSRDiff(prevVsr, vsr) && vsr.Status.State != conf_v1.StateInvalid {
-				changes, problems = lbc.configuration.AddOrUpdateVirtualServerRoute(vsr)
-				lbc.processProblems(problems)
-				if len(problems) > 0 {
-					return
-				}
-
-				var allWeightUpdates []configs.WeightUpdate
-				for _, c := range changes {
-					if c.Op == AddOrUpdate {
-						if impl, ok := c.Resource.(*VirtualServerConfiguration); ok {
-							vsEx := lbc.createVirtualServerEx(impl.VirtualServer, impl.VirtualServerRoutes, impl.VirtualServerRouteSelectors)
-							startingIndex := lbc.getStartingSplitClientsIndex(vsr, vsEx)
-							weightUpdates := computeVSRWeightUpdates(vsEx, prevVsr, vsr, startingIndex)
-							allWeightUpdates = append(allWeightUpdates, weightUpdates...)
-							lbc.updateVirtualServerStatusAndEvents(impl, configs.Warnings{}, nil)
-						}
-					}
-				}
-
-				for _, w := range allWeightUpdates {
-					lbc.configurator.UpsertSplitClientsKeyVal(w.Zone, w.Key, w.Value)
-				}
-				return
-			}
+			prevVsr = lbc.configuration.GetVirtualServerRoute(key)
+			weightOnly = vsrWeightOnlyEligible(prevVsr, vsr)
 		}
 
 		changes, problems = lbc.configuration.AddOrUpdateVirtualServerRoute(vsr)
+
+		if weightOnly {
+			lbc.processProblems(problems)
+			// A rejected update halts here rather than falling back to
+			// processChanges, matching the pre-fast-lane behavior of
+			// haltIfVSRConfigInvalid: NGINX keeps serving the last valid
+			// config and the resource gets a fresh sync on its next event.
+			if len(problems) > 0 {
+				return
+			}
+			if lbc.applyWeightOnlyVSRChanges(prevVsr, vsr, changes) {
+				return
+			}
+		}
 	}
 
 	lbc.processChanges(changes)
 	lbc.processProblems(problems)
+}
+
+// vsrWeightOnlyEligible reports whether curVsr differs from prevVsr only in
+// 2-way split weights that actually changed. prevVsr is nil when
+// Configuration has no baseline yet, which is never eligible.
+//
+// A VirtualServerRoute's labels drive routeSelector matching, so a label
+// change can attach it to another VirtualServer, or detach it, which needs a
+// real render even when the spec is otherwise weight-only-equal -- including
+// when a label and a weight change arrive in the same update. The
+// VirtualServerRoute UpdateFunc enqueues on a label change for exactly that
+// reason, so the fast lane must exclude it too.
+func vsrWeightOnlyEligible(prevVsr, curVsr *conf_v1.VirtualServerRoute) bool {
+	if prevVsr == nil || curVsr.Status.State == conf_v1.StateInvalid {
+		return false
+	}
+	if !reflect.DeepEqual(prevVsr.Labels, curVsr.Labels) {
+		return false
+	}
+	if !isWeightOnlyVSRDiff(prevVsr, curVsr) {
+		return false
+	}
+	// A weight-only-equal spec pair can also be entirely identical, in which
+	// case this sync was triggered by something other than a weight change
+	// and there is nothing to apply in place.
+	return hasTwoWaySplitWeightChanges(prevVsr.Spec.Subroutes, curVsr.Spec.Subroutes)
+}
+
+// applyWeightOnlyVSRChanges applies keyval-only weight updates for every
+// VirtualServer affected by a weight-only VirtualServerRoute change, skipping
+// template regeneration and the reload. Keyval zone names are VirtualServer
+// scoped, so each affected VirtualServer needs its own updates computed
+// against its own render.
+//
+// It returns false, without side effects, unless every change is a plain
+// AddOrUpdate of a VirtualServer that actually references vsrNew.
+// rebuildHosts reports a change for every host whose configuration moved, so
+// an unrelated VirtualServer can appear in this set; it needs a real render,
+// and its starting split_clients index cannot be derived from this VSR in any
+// case. The caller must fall back to processChanges for both that shape and a
+// Delete.
+func (lbc *LoadBalancerController) applyWeightOnlyVSRChanges(vsrOld, vsrNew *conf_v1.VirtualServerRoute, changes []ResourceChange) bool {
+	target := getResourceKey(&vsrNew.ObjectMeta)
+
+	for _, c := range changes {
+		if c.Op != AddOrUpdate {
+			return false
+		}
+		impl, ok := c.Resource.(*VirtualServerConfiguration)
+		if !ok || !vsConfigReferencesVSR(impl, target) {
+			return false
+		}
+	}
+
+	var allWeightUpdates []configs.WeightUpdate
+	for _, c := range changes {
+		impl := c.Resource.(*VirtualServerConfiguration)
+
+		vsEx := lbc.createVirtualServerEx(impl.VirtualServer, impl.VirtualServerRoutes, impl.VirtualServerRouteSelectors)
+		startingIndex := getStartingSplitClientsIndex(vsrNew, vsEx)
+		namer := configs.NewVSVariableNamer(vsEx.VirtualServer)
+		allWeightUpdates = append(allWeightUpdates, computeVSRWeightUpdates(vsrOld, vsrNew, startingIndex, namer)...)
+
+		lbc.updateVirtualServerStatusAndEvents(impl, configs.Warnings{}, nil)
+	}
+
+	for _, w := range allWeightUpdates {
+		lbc.configurator.UpsertSplitClientsKeyVal(w.Zone, w.Key, w.Value)
+	}
+
+	return true
+}
+
+// vsConfigReferencesVSR reports whether vsConfig's resolved
+// VirtualServerRoute list contains the VirtualServerRoute with the given
+// namespace/name key.
+func vsConfigReferencesVSR(vsConfig *VirtualServerConfiguration, key string) bool {
+	for _, vsr := range vsConfig.VirtualServerRoutes {
+		if getResourceKey(&vsr.ObjectMeta) == key {
+			return true
+		}
+	}
+	return false
 }
 
 func (lbc *LoadBalancerController) syncIngress(task task) {
@@ -4492,11 +4608,75 @@ func isWeightOnlyVSRDiff(prev, cur *conf_v1.VirtualServerRoute) bool {
 }
 
 func computeVSWeightUpdates(prev, cur *conf_v1.VirtualServer) []configs.WeightUpdate {
+	if !routesShapeMatch(prev.Spec.Routes, cur.Spec.Routes) {
+		return nil
+	}
 	return appendRouteWeightUpdates(nil, prev.Spec.Routes, cur.Spec.Routes, configs.NewVSVariableNamer(cur), 0)
 }
 
-func computeVSRWeightUpdates(vsEx *configs.VirtualServerEx, prev, cur *conf_v1.VirtualServerRoute, startingIndex int) []configs.WeightUpdate {
-	return appendRouteWeightUpdates(nil, prev.Spec.Subroutes, cur.Spec.Subroutes, configs.NewVSVariableNamer(vsEx.VirtualServer), startingIndex)
+func computeVSRWeightUpdates(prev, cur *conf_v1.VirtualServerRoute, startingIndex int, namer *configs.VariableNamer) []configs.WeightUpdate {
+	if !routesShapeMatch(prev.Spec.Subroutes, cur.Spec.Subroutes) {
+		return nil
+	}
+	return appendRouteWeightUpdates(nil, prev.Spec.Subroutes, cur.Spec.Subroutes, namer, startingIndex)
+}
+
+// routesShapeMatch reports whether two route slices have identical
+// match-and-split structure. The weight-update walks below index the two
+// slices positionally, so a shape mismatch would panic the sync goroutine
+// instead of falling back to a full reload; this is the guard that prevents
+// that.
+func routesShapeMatch(oldRoutes, newRoutes []conf_v1.Route) bool {
+	if len(oldRoutes) != len(newRoutes) {
+		return false
+	}
+	for i := range newRoutes {
+		if len(oldRoutes[i].Matches) != len(newRoutes[i].Matches) {
+			return false
+		}
+		if len(oldRoutes[i].Splits) != len(newRoutes[i].Splits) {
+			return false
+		}
+		for j := range newRoutes[i].Matches {
+			if len(oldRoutes[i].Matches[j].Splits) != len(newRoutes[i].Matches[j].Splits) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// hasTwoWaySplitWeightChanges reports whether any 2-way split's weights
+// actually differ between the two route slices. A weight-only spec diff
+// (see isWeightOnlyVSDiff / isWeightOnlyVSRDiff) is not the same thing as a
+// weight change: two specs can be weight-only-equal and yet identical, which
+// happens whenever a resource is synced for a reason other than its own
+// weights.
+func hasTwoWaySplitWeightChanges(prevRoutes, curRoutes []conf_v1.Route) bool {
+	if !routesShapeMatch(prevRoutes, curRoutes) {
+		return false
+	}
+
+	for i, curRoute := range curRoutes {
+		prevRoute := prevRoutes[i]
+
+		for j, curMatch := range curRoute.Matches {
+			prevMatch := prevRoute.Matches[j]
+			if len(curMatch.Splits) == 2 &&
+				(curMatch.Splits[0].Weight != prevMatch.Splits[0].Weight ||
+					curMatch.Splits[1].Weight != prevMatch.Splits[1].Weight) {
+				return true
+			}
+		}
+
+		if len(curRoute.Splits) == 2 &&
+			(curRoute.Splits[0].Weight != prevRoute.Splits[0].Weight ||
+				curRoute.Splits[1].Weight != prevRoute.Splits[1].Weight) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func appendRouteWeightUpdates(updates []configs.WeightUpdate, prevRoutes, curRoutes []conf_v1.Route, namer *configs.VariableNamer, splitClientsIndex int) []configs.WeightUpdate {
@@ -4533,7 +4713,11 @@ func appendRouteWeightUpdates(updates []configs.WeightUpdate, prevRoutes, curRou
 	return updates
 }
 
-func (lbc *LoadBalancerController) getStartingSplitClientsIndex(vsr *conf_v1.VirtualServerRoute, vsEx *configs.VirtualServerEx) int {
+// getStartingSplitClientsIndex returns the split_clients index vsr's first
+// subroute occupies within vsEx's overall sequence: the referencing
+// VirtualServer's own routes first, then every VirtualServerRoute ahead of
+// vsr in vsEx.VirtualServerRoutes.
+func getStartingSplitClientsIndex(vsr *conf_v1.VirtualServerRoute, vsEx *configs.VirtualServerEx) int {
 	var startingSplitClientsIndex int
 
 	for _, r := range vsEx.VirtualServer.Spec.Routes {
@@ -4552,8 +4736,14 @@ func (lbc *LoadBalancerController) getStartingSplitClientsIndex(vsr *conf_v1.Vir
 
 	}
 
+	target := getResourceKey(&vsr.ObjectMeta)
+
 	for _, vsRoute := range vsEx.VirtualServerRoutes {
-		if vsRoute.Name == vsr.Name {
+		// Compare namespace/name, not name alone. A VirtualServer can
+		// reference VirtualServerRoutes in other namespaces, and routeSelector
+		// matches across all of them, so this list can hold two VSRs with the
+		// same name; matching on name alone would return another VSR's offset.
+		if getResourceKey(&vsRoute.ObjectMeta) == target {
 			return startingSplitClientsIndex
 		}
 		for _, r := range vsRoute.Spec.Subroutes {

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -41,6 +41,7 @@ type testNginxManager struct {
 	FailCreateForName  string
 	FailCreateOnCall   int
 	CreateCalls        int
+	KeyValUpdates      []configs.WeightUpdate
 }
 
 func newTestNginxManager() *testNginxManager {
@@ -56,6 +57,13 @@ func (m *testNginxManager) CreateConfig(name string, content []byte) (bool, erro
 	}
 
 	return m.FakeManager.CreateConfig(name, content)
+}
+
+// UpsertSplitClientsKeyVal records the keyval writes the weight-change fast
+// lane makes, so tests can assert on them without a real NGINX process.
+func (m *testNginxManager) UpsertSplitClientsKeyVal(zoneName, key, value string) {
+	m.KeyValUpdates = append(m.KeyValUpdates, configs.WeightUpdate{Zone: zoneName, Key: key, Value: value})
+	m.FakeManager.UpsertSplitClientsKeyVal(zoneName, key, value)
 }
 
 // fakeStore wraps FakeCustomStore to satisfy the cache.Store interface, which gained

--- a/internal/k8s/split_clients_index_test.go
+++ b/internal/k8s/split_clients_index_test.go
@@ -1,0 +1,209 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nginx/kubernetes-ingress/internal/configs"
+	conf_v1 "github.com/nginx/kubernetes-ingress/pkg/apis/configuration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// splitShape describes the splits on one route or subroute: zero or more
+// matches, each with its own split weights, followed by the route-level split
+// weights. An empty weight list means "no splits here".
+type splitShape struct {
+	matchSplits [][]int
+	routeSplits []int
+}
+
+func splitsFromWeights(weights []int) []conf_v1.Split {
+	if len(weights) == 0 {
+		return nil
+	}
+	splits := make([]conf_v1.Split, 0, len(weights))
+	for i, w := range weights {
+		splits = append(splits, conf_v1.Split{
+			Weight: w,
+			Action: &conf_v1.Action{Pass: fmt.Sprintf("upstream-%d", i)},
+		})
+	}
+	return splits
+}
+
+func routesFromShapes(pathPrefix string, shapes []splitShape) []conf_v1.Route {
+	var routes []conf_v1.Route
+	for i, s := range shapes {
+		route := conf_v1.Route{Path: fmt.Sprintf("/%s-%d", pathPrefix, i)}
+		for _, weights := range s.matchSplits {
+			route.Matches = append(route.Matches, conf_v1.Match{
+				Conditions: []conf_v1.Condition{{Header: "x-test", Value: "yes"}},
+				Splits:     splitsFromWeights(weights),
+			})
+		}
+		route.Splits = splitsFromWeights(s.routeSplits)
+		routes = append(routes, route)
+	}
+	return routes
+}
+
+func testVSRWithSubroutes(namespace, name string, shapes []splitShape) *conf_v1.VirtualServerRoute {
+	return &conf_v1.VirtualServerRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: conf_v1.VirtualServerRouteSpec{
+			Host:      "cafe.example.com",
+			Subroutes: routesFromShapes(name, shapes),
+		},
+	}
+}
+
+// TestGetStartingSplitClientsIndex covers the offset a VirtualServerRoute's
+// subroutes start at within its referencing VirtualServer's split_clients
+// sequence.
+//
+// The walk accumulates the VS's own routes first, then every VSR ahead of the
+// target in vsEx.VirtualServerRoutes, advancing by
+// splitClientAmountWhenWeightChangesDynamicReload per 2-way split and by 1 for
+// any other split count.
+//
+// Identifying the target VSR by name alone is not sufficient: a VS may
+// reference VSRs in other namespaces (`route: other-ns/coffee`, see
+// Configuration.validateVSRs), and routeSelector matches across all
+// namespaces, so vsEx.VirtualServerRoutes can hold two VSRs with the same
+// name from different namespaces.
+func TestGetStartingSplitClientsIndex(t *testing.T) {
+	t.Parallel()
+
+	const step = splitClientAmountWhenWeightChangesDynamicReload
+
+	oneTwoWaySubroute := []splitShape{{routeSplits: []int{50, 50}}}
+
+	tests := []struct {
+		name string
+		// vsShapes are the splits on the referencing VS's own routes.
+		vsShapes []splitShape
+		vsrs     []*conf_v1.VirtualServerRoute
+		// targetIdx is the index into vsrs of the VSR to look up.
+		targetIdx int
+		want      int
+	}{
+		{
+			name:      "single VSR, no VS-level splits",
+			vsrs:      []*conf_v1.VirtualServerRoute{testVSRWithSubroutes("default", "coffee", oneTwoWaySubroute)},
+			targetIdx: 0,
+			want:      0,
+		},
+		{
+			name:     "VS route-level two-way split offsets the first VSR",
+			vsShapes: []splitShape{{routeSplits: []int{50, 50}}},
+			vsrs:     []*conf_v1.VirtualServerRoute{testVSRWithSubroutes("default", "coffee", oneTwoWaySubroute)},
+			// The VS's own 2-way split consumes indices 0..100.
+			targetIdx: 0,
+			want:      step,
+		},
+		{
+			name: "second VSR starts after the first VSR's two-way split",
+			vsrs: []*conf_v1.VirtualServerRoute{
+				testVSRWithSubroutes("default", "coffee", oneTwoWaySubroute),
+				testVSRWithSubroutes("default", "tea", oneTwoWaySubroute),
+			},
+			targetIdx: 1,
+			want:      step,
+		},
+		{
+			// Regression case. Both VSRs are named "coffee" but live in
+			// different namespaces, which is legal and reachable via either a
+			// namespaced `route:` reference or a routeSelector. Matching on
+			// name alone returns 0 for both, so ns-b/coffee's weight updates
+			// land in ns-a/coffee's keyval zone.
+			name: "same-name VSRs in different namespaces are distinguished",
+			vsrs: []*conf_v1.VirtualServerRoute{
+				testVSRWithSubroutes("ns-a", "coffee", oneTwoWaySubroute),
+				testVSRWithSubroutes("ns-b", "coffee", oneTwoWaySubroute),
+			},
+			targetIdx: 1,
+			want:      step,
+		},
+		{
+			// The same collision with the target first: this direction
+			// already returns 0 today, so it pins that the fix does not
+			// overshoot in the other direction.
+			name: "same-name VSRs in different namespaces, target is first",
+			vsrs: []*conf_v1.VirtualServerRoute{
+				testVSRWithSubroutes("ns-a", "coffee", oneTwoWaySubroute),
+				testVSRWithSubroutes("ns-b", "coffee", oneTwoWaySubroute),
+			},
+			targetIdx: 0,
+			want:      0,
+		},
+		{
+			// Three same-name VSRs: drift accumulates, so the third is two
+			// steps in rather than one.
+			name: "three same-name VSRs in different namespaces",
+			vsrs: []*conf_v1.VirtualServerRoute{
+				testVSRWithSubroutes("ns-a", "coffee", oneTwoWaySubroute),
+				testVSRWithSubroutes("ns-b", "coffee", oneTwoWaySubroute),
+				testVSRWithSubroutes("ns-c", "coffee", oneTwoWaySubroute),
+			},
+			targetIdx: 2,
+			want:      2 * step,
+		},
+		{
+			// Non-2-way splits advance by 1, and match-level splits count
+			// too, so this exercises the accounting either side of the
+			// identity check as well as the check itself.
+			name: "mixed split shapes ahead of a same-name VSR",
+			vsShapes: []splitShape{
+				{matchSplits: [][]int{{50, 50}}}, // +step
+				{routeSplits: []int{34, 33, 33}}, // +1
+			},
+			vsrs: []*conf_v1.VirtualServerRoute{
+				testVSRWithSubroutes("ns-a", "coffee", []splitShape{
+					{routeSplits: []int{50, 50}},     // +step
+					{routeSplits: []int{34, 33, 33}}, // +1
+				}),
+				testVSRWithSubroutes("ns-b", "coffee", oneTwoWaySubroute),
+			},
+			targetIdx: 1,
+			want:      2*step + 2,
+		},
+		{
+			// A VSR absent from the VS's list yields the total accumulated
+			// offset. Pinning the existing behavior so the fix is not
+			// mistaken for changing it.
+			name: "target VSR not referenced by the VS",
+			vsrs: []*conf_v1.VirtualServerRoute{
+				testVSRWithSubroutes("ns-a", "coffee", oneTwoWaySubroute),
+			},
+			targetIdx: -1,
+			want:      step,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			vsEx := &configs.VirtualServerEx{
+				VirtualServer: &conf_v1.VirtualServer{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cafe"},
+					Spec: conf_v1.VirtualServerSpec{
+						Host:   "cafe.example.com",
+						Routes: routesFromShapes("route", test.vsShapes),
+					},
+				},
+				VirtualServerRoutes: test.vsrs,
+			}
+
+			target := testVSRWithSubroutes("other-ns", "absent", oneTwoWaySubroute)
+			if test.targetIdx >= 0 {
+				target = test.vsrs[test.targetIdx]
+			}
+
+			if got := getStartingSplitClientsIndex(target, vsEx); got != test.want {
+				t.Errorf("getStartingSplitClientsIndex(%s/%s) = %d, want %d",
+					target.Namespace, target.Name, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/k8s/weight_fast_lane_test.go
+++ b/internal/k8s/weight_fast_lane_test.go
@@ -1,0 +1,826 @@
+package k8s
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/nginx/kubernetes-ingress/internal/configs"
+	"github.com/nginx/kubernetes-ingress/internal/configs/version1"
+	"github.com/nginx/kubernetes-ingress/internal/configs/version2"
+	nl "github.com/nginx/kubernetes-ingress/internal/logger"
+	"github.com/nginx/kubernetes-ingress/internal/nginx"
+	conf_v1 "github.com/nginx/kubernetes-ingress/pkg/apis/configuration/v1"
+	"github.com/nginx/kubernetes-ingress/pkg/apis/configuration/validation"
+	fake_v1 "github.com/nginx/kubernetes-ingress/pkg/client/clientset/versioned/fake"
+	api_v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+)
+
+// recordingWeightManager records the keyval writes and config/reload activity
+// that the dynamic-weight-change fast lane is supposed to avoid. Keyval writes
+// with no config write and no reload is the signature of the fast lane; the
+// reverse is the signature of the normal path.
+type recordingWeightManager struct {
+	*nginx.FakeManager
+
+	mu      sync.Mutex
+	keyvals []configs.WeightUpdate
+
+	configWrites atomic.Int32
+	reloads      atomic.Int32
+}
+
+func newRecordingWeightManager() *recordingWeightManager {
+	return &recordingWeightManager{FakeManager: nginx.NewFakeManager("/etc/nginx")}
+}
+
+func (m *recordingWeightManager) UpsertSplitClientsKeyVal(zoneName, key, value string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.keyvals = append(m.keyvals, configs.WeightUpdate{Zone: zoneName, Key: key, Value: value})
+}
+
+func (m *recordingWeightManager) recordedKeyvals() []configs.WeightUpdate {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]configs.WeightUpdate(nil), m.keyvals...)
+}
+
+// keyvalsSince returns the writes recorded after the first n. A full render
+// also seeds the keyval zones with the current weights, so tests have to
+// discount whatever the seeding sync produced before judging the fast lane.
+func (m *recordingWeightManager) keyvalsSince(n int) []configs.WeightUpdate {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]configs.WeightUpdate(nil), m.keyvals[n:]...)
+}
+
+func (m *recordingWeightManager) CreateConfig(name string, content []byte) (bool, error) {
+	m.configWrites.Add(1)
+	return m.FakeManager.CreateConfig(name, content)
+}
+
+func (m *recordingWeightManager) Reload(isEndpointsUpdate bool) error {
+	m.reloads.Add(1)
+	return m.FakeManager.Reload(isEndpointsUpdate)
+}
+
+// newWeightTestLBC wires the minimum LoadBalancerController surface needed to
+// drive syncVirtualServer and syncVirtualServerRoute to completion.
+//
+// isNginxReady is left false so status writes land on the pending slices
+// instead of needing a live status updater backend; the fast-lane decision
+// happens well before that branch.
+func newWeightTestLBC(tb testing.TB, dynamicReload bool) (*LoadBalancerController, *recordingWeightManager) {
+	tb.Helper()
+
+	mgr := newRecordingWeightManager()
+
+	templateExecutor, err := version1.NewTemplateExecutor(
+		filepath.Join("..", "configs", "version1", "nginx.tmpl"),
+		filepath.Join("..", "configs", "version1", "nginx.ingress.tmpl"),
+	)
+	if err != nil {
+		tb.Fatalf("v1 template executor: %v", err)
+	}
+	templateExecutorV2, err := version2.NewTemplateExecutor(
+		filepath.Join("..", "configs", "version2", "nginx.virtualserver.tmpl"),
+		filepath.Join("..", "configs", "version2", "nginx.transportserver.tmpl"),
+		filepath.Join("..", "configs", "version2", "oidc.tmpl"),
+	)
+	if err != nil {
+		tb.Fatalf("v2 template executor: %v", err)
+	}
+
+	// svcLister and endpointSliceLister are needed because
+	// createVirtualServerEx resolves upstream endpoints; the services below
+	// exist so resolution produces no endpoints rather than panicking.
+	svcStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, name := range []string{"v1-svc", "v2-svc"} {
+		if err := svcStore.Add(&api_v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name},
+			Spec: api_v1.ServiceSpec{
+				Ports: []api_v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(80)}},
+			},
+		}); err != nil {
+			tb.Fatalf("seeding service %s: %v", name, err)
+		}
+	}
+
+	nsi := &namespacedInformer{
+		virtualServerLister:      cache.NewStore(cache.MetaNamespaceKeyFunc),
+		virtualServerRouteLister: cache.NewStore(cache.MetaNamespaceKeyFunc),
+		svcLister:                svcStore,
+		endpointSliceLister:      storeToEndpointSliceLister{Store: cache.NewStore(cache.MetaNamespaceKeyFunc)},
+	}
+
+	// processProblems writes VS/VSR statuses straight through rather than
+	// deferring them to the pending slices, so a real statusUpdater backed by
+	// the fake CRD clientset is needed for fixtures that produce problems
+	// (an unattached VirtualServerRoute, for instance).
+	confClient := fake_v1.NewClientset()
+
+	lbc := &LoadBalancerController{
+		configurator: configs.NewConfigurator(configs.ConfiguratorParams{
+			NginxManager:       mgr,
+			StaticCfgParams:    &configs.StaticConfigParams{DynamicWeightChangesReload: dynamicReload},
+			Config:             configs.NewDefaultConfigParams(context.Background(), false),
+			MGMTCfgParams:      configs.NewDefaultMGMTConfigParams(context.Background()),
+			TemplateExecutor:   templateExecutor,
+			TemplateExecutorV2: templateExecutorV2,
+			IsPlus:             true,
+		}),
+		configuration: NewConfiguration(
+			func(interface{}) bool { return true },
+			true, false, false,
+			validation.NewVirtualServerValidator(),
+			validation.NewGlobalConfigurationValidator(map[int]bool{}),
+			validation.NewTransportServerValidator(false, false, false),
+			false, false, false, false, false, false,
+		),
+		weightChangesDynamicReload: dynamicReload,
+		recorder:                   record.NewFakeRecorder(100),
+		Logger:                     nl.LoggerFromContext(context.Background()),
+		client:                     fake.NewClientset(),
+		isNginxReady:               false,
+		namespacedInformers:        map[string]*namespacedInformer{"default": nsi},
+		statusUpdater: &statusUpdater{
+			confClient:          confClient,
+			namespacedInformers: map[string]*namespacedInformer{"default": nsi},
+			keyFunc:             cache.DeletionHandlingMetaNamespaceKeyFunc,
+			logger:              nl.LoggerFromContext(context.Background()),
+		},
+	}
+	lbc.configuration.CompleteStartup()
+	lbc.syncQueue = newTaskQueue(lbc.Logger, lbc.sync)
+	tb.Cleanup(func() { lbc.syncQueue.queue.ShutDown() })
+
+	return lbc, mgr
+}
+
+func weightTestVS(name string, generation int64, routes []conf_v1.Route) *conf_v1.VirtualServer {
+	return &conf_v1.VirtualServer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name, Generation: generation},
+		Spec: conf_v1.VirtualServerSpec{
+			IngressClass: "nginx",
+			Host:         name + ".example.com",
+			Upstreams: []conf_v1.Upstream{
+				{Name: "v1", Service: "v1-svc", Port: 80},
+				{Name: "v2", Service: "v2-svc", Port: 80},
+			},
+			Routes: routes,
+		},
+	}
+}
+
+func twoWayRoute(path string, w0, w1 int) conf_v1.Route {
+	return conf_v1.Route{
+		Path: path,
+		Splits: []conf_v1.Split{
+			{Weight: w0, Action: &conf_v1.Action{Pass: "v1"}},
+			{Weight: w1, Action: &conf_v1.Action{Pass: "v2"}},
+		},
+	}
+}
+
+// seedVS applies vs through the normal path so that Configuration holds it as
+// the last-applied baseline and the informer store can serve it, exactly as it
+// would be after a real first sync.
+func seedVS(tb testing.TB, lbc *LoadBalancerController, vs *conf_v1.VirtualServer) {
+	tb.Helper()
+
+	nsi := lbc.namespacedInformers["default"]
+	if err := nsi.virtualServerLister.Add(vs); err != nil {
+		tb.Fatalf("seeding informer: %v", err)
+	}
+	changes, problems := lbc.configuration.AddOrUpdateVirtualServer(vs)
+	lbc.processChanges(changes)
+	lbc.processProblems(problems)
+
+	if got := lbc.configuration.GetVirtualServer(getResourceKey(&vs.ObjectMeta)); got == nil {
+		tb.Fatalf("seeding failed: Configuration does not hold %s", vs.Name)
+	}
+}
+
+// updateVS replaces the informer's copy, standing in for the UPDATE event that
+// would normally precede a sync.
+func updateVS(tb testing.TB, lbc *LoadBalancerController, vs *conf_v1.VirtualServer) {
+	tb.Helper()
+
+	if err := lbc.namespacedInformers["default"].virtualServerLister.Update(vs); err != nil {
+		tb.Fatalf("updating informer: %v", err)
+	}
+}
+
+func TestSyncVirtualServer_WeightOnlyDiffAppliesKeyvalWithoutReload(t *testing.T) {
+	t.Parallel()
+
+	lbc, mgr := newWeightTestLBC(t, true)
+
+	vs := weightTestVS("cafe", 1, []conf_v1.Route{twoWayRoute("/tea", 50, 50)})
+	seedVS(t, lbc, vs)
+
+	// Seeding goes through the normal path, so discount everything it did.
+	writesAfterSeed := mgr.configWrites.Load()
+	keyvalsAfterSeed := len(mgr.recordedKeyvals())
+	reloadsAfterSeed := mgr.reloads.Load()
+
+	updated := weightTestVS("cafe", 2, []conf_v1.Route{twoWayRoute("/tea", 70, 30)})
+	updateVS(t, lbc, updated)
+
+	lbc.syncVirtualServer(task{Kind: virtualserver, Key: "default/cafe"})
+
+	namer := configs.NewVSVariableNamer(updated)
+	want := []configs.WeightUpdate{{
+		Zone:  namer.GetNameOfKeyvalZoneForSplitClientIndex(0),
+		Key:   namer.GetNameOfKeyvalKeyForSplitClientIndex(0),
+		Value: namer.GetNameOfKeyOfMapForWeights(0, 70, 30),
+	}}
+	if diff := cmp.Diff(want, mgr.keyvalsSince(keyvalsAfterSeed)); diff != "" {
+		t.Errorf("keyval writes mismatch (-want +got):\n%s", diff)
+	}
+
+	if got := mgr.configWrites.Load() - writesAfterSeed; got != 0 {
+		t.Errorf("fast lane wrote %d NGINX configs, want 0", got)
+	}
+	if got := mgr.reloads.Load() - reloadsAfterSeed; got != 0 {
+		t.Errorf("fast lane triggered %d reloads, want 0", got)
+	}
+
+	// The baseline must advance, or the next weight change would be computed
+	// against a stale spec.
+	stored := lbc.configuration.GetVirtualServer("default/cafe")
+	if got := stored.Spec.Routes[0].Splits[0].Weight; got != 70 {
+		t.Errorf("Configuration baseline weight = %d, want 70", got)
+	}
+}
+
+func TestSyncVirtualServer_FallsBackToReload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		dynamicReload bool
+		// mutate produces the version fed to the sync handler.
+		mutate func(*conf_v1.VirtualServer)
+		// skipSeed leaves Configuration without a baseline.
+		skipSeed bool
+	}{
+		{
+			name:          "feature flag disabled",
+			dynamicReload: false,
+			mutate: func(vs *conf_v1.VirtualServer) {
+				vs.Spec.Routes = []conf_v1.Route{twoWayRoute("/tea", 70, 30)}
+			},
+		},
+		{
+			name:          "spec change beyond weights",
+			dynamicReload: true,
+			mutate: func(vs *conf_v1.VirtualServer) {
+				vs.Spec.Routes = []conf_v1.Route{
+					twoWayRoute("/tea", 70, 30),
+					{Path: "/coffee", Action: &conf_v1.Action{Pass: "v1"}},
+				}
+			},
+		},
+		{
+			name:          "split count changed",
+			dynamicReload: true,
+			mutate: func(vs *conf_v1.VirtualServer) {
+				vs.Spec.Routes = []conf_v1.Route{{
+					Path: "/tea",
+					Splits: []conf_v1.Split{
+						{Weight: 34, Action: &conf_v1.Action{Pass: "v1"}},
+						{Weight: 33, Action: &conf_v1.Action{Pass: "v2"}},
+						{Weight: 33, Action: &conf_v1.Action{Pass: "v1"}},
+					},
+				}}
+			},
+		},
+		{
+			name:          "no baseline in Configuration",
+			dynamicReload: true,
+			skipSeed:      true,
+			mutate: func(vs *conf_v1.VirtualServer) {
+				vs.Spec.Routes = []conf_v1.Route{twoWayRoute("/tea", 70, 30)}
+			},
+		},
+		{
+			name:          "current object reports StateInvalid",
+			dynamicReload: true,
+			mutate: func(vs *conf_v1.VirtualServer) {
+				vs.Spec.Routes = []conf_v1.Route{twoWayRoute("/tea", 70, 30)}
+				vs.Status.State = conf_v1.StateInvalid
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			lbc, mgr := newWeightTestLBC(t, test.dynamicReload)
+
+			vs := weightTestVS("cafe", 1, []conf_v1.Route{twoWayRoute("/tea", 50, 50)})
+			nsi := lbc.namespacedInformers["default"]
+
+			if test.skipSeed {
+				if err := nsi.virtualServerLister.Add(vs); err != nil {
+					t.Fatalf("seeding informer: %v", err)
+				}
+			} else {
+				seedVS(t, lbc, vs)
+			}
+
+			writesAfterSeed := mgr.configWrites.Load()
+			keyvalsAfterSeed := len(mgr.recordedKeyvals())
+
+			updated := weightTestVS("cafe", 2, nil)
+			test.mutate(updated)
+			if err := nsi.virtualServerLister.Update(updated); err != nil {
+				t.Fatalf("updating informer: %v", err)
+			}
+
+			lbc.syncVirtualServer(task{Kind: virtualserver, Key: "default/cafe"})
+
+			// The normal path is identified by a config write. It may also
+			// re-seed the keyval zones as part of rendering, so the absence of
+			// keyval writes is not the signal here; the config write is.
+			if got := mgr.configWrites.Load() - writesAfterSeed; got == 0 {
+				t.Error("normal path not taken: no NGINX config was written")
+			}
+			if lbc.weightChangesDynamicReload {
+				return
+			}
+			if got := mgr.keyvalsSince(keyvalsAfterSeed); len(got) != 0 {
+				t.Errorf("keyval writes with the feature disabled: %d, want 0", len(got))
+			}
+		})
+	}
+}
+
+func weightTestVSR(name string, generation int64, subroutes []conf_v1.Route) *conf_v1.VirtualServerRoute {
+	return &conf_v1.VirtualServerRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name, Generation: generation},
+		Spec: conf_v1.VirtualServerRouteSpec{
+			IngressClass: "nginx",
+			Host:         "cafe.example.com",
+			Upstreams: []conf_v1.Upstream{
+				{Name: "v1", Service: "v1-svc", Port: 80},
+				{Name: "v2", Service: "v2-svc", Port: 80},
+			},
+			Subroutes: subroutes,
+		},
+	}
+}
+
+// weightTestSelectorVS builds a VirtualServer whose single route attaches
+// VirtualServerRoutes by label rather than by name, so that a VSR label change
+// alone can change which VSRs the rendered configuration contains.
+func weightTestSelectorVS(name string, generation int64) *conf_v1.VirtualServer {
+	vs := weightTestVS(name, generation, []conf_v1.Route{{
+		Path:          "/tea",
+		RouteSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "route"}},
+	}})
+	return vs
+}
+
+// TestSyncVirtualServerRoute_FallsBackToReload covers the cases where a
+// VirtualServerRoute update looks weight-only but still needs a full render.
+//
+// The VSR UpdateFunc enqueues on a spec change *or* a label change, and labels
+// drive routeSelector matching, so "the spec differs only in 2-way weights" is
+// not sufficient grounds to skip rendering. Taking the fast lane in these
+// cases consumes the sync and leaves NGINX serving a configuration that no
+// longer matches the cluster.
+func TestSyncVirtualServerRoute_FallsBackToReload(t *testing.T) {
+	t.Parallel()
+
+	const attached = "app"
+
+	tests := []struct {
+		name string
+		// seedLabels are the VSR's labels when first applied.
+		seedLabels map[string]string
+		// mutate produces the updated VSR fed to the sync handler.
+		mutate func(*conf_v1.VirtualServerRoute)
+	}{
+		{
+			// A label change that newly attaches the VSR to the selector VS.
+			// The spec is untouched, so a spec-only predicate sees a
+			// weight-only diff and the new subroute would never be rendered.
+			name:       "label change attaches the VSR",
+			seedLabels: nil,
+			mutate: func(vsr *conf_v1.VirtualServerRoute) {
+				vsr.Labels = map[string]string{attached: "route"}
+			},
+		},
+		{
+			// A label change that detaches it. Already handled by the
+			// change-set reference filter; pinned so that stays true.
+			name:       "label change detaches the VSR",
+			seedLabels: map[string]string{attached: "route"},
+			mutate: func(vsr *conf_v1.VirtualServerRoute) {
+				vsr.Labels = map[string]string{attached: "other"}
+			},
+		},
+		{
+			// A single apply that changes a label and a weight together. Both
+			// clauses of the enqueue condition fire, the spec diff really is
+			// weight-only, and a weight really did change — so only the label
+			// comparison keeps this out of the fast lane.
+			name:       "label and weight change together",
+			seedLabels: nil,
+			mutate: func(vsr *conf_v1.VirtualServerRoute) {
+				vsr.Labels = map[string]string{attached: "route"}
+				vsr.Spec.Subroutes = []conf_v1.Route{twoWayRoute("/tea", 70, 30)}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			lbc, mgr := newWeightTestLBC(t, true)
+			nsi := lbc.namespacedInformers["default"]
+
+			vsr := weightTestVSR("coffee", 1, []conf_v1.Route{twoWayRoute("/tea", 50, 50)})
+			vsr.Labels = test.seedLabels
+			if err := nsi.virtualServerRouteLister.Add(vsr); err != nil {
+				t.Fatalf("seeding VSR informer: %v", err)
+			}
+			lbc.configuration.AddOrUpdateVirtualServerRoute(vsr)
+
+			seedVS(t, lbc, weightTestSelectorVS("cafe", 1))
+
+			writesAfterSeed := mgr.configWrites.Load()
+
+			updated := weightTestVSR("coffee", 1, []conf_v1.Route{twoWayRoute("/tea", 50, 50)})
+			updated.Labels = test.seedLabels
+			test.mutate(updated)
+			if err := nsi.virtualServerRouteLister.Update(updated); err != nil {
+				t.Fatalf("updating VSR informer: %v", err)
+			}
+
+			lbc.syncVirtualServerRoute(task{Kind: virtualServerRoute, Key: "default/coffee"})
+
+			// A config write is the discriminator: the fast lane returns
+			// before processChanges, so if it had been taken the attachment
+			// change would never reach NGINX. Keyval writes are not a useful
+			// signal here, because a full render also re-seeds the keyval
+			// zones with the current weights.
+			if got := mgr.configWrites.Load() - writesAfterSeed; got == 0 {
+				t.Error("fast lane taken: no NGINX config was written, so the label change never reached NGINX")
+			}
+		})
+	}
+}
+
+func TestSyncVirtualServerRoute_WeightOnlyDiffAppliesKeyvalWithoutReload(t *testing.T) {
+	t.Parallel()
+
+	lbc, mgr := newWeightTestLBC(t, true)
+	nsi := lbc.namespacedInformers["default"]
+
+	vsr := weightTestVSR("coffee", 1, []conf_v1.Route{twoWayRoute("/tea", 50, 50)})
+	if err := nsi.virtualServerRouteLister.Add(vsr); err != nil {
+		t.Fatalf("seeding VSR informer: %v", err)
+	}
+	lbc.configuration.AddOrUpdateVirtualServerRoute(vsr)
+
+	vs := weightTestVS("cafe", 1, []conf_v1.Route{{Path: "/tea", Route: "coffee"}})
+	seedVS(t, lbc, vs)
+
+	vsConfig, ok := lbc.configuration.hosts["cafe.example.com"].(*VirtualServerConfiguration)
+	if !ok || len(vsConfig.VirtualServerRoutes) != 1 {
+		t.Fatalf("fixture did not attach the VirtualServerRoute to the VirtualServer")
+	}
+
+	writesAfterSeed := mgr.configWrites.Load()
+	keyvalsAfterSeed := len(mgr.recordedKeyvals())
+	reloadsAfterSeed := mgr.reloads.Load()
+
+	updated := weightTestVSR("coffee", 2, []conf_v1.Route{twoWayRoute("/tea", 70, 30)})
+	if err := nsi.virtualServerRouteLister.Update(updated); err != nil {
+		t.Fatalf("updating VSR informer: %v", err)
+	}
+
+	lbc.syncVirtualServerRoute(task{Kind: virtualServerRoute, Key: "default/coffee"})
+
+	// Keyval zone names are VirtualServer scoped, so the update is addressed
+	// with the referencing VirtualServer's namer, not the VSR's.
+	namer := configs.NewVSVariableNamer(vs)
+	want := []configs.WeightUpdate{{
+		Zone:  namer.GetNameOfKeyvalZoneForSplitClientIndex(0),
+		Key:   namer.GetNameOfKeyvalKeyForSplitClientIndex(0),
+		Value: namer.GetNameOfKeyOfMapForWeights(0, 70, 30),
+	}}
+	if diff := cmp.Diff(want, mgr.keyvalsSince(keyvalsAfterSeed)); diff != "" {
+		t.Errorf("keyval writes mismatch (-want +got):\n%s", diff)
+	}
+
+	if got := mgr.configWrites.Load() - writesAfterSeed; got != 0 {
+		t.Errorf("fast lane wrote %d NGINX configs, want 0", got)
+	}
+	if got := mgr.reloads.Load() - reloadsAfterSeed; got != 0 {
+		t.Errorf("fast lane triggered %d reloads, want 0", got)
+	}
+
+	stored := lbc.configuration.GetVirtualServerRoute("default/coffee")
+	if got := stored.Spec.Subroutes[0].Splits[0].Weight; got != 70 {
+		t.Errorf("Configuration baseline weight = %d, want 70", got)
+	}
+}
+
+// TestApplyWeightOnlyVSChanges_RejectsUnexpectedChangeShapes pins the guard
+// that keeps the fast lane safe by construction. A weight-only spec diff is
+// expected to produce exactly one AddOrUpdate for the VirtualServer itself;
+// anything else has to fall through to processChanges, which handles every
+// shape correctly.
+func TestApplyWeightOnlyVSChanges_RejectsUnexpectedChangeShapes(t *testing.T) {
+	t.Parallel()
+
+	const key = "default/cafe"
+	vsc := &VirtualServerConfiguration{
+		VirtualServer: weightTestVS("cafe", 2, []conf_v1.Route{twoWayRoute("/tea", 70, 30)}),
+	}
+	otherVSC := &VirtualServerConfiguration{
+		VirtualServer: weightTestVS("other", 1, []conf_v1.Route{twoWayRoute("/tea", 70, 30)}),
+	}
+
+	tests := []struct {
+		name    string
+		changes []ResourceChange
+	}{
+		{name: "no changes", changes: nil},
+		{
+			name:    "delete instead of add-or-update",
+			changes: []ResourceChange{{Op: Delete, Resource: vsc}},
+		},
+		{
+			name: "cascade to a second resource",
+			changes: []ResourceChange{
+				{Op: AddOrUpdate, Resource: vsc},
+				{Op: AddOrUpdate, Resource: otherVSC},
+			},
+		},
+		{
+			name:    "change is for a different VirtualServer",
+			changes: []ResourceChange{{Op: AddOrUpdate, Resource: otherVSC}},
+		},
+		{
+			name:    "change is not a VirtualServerConfiguration",
+			changes: []ResourceChange{{Op: AddOrUpdate, Resource: &TransportServerConfiguration{}}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			lbc, mgr := newWeightTestLBC(t, true)
+			updates := []configs.WeightUpdate{{Zone: "z", Key: "k", Value: "v"}}
+
+			if lbc.applyWeightOnlyVSChanges(key, test.changes, updates) {
+				t.Error("applyWeightOnlyVSChanges() = true, want false")
+			}
+			if got := mgr.recordedKeyvals(); len(got) != 0 {
+				t.Errorf("rejected change set still wrote %d keyvals, want 0", len(got))
+			}
+		})
+	}
+}
+
+// TestApplyWeightOnlyVSRChanges_RejectsUnexpectedChangeShapes covers the VSR
+// guard, which additionally has to reject VirtualServers that do not reference
+// the VSR: rebuildHosts reports a change for every host whose configuration
+// moved, so an unrelated VirtualServer can appear in the set, and it needs a
+// real render.
+func TestApplyWeightOnlyVSRChanges_RejectsUnexpectedChangeShapes(t *testing.T) {
+	t.Parallel()
+
+	vsrOld := testVSRWithSubroutes("default", "coffee", []splitShape{{routeSplits: []int{50, 50}}})
+	vsrNew := testVSRWithSubroutes("default", "coffee", []splitShape{{routeSplits: []int{70, 30}}})
+
+	referencing := &VirtualServerConfiguration{
+		VirtualServer:       weightTestVS("cafe", 2, nil),
+		VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsrNew},
+	}
+	unrelated := &VirtualServerConfiguration{
+		VirtualServer: weightTestVS("other", 1, nil),
+		VirtualServerRoutes: []*conf_v1.VirtualServerRoute{
+			testVSRWithSubroutes("default", "tea", []splitShape{{routeSplits: []int{50, 50}}}),
+		},
+	}
+
+	tests := []struct {
+		name    string
+		changes []ResourceChange
+	}{
+		{
+			name:    "delete instead of add-or-update",
+			changes: []ResourceChange{{Op: Delete, Resource: referencing}},
+		},
+		{
+			name:    "change is not a VirtualServerConfiguration",
+			changes: []ResourceChange{{Op: AddOrUpdate, Resource: &TransportServerConfiguration{}}},
+		},
+		{
+			name:    "VirtualServer does not reference the VSR",
+			changes: []ResourceChange{{Op: AddOrUpdate, Resource: unrelated}},
+		},
+		{
+			name: "one referencing VirtualServer and one unrelated",
+			changes: []ResourceChange{
+				{Op: AddOrUpdate, Resource: referencing},
+				{Op: AddOrUpdate, Resource: unrelated},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			lbc, mgr := newWeightTestLBC(t, true)
+
+			if lbc.applyWeightOnlyVSRChanges(vsrOld, vsrNew, test.changes) {
+				t.Error("applyWeightOnlyVSRChanges() = true, want false")
+			}
+			if got := mgr.recordedKeyvals(); len(got) != 0 {
+				t.Errorf("rejected change set still wrote %d keyvals, want 0", len(got))
+			}
+		})
+	}
+}
+
+// TestApplyWeightOnlyVSRChanges_EmptyChangeSet covers a VSR that no
+// VirtualServer references: there is nothing to render and nothing to poke, so
+// the fast lane succeeds trivially rather than forcing a reload.
+func TestApplyWeightOnlyVSRChanges_EmptyChangeSet(t *testing.T) {
+	t.Parallel()
+
+	lbc, mgr := newWeightTestLBC(t, true)
+
+	vsrOld := testVSRWithSubroutes("default", "coffee", []splitShape{{routeSplits: []int{50, 50}}})
+	vsrNew := testVSRWithSubroutes("default", "coffee", []splitShape{{routeSplits: []int{70, 30}}})
+
+	if !lbc.applyWeightOnlyVSRChanges(vsrOld, vsrNew, nil) {
+		t.Error("applyWeightOnlyVSRChanges() = false, want true for an empty change set")
+	}
+	if got := mgr.recordedKeyvals(); len(got) != 0 {
+		t.Errorf("empty change set wrote %d keyvals, want 0", len(got))
+	}
+}
+
+// TestSyncHandlersReleaseConfigurationLock is the replacement for the deleted
+// haltIfVS(R)ConfigInvalid deadlock guard.
+//
+// The old fast path held Configuration's write lock across status updates and
+// configurator calls, which made Configuration writable from two goroutines
+// and left every accessor one RLock away from a self-deadlock. The lock is now
+// taken and released inside AddOrUpdate* and never held while the handler
+// calls anything else, so an accessor that takes the read lock is safe from
+// any point in the handler.
+//
+// Taking the write lock from a second goroutine after the handler returns
+// proves the handler left nothing held.
+func TestSyncHandlersReleaseConfigurationLock(t *testing.T) {
+	t.Parallel()
+
+	lbc, _ := newWeightTestLBC(t, true)
+
+	vs := weightTestVS("cafe", 1, []conf_v1.Route{twoWayRoute("/tea", 50, 50)})
+	seedVS(t, lbc, vs)
+
+	updated := weightTestVS("cafe", 2, []conf_v1.Route{twoWayRoute("/tea", 70, 30)})
+	updateVS(t, lbc, updated)
+
+	lbc.syncVirtualServer(task{Kind: virtualserver, Key: "default/cafe"})
+
+	// A read accessor must be callable, and the write lock must be free.
+	if got := lbc.configuration.GetVirtualServer("default/cafe"); got == nil {
+		t.Fatal("GetVirtualServer() returned nil after sync")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		lbc.configuration.lock.Lock()
+		lbc.configuration.lock.Unlock()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Configuration.lock still held after syncVirtualServer returned")
+	}
+}
+
+// TestVSRWeightOnlyEligible covers every branch of the fast-lane decision for
+// VirtualServerRoutes directly, including the ones no sync-level fixture can
+// distinguish.
+func TestVSRWeightOnlyEligible(t *testing.T) {
+	t.Parallel()
+
+	seed := func() *conf_v1.VirtualServerRoute {
+		vsr := weightTestVSR("coffee", 1, []conf_v1.Route{twoWayRoute("/tea", 50, 50)})
+		vsr.Labels = map[string]string{"app": "route"}
+		return vsr
+	}
+
+	tests := []struct {
+		name          string
+		dynamicReload bool
+		skipSeed      bool
+		mutate        func(*conf_v1.VirtualServerRoute)
+		want          bool
+	}{
+		{
+			name:          "pure weight change",
+			dynamicReload: true,
+			mutate: func(vsr *conf_v1.VirtualServerRoute) {
+				vsr.Spec.Subroutes = []conf_v1.Route{twoWayRoute("/tea", 70, 30)}
+			},
+			want: true,
+		},
+		{
+			name:          "current object reports StateInvalid",
+			dynamicReload: true,
+			mutate: func(vsr *conf_v1.VirtualServerRoute) {
+				vsr.Spec.Subroutes = []conf_v1.Route{twoWayRoute("/tea", 70, 30)}
+				vsr.Status.State = conf_v1.StateInvalid
+			},
+			want: false,
+		},
+		{
+			name:          "no baseline in Configuration",
+			dynamicReload: true,
+			skipSeed:      true,
+			mutate: func(vsr *conf_v1.VirtualServerRoute) {
+				vsr.Spec.Subroutes = []conf_v1.Route{twoWayRoute("/tea", 70, 30)}
+			},
+			want: false,
+		},
+		{
+			name:          "spec change beyond weights",
+			dynamicReload: true,
+			mutate: func(vsr *conf_v1.VirtualServerRoute) {
+				vsr.Spec.Subroutes = []conf_v1.Route{
+					twoWayRoute("/tea", 70, 30),
+					{Path: "/coffee", Action: &conf_v1.Action{Pass: "v1"}},
+				}
+			},
+			want: false,
+		},
+		{
+			name:          "labels changed alongside a weight change",
+			dynamicReload: true,
+			mutate: func(vsr *conf_v1.VirtualServerRoute) {
+				vsr.Spec.Subroutes = []conf_v1.Route{twoWayRoute("/tea", 70, 30)}
+				vsr.Labels = map[string]string{"app": "other"}
+			},
+			want: false,
+		},
+		{
+			// Nothing changed. Weight-only-equal specs can also be identical,
+			// which happens when the sync was triggered by something other
+			// than this resource's own weights, and there is nothing to apply
+			// in place.
+			name:          "identical spec and labels",
+			dynamicReload: true,
+			mutate:        func(*conf_v1.VirtualServerRoute) {},
+			want:          false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			lbc, _ := newWeightTestLBC(t, test.dynamicReload)
+			if !test.skipSeed {
+				lbc.configuration.AddOrUpdateVirtualServerRoute(seed())
+			}
+
+			cur := seed()
+			test.mutate(cur)
+
+			prev := lbc.configuration.GetVirtualServerRoute("default/coffee")
+			got := vsrWeightOnlyEligible(prev, cur)
+			if got != test.want {
+				t.Errorf("vsrWeightOnlyEligible() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/k8s/weight_update_test.go
+++ b/internal/k8s/weight_update_test.go
@@ -1,0 +1,574 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/nginx/kubernetes-ingress/internal/configs"
+	conf_v1 "github.com/nginx/kubernetes-ingress/pkg/apis/configuration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The split_clients index accounting in computeVSWeightUpdates must mirror
+// configs.GenerateVirtualServerConfig exactly. There are four branches, and
+// this test has to cover all of them, because the walk reimplements each one:
+//
+//	route-level 2-way split      -> += splitClientAmountWhenWeightChangesDynamicReload
+//	route-level non-2-way split  -> += 1
+//	match-level 2-way split      -> += splitClientAmountWhenWeightChangesDynamicReload
+//	match-level non-2-way split  -> += 1
+//
+// A route carrying both matches and route-level splits accounts the matches
+// first, then the route-level splits, sharing one counter.
+//
+// The ground truth for these sequences is pinned on the generator side by
+// TestGenerateVirtualServerConfigSplitClientsIndexSequence in
+// internal/configs/virtualserver_routing_test.go, which uses the same
+// fixtures and the same literal indices. The two cannot be compared directly
+// in one test because virtualServerConfigurator is unexported, so if the
+// expectations there change, they must change here too.
+
+// weightUpdateRoute describes one route: one match per matchSplits entry,
+// followed by the route-level split. A nil or empty split list means "no
+// splits on this route/match".
+type weightUpdateRoute struct {
+	matchSplits [][]int
+	routeSplits []int
+}
+
+func buildWeightUpdateVS(routes []weightUpdateRoute) *conf_v1.VirtualServer {
+	vs := &conf_v1.VirtualServer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cafe"},
+		Spec: conf_v1.VirtualServerSpec{
+			Host: "cafe.example.com",
+		},
+	}
+
+	for i, r := range routes {
+		route := conf_v1.Route{Path: fmt.Sprintf("/route-%d", i)}
+
+		for _, weights := range r.matchSplits {
+			route.Matches = append(route.Matches, conf_v1.Match{
+				Conditions: []conf_v1.Condition{{Header: "x-test", Value: "yes"}},
+				Splits:     buildSplits(weights),
+			})
+		}
+		route.Splits = buildSplits(r.routeSplits)
+
+		vs.Spec.Routes = append(vs.Spec.Routes, route)
+	}
+	return vs
+}
+
+// buildWeightUpdateVSR builds a VirtualServerRoute whose subroutes have the
+// shapes described by subroutes, using the same description struct as
+// buildWeightUpdateVS.
+func buildWeightUpdateVSR(namespace, name string, subroutes []weightUpdateRoute) *conf_v1.VirtualServerRoute {
+	vsr := &conf_v1.VirtualServerRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       conf_v1.VirtualServerRouteSpec{Host: "cafe.example.com"},
+	}
+
+	for i, r := range subroutes {
+		route := conf_v1.Route{Path: fmt.Sprintf("/%s-%d", name, i)}
+		for _, weights := range r.matchSplits {
+			route.Matches = append(route.Matches, conf_v1.Match{
+				Conditions: []conf_v1.Condition{{Header: "x-test", Value: "yes"}},
+				Splits:     buildSplits(weights),
+			})
+		}
+		route.Splits = buildSplits(r.routeSplits)
+		vsr.Spec.Subroutes = append(vsr.Spec.Subroutes, route)
+	}
+
+	return vsr
+}
+
+func buildSplits(weights []int) []conf_v1.Split {
+	if len(weights) == 0 {
+		return nil
+	}
+	splits := make([]conf_v1.Split, 0, len(weights))
+	for i, w := range weights {
+		splits = append(splits, conf_v1.Split{
+			Weight: w,
+			Action: &conf_v1.Action{Pass: fmt.Sprintf("upstream-%d", i)},
+		})
+	}
+	return splits
+}
+
+// wantUpdate builds the WeightUpdate that computeVSWeightUpdates should emit
+// for a 2-way split sitting at splitClientsIndex with the given new weights.
+// Deriving it from the namer keeps these tests about index arithmetic (which
+// is what the bug is) rather than about zone naming (which is not).
+func wantUpdate(vs *conf_v1.VirtualServer, splitClientsIndex, w0, w1 int) configs.WeightUpdate {
+	namer := configs.NewVSVariableNamer(vs)
+	return configs.WeightUpdate{
+		Zone:  namer.GetNameOfKeyvalZoneForSplitClientIndex(splitClientsIndex),
+		Key:   namer.GetNameOfKeyvalKeyForSplitClientIndex(splitClientsIndex),
+		Value: namer.GetNameOfKeyOfMapForWeights(splitClientsIndex, w0, w1),
+	}
+}
+
+func TestComputeVSWeightUpdates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		old  []weightUpdateRoute
+		cur  []weightUpdateRoute
+		// wantIndexes are the split_clients indices the updates must target,
+		// paired with the new weights at that index.
+		wantIndexes [][3]int // {splitClientsIndex, weight0, weight1}
+	}{
+		{
+			name:        "single route-level split changes",
+			old:         []weightUpdateRoute{{routeSplits: []int{50, 50}}},
+			cur:         []weightUpdateRoute{{routeSplits: []int{70, 30}}},
+			wantIndexes: [][3]int{{0, 70, 30}},
+		},
+		{
+			name: "two route-level splits, only the first changes",
+			old: []weightUpdateRoute{
+				{routeSplits: []int{50, 50}},
+				{routeSplits: []int{50, 50}},
+			},
+			cur: []weightUpdateRoute{
+				{routeSplits: []int{70, 30}},
+				{routeSplits: []int{50, 50}},
+			},
+			wantIndexes: [][3]int{{0, 70, 30}},
+		},
+		{
+			name: "two route-level splits, only the second changes",
+			old: []weightUpdateRoute{
+				{routeSplits: []int{50, 50}},
+				{routeSplits: []int{50, 50}},
+			},
+			cur: []weightUpdateRoute{
+				{routeSplits: []int{50, 50}},
+				{routeSplits: []int{70, 30}},
+			},
+			wantIndexes: [][3]int{{101, 70, 30}},
+		},
+		{
+			// Regression case for the double-increment: the extra increment
+			// only fired when an earlier route-level split had itself changed,
+			// so each changed split added a surplus 101 to every index after
+			// it. Today this returns indices 0 and 202.
+			name: "two route-level splits, both change",
+			old: []weightUpdateRoute{
+				{routeSplits: []int{50, 50}},
+				{routeSplits: []int{50, 50}},
+			},
+			cur: []weightUpdateRoute{
+				{routeSplits: []int{70, 30}},
+				{routeSplits: []int{60, 40}},
+			},
+			wantIndexes: [][3]int{{0, 70, 30}, {101, 60, 40}},
+		},
+		{
+			// Drift accumulates. Today this returns 0, 202, 404 — and 404 is
+			// past the end of the 303 split_clients blocks the generator
+			// emitted, so that update is silently dropped by the keyval API.
+			name: "three route-level splits, all change",
+			old: []weightUpdateRoute{
+				{routeSplits: []int{50, 50}},
+				{routeSplits: []int{50, 50}},
+				{routeSplits: []int{50, 50}},
+			},
+			cur: []weightUpdateRoute{
+				{routeSplits: []int{70, 30}},
+				{routeSplits: []int{60, 40}},
+				{routeSplits: []int{90, 10}},
+			},
+			wantIndexes: [][3]int{{0, 70, 30}, {101, 60, 40}, {202, 90, 10}},
+		},
+		{
+			// Match-level and route-level splits share one counter sequence.
+			name: "match split then route split, both change",
+			old: []weightUpdateRoute{
+				{matchSplits: [][]int{{50, 50}}},
+				{routeSplits: []int{50, 50}},
+			},
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{80, 20}}},
+				{routeSplits: []int{60, 40}},
+			},
+			wantIndexes: [][3]int{{0, 80, 20}, {101, 60, 40}},
+		},
+		{
+			// A non-2-way split advances the counter by 1, not 101. The
+			// following 2-way split therefore sits at index 1.
+			name: "three-way split advances index by one",
+			old: []weightUpdateRoute{
+				{routeSplits: []int{34, 33, 33}},
+				{routeSplits: []int{50, 50}},
+			},
+			cur: []weightUpdateRoute{
+				{routeSplits: []int{34, 33, 33}},
+				{routeSplits: []int{70, 30}},
+			},
+			wantIndexes: [][3]int{{1, 70, 30}},
+		},
+		{
+			// Mirrors the "non-two-way splits advance the counter by one
+			// each" fixture in the generator-side test: two 3-way splits
+			// ahead of a 2-way one, so it lands at index 2.
+			name: "two non-two-way splits then a two-way split",
+			old: []weightUpdateRoute{
+				{routeSplits: []int{34, 33, 33}},
+				{routeSplits: []int{34, 33, 33}},
+				{routeSplits: []int{50, 50}},
+			},
+			cur: []weightUpdateRoute{
+				{routeSplits: []int{34, 33, 33}},
+				{routeSplits: []int{34, 33, 33}},
+				{routeSplits: []int{70, 30}},
+			},
+			wantIndexes: [][3]int{{2, 70, 30}},
+		},
+		{
+			// Mirrors the "mixed match-level, non-two-way and route-level
+			// splits" fixture in the generator-side test. Covers all four
+			// accounting branches in one sequence, including a route that
+			// carries both matches and route-level splits:
+			//
+			//	/a match[0] 2-way   -> index 0,   +101
+			//	/a match[1] 3-way   -> index 101, +1
+			//	/a route    2-way   -> index 102, +101
+			//	/b route    3-way   -> index 203, +1
+			//	/c route    2-way   -> index 204, +101
+			//
+			// The 3-way splits are left unchanged: they emit no update but
+			// must still advance the counter, which is exactly what would
+			// break if a generator branch changed underneath us.
+			name: "mixed match-level, non-two-way and route-level splits",
+			old: []weightUpdateRoute{
+				{matchSplits: [][]int{{50, 50}, {34, 33, 33}}, routeSplits: []int{50, 50}},
+				{routeSplits: []int{34, 33, 33}},
+				{routeSplits: []int{50, 50}},
+			},
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{80, 20}, {34, 33, 33}}, routeSplits: []int{70, 30}},
+				{routeSplits: []int{34, 33, 33}},
+				{routeSplits: []int{60, 40}},
+			},
+			wantIndexes: [][3]int{{0, 80, 20}, {102, 70, 30}, {204, 60, 40}},
+		},
+		{
+			name: "identical specs produce no updates",
+			old: []weightUpdateRoute{
+				{routeSplits: []int{50, 50}},
+				{routeSplits: []int{50, 50}},
+			},
+			cur: []weightUpdateRoute{
+				{routeSplits: []int{50, 50}},
+				{routeSplits: []int{50, 50}},
+			},
+			wantIndexes: nil,
+		},
+		{
+			name:        "route with no splits produces no updates",
+			old:         []weightUpdateRoute{{}},
+			cur:         []weightUpdateRoute{{}},
+			wantIndexes: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			vsOld := buildWeightUpdateVS(test.old)
+			vsNew := buildWeightUpdateVS(test.cur)
+
+			var want []configs.WeightUpdate
+			for _, w := range test.wantIndexes {
+				want = append(want, wantUpdate(vsNew, w[0], w[1], w[2]))
+			}
+
+			got := computeVSWeightUpdates(vsOld, vsNew)
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("computeVSWeightUpdates() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsWeightOnlyVSDiff(t *testing.T) {
+	t.Parallel()
+
+	base := []weightUpdateRoute{
+		{matchSplits: [][]int{{50, 50}}, routeSplits: []int{50, 50}},
+		{routeSplits: []int{34, 33, 33}},
+	}
+
+	tests := []struct {
+		name string
+		cur  []weightUpdateRoute
+		want bool
+	}{
+		{name: "identical", cur: base, want: true},
+		{
+			name: "two-way weights changed",
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{80, 20}}, routeSplits: []int{70, 30}},
+				{routeSplits: []int{34, 33, 33}},
+			},
+			want: true,
+		},
+		{
+			// Only 2-way weights are zeroed before comparison, so a change to
+			// a 3-way split is a real spec change: the generator renders those
+			// weights into the config and there is no keyval zone to poke.
+			name: "three-way weights changed",
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{50, 50}}, routeSplits: []int{50, 50}},
+				{routeSplits: []int{50, 25, 25}},
+			},
+			want: false,
+		},
+		{
+			name: "route added",
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{50, 50}}, routeSplits: []int{50, 50}},
+				{routeSplits: []int{34, 33, 33}},
+				{routeSplits: []int{50, 50}},
+			},
+			want: false,
+		},
+		{
+			name: "split count changed",
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{50, 50}}, routeSplits: []int{34, 33, 33}},
+				{routeSplits: []int{34, 33, 33}},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			prev := buildWeightUpdateVS(base)
+			cur := buildWeightUpdateVS(test.cur)
+
+			// Snapshot the inputs to prove the predicate does not mutate the
+			// shared informer cache or the Configuration-owned baseline.
+			prevBefore := buildWeightUpdateVS(base)
+			curBefore := buildWeightUpdateVS(test.cur)
+
+			got := isWeightOnlyVSDiff(prev, cur)
+			if got != test.want {
+				t.Errorf("isWeightOnlyVSDiff() = %v, want %v", got, test.want)
+			}
+
+			if diff := cmp.Diff(prevBefore.Spec, prev.Spec); diff != "" {
+				t.Errorf("baseline was mutated (-before +after):\n%s", diff)
+			}
+			if diff := cmp.Diff(curBefore.Spec, cur.Spec); diff != "" {
+				t.Errorf("current object was mutated (-before +after):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestComputeVSRWeightUpdates(t *testing.T) {
+	t.Parallel()
+
+	vsr := func(shapes []weightUpdateRoute) *conf_v1.VirtualServerRoute {
+		return buildWeightUpdateVSR("default", "coffee", shapes)
+	}
+
+	tests := []struct {
+		name          string
+		old, cur      []weightUpdateRoute
+		startingIndex int
+		wantIndexes   [][3]int
+	}{
+		{
+			name:          "single subroute split at offset zero",
+			old:           []weightUpdateRoute{{routeSplits: []int{50, 50}}},
+			cur:           []weightUpdateRoute{{routeSplits: []int{70, 30}}},
+			startingIndex: 0,
+			wantIndexes:   [][3]int{{0, 70, 30}},
+		},
+		{
+			// The starting offset comes from the referencing VirtualServer's
+			// render; everything after it advances the same way as the VS walk.
+			name:          "offset applies to every emitted update",
+			old:           []weightUpdateRoute{{routeSplits: []int{50, 50}}, {routeSplits: []int{50, 50}}},
+			cur:           []weightUpdateRoute{{routeSplits: []int{70, 30}}, {routeSplits: []int{60, 40}}},
+			startingIndex: 101,
+			wantIndexes:   [][3]int{{101, 70, 30}, {202, 60, 40}},
+		},
+		{
+			name: "match-level and non-two-way accounting",
+			old: []weightUpdateRoute{
+				{matchSplits: [][]int{{50, 50}, {34, 33, 33}}, routeSplits: []int{50, 50}},
+				{routeSplits: []int{50, 50}},
+			},
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{80, 20}, {34, 33, 33}}, routeSplits: []int{70, 30}},
+				{routeSplits: []int{60, 40}},
+			},
+			startingIndex: 0,
+			wantIndexes:   [][3]int{{0, 80, 20}, {102, 70, 30}, {203, 60, 40}},
+		},
+		{
+			name:          "no weight change",
+			old:           []weightUpdateRoute{{routeSplits: []int{50, 50}}},
+			cur:           []weightUpdateRoute{{routeSplits: []int{50, 50}}},
+			startingIndex: 0,
+			wantIndexes:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			vsrOld := vsr(test.old)
+			vsrNew := vsr(test.cur)
+			namer := configs.NewVSVariableNamer(buildWeightUpdateVS(nil))
+
+			var want []configs.WeightUpdate
+			for _, w := range test.wantIndexes {
+				want = append(want, configs.WeightUpdate{
+					Zone:  namer.GetNameOfKeyvalZoneForSplitClientIndex(w[0]),
+					Key:   namer.GetNameOfKeyvalKeyForSplitClientIndex(w[0]),
+					Value: namer.GetNameOfKeyOfMapForWeights(w[0], w[1], w[2]),
+				})
+			}
+
+			got := computeVSRWeightUpdates(vsrOld, vsrNew, test.startingIndex, namer)
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("computeVSRWeightUpdates() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestWeightUpdateWalksRejectShapeMismatch pins the defensive guard. The walks
+// index the two specs positionally, so without it a caller that skipped the
+// weight-only predicate would panic the sync goroutine. Returning nil instead
+// degrades to a full reload, which is always safe.
+func TestWeightUpdateWalksRejectShapeMismatch(t *testing.T) {
+	t.Parallel()
+
+	twoWay := []weightUpdateRoute{{routeSplits: []int{50, 50}}}
+
+	mismatches := []struct {
+		name     string
+		old, cur []weightUpdateRoute
+	}{
+		{
+			name: "route count differs",
+			old:  twoWay,
+			cur:  []weightUpdateRoute{{routeSplits: []int{70, 30}}, {routeSplits: []int{50, 50}}},
+		},
+		{
+			name: "match count differs",
+			old:  []weightUpdateRoute{{matchSplits: [][]int{{50, 50}}}},
+			cur:  []weightUpdateRoute{{matchSplits: [][]int{{70, 30}, {50, 50}}}},
+		},
+		{
+			name: "split count differs",
+			old:  twoWay,
+			cur:  []weightUpdateRoute{{routeSplits: []int{34, 33, 33}}},
+		},
+		{
+			name: "match split count differs",
+			old:  []weightUpdateRoute{{matchSplits: [][]int{{50, 50}}}},
+			cur:  []weightUpdateRoute{{matchSplits: [][]int{{34, 33, 33}}}},
+		},
+	}
+
+	for _, test := range mismatches {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := computeVSWeightUpdates(buildWeightUpdateVS(test.old), buildWeightUpdateVS(test.cur)); got != nil {
+				t.Errorf("computeVSWeightUpdates() = %v, want nil for mismatched shapes", got)
+			}
+
+			namer := configs.NewVSVariableNamer(buildWeightUpdateVS(nil))
+			vsrOld := buildWeightUpdateVSR("default", "coffee", test.old)
+			vsrNew := buildWeightUpdateVSR("default", "coffee", test.cur)
+			if got := computeVSRWeightUpdates(vsrOld, vsrNew, 0, namer); got != nil {
+				t.Errorf("computeVSRWeightUpdates() = %v, want nil for mismatched shapes", got)
+			}
+		})
+	}
+}
+
+func TestHasTwoWaySplitWeightChanges(t *testing.T) {
+	t.Parallel()
+
+	base := []weightUpdateRoute{
+		{matchSplits: [][]int{{50, 50}, {34, 33, 33}}, routeSplits: []int{50, 50}},
+		{routeSplits: []int{34, 33, 33}},
+	}
+
+	tests := []struct {
+		name string
+		cur  []weightUpdateRoute
+		want bool
+	}{
+		{name: "identical", cur: base, want: false},
+		{
+			name: "route-level two-way weights changed",
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{50, 50}, {34, 33, 33}}, routeSplits: []int{70, 30}},
+				{routeSplits: []int{34, 33, 33}},
+			},
+			want: true,
+		},
+		{
+			name: "match-level two-way weights changed",
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{80, 20}, {34, 33, 33}}, routeSplits: []int{50, 50}},
+				{routeSplits: []int{34, 33, 33}},
+			},
+			want: true,
+		},
+		{
+			// Only 2-way splits have a keyval zone to poke, so a change to a
+			// 3-way split is not something the fast lane can apply.
+			name: "only non-two-way weights changed",
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{50, 50}, {50, 25, 25}}, routeSplits: []int{50, 50}},
+				{routeSplits: []int{50, 25, 25}},
+			},
+			want: false,
+		},
+		{
+			// Shape mismatch cannot be walked positionally, so the answer is
+			// "no in-place change", which sends the caller down the full path.
+			name: "shape mismatch",
+			cur: []weightUpdateRoute{
+				{matchSplits: [][]int{{50, 50}, {34, 33, 33}}, routeSplits: []int{50, 50}},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			prev := buildWeightUpdateVS(base)
+			cur := buildWeightUpdateVS(test.cur)
+
+			got := hasTwoWaySplitWeightChanges(prev.Spec.Routes, cur.Spec.Routes)
+			if got != test.want {
+				t.Errorf("hasTwoWaySplitWeightChanges() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- VSR fan-out isn't filtered. When a VirtualServerRoute's weights change, rebuildHosts can report changes for other, unrelated VirtualServers too (cascading effects). The original PR pushed a keyval write to every changed VS without checking it actually references the VSR — the unrelated VS got a bogus write derived from the wrong split index and never got rendered. Fixed: reject the fast lane unless every changed VS demonstrably references this VSR.
- VS change-shape wasn't checked. The fast lane assumed the single change was always an AddOrUpdate of the VS itself. A Delete or a cascade to a second resource silently got dropped instead of falling back to a full render. Fixed: require exactly one AddOrUpdate matching the target VS's key.
- Label-only VSR changes were mishandled (a real, currently-live bug on main). VirtualServerRoute labels drive routeSelector attachment to a VirtualServer. A label change (attach/detach), or a label change bundled with a weight change, looks "weight-only" to a spec-only diff — so it took the fast lane and NGINX never got re-rendered to reflect the attachment change. Fixed: reject the fast lane whenever labels differ.
- getStartingSplitClientsIndex matched VSRs by name only, not namespace+name. Two VSRs with the same name in different namespaces (legal — reachable via namespaced route: refs or routeSelector) would collide, and one's weight update would land in the other's keyval zone. Fixed: match on the full namespace/name key.

Plus one small API cleanup: computeVSRWeightUpdates now takes a VariableNamer directly instead of a whole VirtualServerEx, dropping an unneeded dependency.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
