### PR TITLE
PoC: e2e test stability fixes

### DIFF
--- a/perf-tests/conftest.py
+++ b/perf-tests/conftest.py
@@ -15,7 +15,7 @@ from settings import (
     DEFAULT_SERVICE,
     NUM_REPLICAS,
 )
-from suite.utils.resources_utils import get_first_pod_name
+from suite.utils.resources_utils import get_e2e_run_selector, get_first_pod_name
 
 
 def pytest_addoption(parser) -> None:
@@ -157,7 +157,8 @@ def pytest_runtest_makereport(item) -> None:
     # we only look at actual failing test calls, not setup/teardown
     if rep.when == "call" and rep.failed and item.config.getoption("--show-ic-logs") == "yes":
         pod_namespace = item.funcargs["ingress_controller_prerequisites"].namespace
-        pod_name = get_first_pod_name(item.funcargs["kube_apis"].v1, pod_namespace)
+        selector = get_e2e_run_selector(item.funcargs["ingress_controller_prerequisites"].e2e_run_id)
+        pod_name = get_first_pod_name(item.funcargs["kube_apis"].v1, pod_namespace, selector)
         print("\n===================== IC Logs Start =====================")
         print(item.funcargs["kube_apis"].v1.read_namespaced_pod_log(pod_name, pod_namespace))
         print("\n===================== IC Logs End =====================")

--- a/perf-tests/suite/test_ap_reload_perf.py
+++ b/perf-tests/suite/test_ap_reload_perf.py
@@ -24,6 +24,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     get_resource_metrics,
     replace_ingress_with_ap_annotations,
     wait_before_test,
@@ -62,7 +63,11 @@ def enable_prometheus_port(
     body = kube_apis.apps_v1_api.read_namespaced_deployment("nginx-ingress", namespace)
     body.spec.template.spec.containers[0].ports.append(port)
     kube_apis.apps_v1_api.patch_namespaced_deployment("nginx-ingress", namespace, body)
-    wait_until_all_pods_are_ready(kube_apis.v1, namespace)
+    wait_until_all_pods_are_ready(
+        kube_apis.v1,
+        namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
 
 
 @pytest.fixture(scope="class")

--- a/perf-tests/suite/test_ap_reload_perf.py
+++ b/perf-tests/suite/test_ap_reload_perf.py
@@ -24,6 +24,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
     get_e2e_run_selector,
     get_resource_metrics,
     replace_ingress_with_ap_annotations,
@@ -85,9 +86,10 @@ def appprotect_setup(
     """
 
     print("------------------------- Deploy simple backend application -------------------------")
-    create_example_app(kube_apis, "simple", test_namespace)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
     req_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/perf-tests/suite/test_ingress_perf.py
+++ b/perf-tests/suite/test_ingress_perf.py
@@ -13,6 +13,8 @@ from suite.utils.resources_utils import (
     delete_secret,
     ensure_connection,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_resource_metrics,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -37,10 +39,11 @@ class Setup:
 @pytest.fixture(scope="class")
 def setup(request, kube_apis, ingress_controller_prerequisites, ingress_controller_endpoint, test_namespace) -> Setup:
     print("------------------------- Deploy prerequisites -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     secret_name = create_secret_from_yaml(kube_apis.v1, test_namespace, f"{TEST_DATA}/smoke/smoke-secret.yaml")
 
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     req_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -17,7 +17,9 @@ COPY --link config /workspace/config
 COPY --link tests /workspace/tests
 COPY --link pyproject.toml /workspace/pyproject.toml
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl \
+RUN --mount=type=secret,id=ca-bundle,required=false \
+	if [ -s /run/secrets/ca-bundle ]; then export CURL_CA_BUNDLE=/run/secrets/ca-bundle; fi \
+	&& curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl \
 	&& install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
 	&& install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,6 +6,8 @@ DEPLOYMENT_TYPE             = deployment
 SERVICE                     ?= nodeport
 NODE_IP                     =
 TEST_PREFIX                 = test-runner
+CA_BUNDLE                   ?= $(CURL_CA_BUNDLE)
+COMMA                       := ,
 KUBE_CONFIG_FOLDER          = ${HOME}/.kube
 KIND_KUBE_CONFIG_FOLDER     = $(KUBE_CONFIG_FOLDER)/kind
 MINIKUBE_KUBE_CONFIG_FOLDER = $(KUBE_CONFIG_FOLDER)/minikube
@@ -46,7 +48,7 @@ help: ## Show available make targets
 
 .PHONY: build
 build: ## Run build
-	docker build --build-arg ARCH=$(ARCH) -t $(TEST_PREFIX):$(TEST_TAG) -f $(DOCKERFILEPATH) $(ROOT_DIR)
+	docker build --build-arg ARCH=$(ARCH) $(if $(CA_BUNDLE),--secret id=ca-bundle$(COMMA)src="$(CA_BUNDLE)") -t $(TEST_PREFIX):$(TEST_TAG) -f $(DOCKERFILEPATH) $(ROOT_DIR)
 
 
 $(KUBE_CONFIG_FOLDER):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from settings import (
 )
 from suite.utils.resources_utils import (
     are_all_pods_in_ready_state,
+    get_e2e_run_selector,
     get_first_pod_name,
     wait_before_test,
 )
@@ -240,10 +241,11 @@ def pytest_runtest_makereport(item) -> None:
     # we only look at actual failing test calls, not setup/teardown
     if rep.when == "call" and rep.failed and item.config.getoption("--show-ic-logs") == "yes":
         pod_namespace = item.funcargs["ingress_controller_prerequisites"].namespace
-        pod_name = get_first_pod_name(item.funcargs["kube_apis"].v1, pod_namespace)
+        selector = get_e2e_run_selector(item.funcargs["ingress_controller_prerequisites"].e2e_run_id)
+        pod_name = get_first_pod_name(item.funcargs["kube_apis"].v1, pod_namespace, selector)
         print("\n::group::NGINX Ingress Controller Pod Logs")
         count = 0
-        while (not are_all_pods_in_ready_state(item.funcargs["kube_apis"].v1, pod_namespace)) and count < 10:
+        while (not are_all_pods_in_ready_state(item.funcargs["kube_apis"].v1, pod_namespace, selector)) and count < 10:
             count += 1
             wait_before_test()
         pod = item.funcargs["kube_apis"].v1.read_namespaced_pod(pod_name, pod_namespace)

--- a/tests/suite/fixtures/custom_resource_fixtures.py
+++ b/tests/suite/fixtures/custom_resource_fixtures.py
@@ -185,7 +185,11 @@ def transport_server_setup(
 
     request.addfinalizer(fin)
 
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
     ic_namespace = ingress_controller_prerequisites.namespace
 
     metrics_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"

--- a/tests/suite/fixtures/custom_resource_fixtures.py
+++ b/tests/suite/fixtures/custom_resource_fixtures.py
@@ -15,6 +15,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_namespace,
     delete_service,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_first_pod_name,
     wait_until_all_pods_are_ready,
 )
@@ -101,13 +103,14 @@ def virtual_server_setup(request, kube_apis, ingress_controller_endpoint, test_n
     :return: VirtualServerSetup
     """
     print("------------------------- Deploy Virtual Server Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     vs_source = f"{TEST_DATA}/{request.param['example']}/standard/virtual-server.yaml"
     vs_name = create_virtual_server_from_yaml(kube_apis.custom_objects, vs_source, test_namespace)
     vs_host = get_first_host_from_yaml(vs_source)
     vs_paths = get_paths_from_vs_yaml(vs_source)
     if request.param.get("app_type"):
-        create_example_app(kube_apis, request.param["app_type"], test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, request.param["app_type"], test_namespace, e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -157,6 +160,7 @@ def transport_server_setup(
     :return: TransportServerSetup
     """
     print("------------------------- Deploy Transport Server Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
 
     # deploy global config
     global_config_file = f"{TEST_DATA}/{request.param['example']}/standard/global-configuration.yaml"
@@ -164,13 +168,13 @@ def transport_server_setup(
 
     # deploy service_file
     service_file = f"{TEST_DATA}/{request.param['example']}/standard/service_deployment.yaml"
-    create_items_from_yaml(kube_apis, service_file, test_namespace)
+    create_items_from_yaml(kube_apis, service_file, test_namespace, e2e_run_id)
 
     # deploy transport server
     transport_server_file = f"{TEST_DATA}/{request.param['example']}/standard/transport-server.yaml"
     ts_resource = create_ts_from_yaml(kube_apis.custom_objects, transport_server_file, test_namespace)
 
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -210,16 +214,24 @@ def v_s_route_app_setup(request, kube_apis, v_s_route_setup) -> None:
     :return:
     """
     print("---------------------- Deploy a VS Route Example Application ----------------------------")
+    e2e_run_id = generate_e2e_run_id()
     svc_one = create_service_with_name(kube_apis.v1, v_s_route_setup.route_m.namespace, "backend1-svc")
     svc_three = create_service_with_name(kube_apis.v1, v_s_route_setup.route_m.namespace, "backend3-svc")
-    deployment_one = create_deployment_with_name(kube_apis.apps_v1_api, v_s_route_setup.route_m.namespace, "backend1")
-    deployment_three = create_deployment_with_name(kube_apis.apps_v1_api, v_s_route_setup.route_m.namespace, "backend3")
+    deployment_one = create_deployment_with_name(
+        kube_apis.apps_v1_api, v_s_route_setup.route_m.namespace, "backend1", e2e_run_id
+    )
+    deployment_three = create_deployment_with_name(
+        kube_apis.apps_v1_api, v_s_route_setup.route_m.namespace, "backend3", e2e_run_id
+    )
 
     svc_two = create_service_with_name(kube_apis.v1, v_s_route_setup.route_s.namespace, "backend2-svc")
-    deployment_two = create_deployment_with_name(kube_apis.apps_v1_api, v_s_route_setup.route_s.namespace, "backend2")
+    deployment_two = create_deployment_with_name(
+        kube_apis.apps_v1_api, v_s_route_setup.route_s.namespace, "backend2", e2e_run_id
+    )
 
-    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_setup.route_m.namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_setup.route_s.namespace)
+    selector = get_e2e_run_selector(e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_setup.route_m.namespace, selector)
+    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_setup.route_s.namespace, selector)
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -247,22 +259,24 @@ def v_s_route_selector_app_setup(request, kube_apis, v_s_route_selector_setup) -
     :return:
     """
     print("---------------------- Deploy a VS Route Example Application ----------------------------")
+    e2e_run_id = generate_e2e_run_id()
     svc_one = create_service_with_name(kube_apis.v1, v_s_route_selector_setup.route_m.namespace, "backend1-svc")
     svc_three = create_service_with_name(kube_apis.v1, v_s_route_selector_setup.route_m.namespace, "backend3-svc")
     deployment_one = create_deployment_with_name(
-        kube_apis.apps_v1_api, v_s_route_selector_setup.route_m.namespace, "backend1"
+        kube_apis.apps_v1_api, v_s_route_selector_setup.route_m.namespace, "backend1", e2e_run_id
     )
     deployment_three = create_deployment_with_name(
-        kube_apis.apps_v1_api, v_s_route_selector_setup.route_m.namespace, "backend3"
+        kube_apis.apps_v1_api, v_s_route_selector_setup.route_m.namespace, "backend3", e2e_run_id
     )
 
     svc_two = create_service_with_name(kube_apis.v1, v_s_route_selector_setup.route_s.namespace, "backend2-svc")
     deployment_two = create_deployment_with_name(
-        kube_apis.apps_v1_api, v_s_route_selector_setup.route_s.namespace, "backend2"
+        kube_apis.apps_v1_api, v_s_route_selector_setup.route_s.namespace, "backend2", e2e_run_id
     )
 
-    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_selector_setup.route_m.namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_selector_setup.route_s.namespace)
+    selector = get_e2e_run_selector(e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_selector_setup.route_m.namespace, selector)
+    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_selector_setup.route_s.namespace, selector)
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/fixtures/fixtures.py
+++ b/tests/suite/fixtures/fixtures.py
@@ -35,6 +35,7 @@ from suite.utils.resources_utils import (
     delete_namespace,
     delete_testing_namespaces,
     generate_e2e_run_id,
+    get_e2e_run_selector,
     get_leases,
     get_service_node_ports,
     replace_configmap_from_yaml,
@@ -472,10 +473,11 @@ def create_certmanager(request):
     """
     cm_yaml = f"{TEST_DATA}/virtual-server-certmanager/certmanager.yaml"
     kube_apis = request.getfixturevalue("kube_apis")
+    e2e_run_id = generate_e2e_run_id()
     with open(cm_yaml) as f:
         cm_yaml_content = yaml.load_all(f, Loader=yaml.SafeLoader)
         print("------------------------- Deploy CertManager in the cluster -----------------------------------")
-        create_generic_from_yaml(cm_yaml, request)
+        create_generic_from_yaml(cm_yaml, request, e2e_run_id)
         for doc in cm_yaml_content:
             if doc["kind"] == "Deployment":
                 replicas = doc["spec"].get("replicas", 1)
@@ -483,7 +485,11 @@ def create_certmanager(request):
                 name = doc["metadata"]["name"]
                 print(f"Wait until Cert-manager deployment {name} in namespace {ns} has {replicas} ready replicas")
                 count = 0
-                while (not are_all_pods_in_ready_state(request.getfixturevalue("kube_apis").v1, ns)) and count < 10:
+                while (
+                    not are_all_pods_in_ready_state(
+                        request.getfixturevalue("kube_apis").v1, ns, get_e2e_run_selector(e2e_run_id)
+                    )
+                ) and count < 10:
                     count += 1
                     wait_before_test()
 

--- a/tests/suite/fixtures/fixtures.py
+++ b/tests/suite/fixtures/fixtures.py
@@ -33,6 +33,7 @@ from suite.utils.resources_utils import (
     delete_lease,
     delete_namespace,
     delete_testing_namespaces,
+    generate_e2e_run_id,
     get_leases,
     get_service_node_ports,
     replace_configmap_from_yaml,
@@ -130,6 +131,12 @@ def print_name() -> None:
     """Print out a current test name."""
     test_name = f"{os.environ.get('PYTEST_CURRENT_TEST').split(':')[2]} :: {os.environ.get('PYTEST_CURRENT_TEST').split(':')[4].split(' ')[0]}"
     print(f"\n============================= {test_name} =============================")
+
+
+@pytest.fixture(scope="function")
+def e2e_run_id() -> str:
+    """Provide one run ID for all workloads created by a test invocation."""
+    return generate_e2e_run_id()
 
 
 @pytest.fixture(scope="class")

--- a/tests/suite/fixtures/fixtures.py
+++ b/tests/suite/fixtures/fixtures.py
@@ -21,6 +21,7 @@ from settings import ALLOWED_DEPLOYMENT_TYPES, ALLOWED_IC_TYPES, ALLOWED_SERVICE
 from suite.utils.custom_resources_utils import create_crd_from_yaml, delete_crd
 from suite.utils.kube_config_utils import ensure_context_in_config, get_current_context_name
 from suite.utils.resources_utils import (
+    add_e2e_run_id_to_workload,
     are_all_pods_in_ready_state,
     cleanup_rbac,
     configure_rbac,
@@ -515,7 +516,7 @@ def create_issuer(request):
         create_generic_from_yaml(issuer_secret_yaml, request)
 
 
-def create_generic_from_yaml(file_path, request):
+def create_generic_from_yaml(file_path, request, e2e_run_id=None):
     """
     Create an object using a path to the yaml file.
 
@@ -523,7 +524,21 @@ def create_generic_from_yaml(file_path, request):
     :param request: pytest fixture
     """
     try:
-        subprocess.run(["kubectl", "apply", "-f", f"{file_path}"], capture_output=True, check=True)
+        if e2e_run_id:
+            with open(file_path) as f:
+                docs = list(yaml.safe_load_all(f))
+            for doc in docs:
+                if doc and doc["kind"] in {"Deployment", "DaemonSet", "StatefulSet"}:
+                    add_e2e_run_id_to_workload(doc, e2e_run_id)
+            subprocess.run(
+                ["kubectl", "apply", "-f", "-"],
+                input=yaml.safe_dump_all(docs),
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+        else:
+            subprocess.run(["kubectl", "apply", "-f", file_path], capture_output=True, check=True)
     except subprocess.CalledProcessError:
         print("Error occurred while applying a resource definition. See logs for details.")
         raise

--- a/tests/suite/fixtures/fixtures.py
+++ b/tests/suite/fixtures/fixtures.py
@@ -122,9 +122,10 @@ class IngressControllerPrerequisites:
         config_map (str): config_map name
     """
 
-    def __init__(self, config_map, namespace):
+    def __init__(self, config_map, namespace, e2e_run_id):
         self.namespace = namespace
         self.config_map = config_map
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(autouse=True)
@@ -287,7 +288,7 @@ def ingress_controller_prerequisites(cli_arguments, kube_apis, request) -> Ingre
 
     request.addfinalizer(fin)
 
-    return IngressControllerPrerequisites(config_map, namespace)
+    return IngressControllerPrerequisites(config_map, namespace, generate_e2e_run_id())
 
 
 @pytest.fixture(scope="session")

--- a/tests/suite/fixtures/ic_fixtures.py
+++ b/tests/suite/fixtures/ic_fixtures.py
@@ -20,6 +20,7 @@ from suite.utils.resources_utils import (
     delete_ingress_controller,
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
     get_first_pod_name,
     patch_rbac,
     replace_configmap_from_yaml,
@@ -49,7 +50,14 @@ def ingress_controller(cli_arguments, kube_apis, ingress_controller_prerequisite
         print("IC will start with CRDs disabled and without any additional cli-arguments")
         extra_args = ["-enable-custom-resources=false"]
     try:
-        name = create_ingress_controller(kube_apis.v1, kube_apis.apps_v1_api, cli_arguments, namespace, extra_args)
+        name = create_ingress_controller(
+            kube_apis.v1,
+            kube_apis.apps_v1_api,
+            cli_arguments,
+            namespace,
+            extra_args,
+            e2e_run_id=ingress_controller_prerequisites.e2e_run_id,
+        )
     except ApiException as ex:
         # Finalizer doesn't start if fixture creation was incomplete, ensure clean up here
         print(f"Failed to complete IC fixture: {ex}\nClean up the cluster as much as possible.")
@@ -97,6 +105,7 @@ def crd_ingress_controller(
             cli_arguments,
             namespace,
             request.param.get("extra_args", None),
+            e2e_run_id=ingress_controller_prerequisites.e2e_run_id,
         )
         if request.param["type"] == "tls-passthrough-custom-port":
             orig_port = ingress_controller_endpoint.port_ssl
@@ -175,6 +184,7 @@ def crd_ingress_controller_with_ap(
             cli_arguments,
             namespace,
             request.param.get("extra_args", None),
+            e2e_run_id=ingress_controller_prerequisites.e2e_run_id,
         )
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
@@ -297,6 +307,7 @@ def crd_ingress_controller_with_waf_v5(
                 "regcred",
                 request.param.get("extra_args", None),
                 True,
+                e2e_run_id=ingress_controller_prerequisites.e2e_run_id,
             )
         else:
             name = create_ingress_controller_wafv5(
@@ -306,9 +317,14 @@ def crd_ingress_controller_with_waf_v5(
                 namespace,
                 "regcred",
                 request.param.get("extra_args", None),
+                e2e_run_id=ingress_controller_prerequisites.e2e_run_id,
             )
         try:
-            pod_name = get_first_pod_name(kube_apis.v1, namespace)
+            pod_name = get_first_pod_name(
+                kube_apis.v1,
+                namespace,
+                f"e2e.nginx.org/run-id={ingress_controller_prerequisites.e2e_run_id}",
+            )
             dest_path = "/etc/app_protect/bundles/wafv5.tgz"
             src_path = f"{dir}/wafv5.tgz"
             result = subprocess.run(
@@ -389,6 +405,7 @@ def crd_ingress_controller_with_dos(
     """
     namespace = ingress_controller_prerequisites.namespace
     name = "nginx-ingress"
+    dos_run_id = generate_e2e_run_id()
 
     try:
         print("--------------------Create roles and bindings for AppProtect------------------------")
@@ -416,14 +433,14 @@ def crd_ingress_controller_with_dos(
 
         print("------------------------- Create syslog svc -----------------------")
         src_syslog_yaml = f"{TEST_DATA}/dos/dos-syslog.yaml"
-        create_items_from_yaml(kube_apis, src_syslog_yaml, namespace)
+        create_items_from_yaml(kube_apis, src_syslog_yaml, namespace, dos_run_id)
 
         print("------------------------- Create accesslog svc -----------------------")
         src_accesslog_yaml = f"{TEST_DATA}/dos/dos-accesslog.yaml"
-        create_items_from_yaml(kube_apis, src_accesslog_yaml, namespace)
+        create_items_from_yaml(kube_apis, src_accesslog_yaml, namespace, dos_run_id)
 
         before = time.time()
-        wait_until_all_pods_are_ready(kube_apis.v1, namespace)
+        wait_until_all_pods_are_ready(kube_apis.v1, namespace, f"e2e.nginx.org/run-id={dos_run_id}")
         after = time.time()
         print(f"All pods came up in {int(after-before)} seconds")
         print(f"syslog and accesslog svc was created")
@@ -435,6 +452,7 @@ def crd_ingress_controller_with_dos(
             namespace,
             f"{DEPLOYMENTS}/deployment/appprotect-dos-arb.yaml",
             f"{DEPLOYMENTS}/service/appprotect-dos-arb-svc.yaml",
+            e2e_run_id=dos_run_id,
         )
 
         print("------------------------- Create IC -----------------------------------")
@@ -444,6 +462,7 @@ def crd_ingress_controller_with_dos(
             cli_arguments,
             namespace,
             request.param.get("extra_args", None),
+            e2e_run_id=ingress_controller_prerequisites.e2e_run_id,
         )
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
@@ -538,6 +557,7 @@ def crd_ingress_controller_with_ed(
             cli_arguments,
             namespace,
             request.param.get("extra_args", None),
+            e2e_run_id=ingress_controller_prerequisites.e2e_run_id,
         )
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,

--- a/tests/suite/test_ac_policies_ingress.py
+++ b/tests/suite/test_ac_policies_ingress.py
@@ -117,10 +117,11 @@ def ingress_setup(
     ingress_controller_prerequisites,
     ingress_controller_endpoint,
     test_namespace,
+    e2e_run_id,
 ) -> IngressSetup:
     print("------------------------- Deploy backend app first -----------------------------------")
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     print("------------------------- Deploy Ingress with AccessControl policy -----------------------------------")
     src = f"{TEST_DATA}/access-control/ingress/{request.param}/annotations-ac-ingress.yaml"

--- a/tests/suite/test_ac_policies_ingress.py
+++ b/tests/suite/test_ac_policies_ingress.py
@@ -10,6 +10,7 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_reload_count,
     replace_configmap_from_yaml,
@@ -136,7 +137,11 @@ def ingress_setup(
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
     )
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_agent.py
+++ b/tests/suite/test_agent.py
@@ -1,7 +1,7 @@
 import pytest
 from kubernetes.stream import stream
 from settings import TEST_DATA
-from suite.utils.resources_utils import get_file_contents, get_first_pod_name, wait_before_test
+from suite.utils.resources_utils import get_e2e_run_selector, get_file_contents, get_first_pod_name, wait_before_test
 
 
 @pytest.mark.agentv3
@@ -18,7 +18,11 @@ from suite.utils.resources_utils import get_file_contents, get_first_pod_name, w
 )
 class TestAgentV3:
     def test_agent(self, kube_apis, ingress_controller_prerequisites, ingress_controller):
-        pod_name = get_first_pod_name(kube_apis.v1, "nginx-ingress")
+        pod_name = get_first_pod_name(
+            kube_apis.v1,
+            "nginx-ingress",
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         log = kube_apis.v1.read_namespaced_pod_log(pod_name, ingress_controller_prerequisites.namespace)
 
         command = ["/usr/bin/nginx-agent", "-v"]

--- a/tests/suite/test_annotations.py
+++ b/tests/suite/test_annotations.py
@@ -11,6 +11,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     generate_ingresses_with_annotation,
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
@@ -128,7 +129,11 @@ def annotations_setup(
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
     )
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
     upstream_names = []
     if request.param == "mergeable":
         event_text = f"Configuration for {test_namespace}/{ingress_name} was added or updated"
@@ -193,7 +198,11 @@ def annotations_grpc_setup(
         ingress_controller_prerequisites.namespace,
         f"{TEST_DATA}/common/configmap-with-grpc.yaml",
     )
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
     event_text = f"Configuration for {test_namespace}/{ingress_name} was added or updated"
     error_text = f"{event_text} ; but was not applied: Error reloading NGINX"
 

--- a/tests/suite/test_annotations.py
+++ b/tests/suite/test_annotations.py
@@ -10,6 +10,7 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
     generate_ingresses_with_annotation,
     get_e2e_run_selector,
     get_events,
@@ -112,6 +113,7 @@ def annotations_setup(
     test_namespace,
 ) -> AnnotationsSetup:
     print("------------------------- Deploy Annotations-Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     if request.param == "grpc":
         create_items_from_yaml(kube_apis, f"{TEST_DATA}/annotations/{request.param}/grpc-secret.yaml", test_namespace)
     create_items_from_yaml(
@@ -124,8 +126,8 @@ def annotations_setup(
     else:
         minions_info = None
 
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
     )

--- a/tests/suite/test_apikey_auth_policies.py
+++ b/tests/suite/test_apikey_auth_policies.py
@@ -10,6 +10,7 @@ from suite.utils.resources_utils import (
     delete_secret,
     get_apikey_auth_secrets_from_yaml,
     get_apikey_policy_details_from_yaml,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -83,7 +84,9 @@ class TestAPIKeyAuthPolicies:
             apikeys=apikeys,
         )
 
-    def test_apikey_auth_policy_vs(self, kube_apis, crd_ingress_controller, virtual_server_setup, test_namespace):
+    def test_apikey_auth_policy_vs(
+        self, kube_apis, crd_ingress_controller, virtual_server_setup, test_namespace, e2e_run_id
+    ):
         apikey_policy_details = self.setup_single_policy(
             kube_apis,
             virtual_server_setup.namespace,
@@ -109,7 +112,7 @@ class TestAPIKeyAuthPolicies:
 
         host = apikey_policy_details.vs_host
 
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         wait_before_test()
 
         # /undefined path (is not a route defined in the VirtualServer)
@@ -292,7 +295,7 @@ class TestAPIKeyAuthPolicies:
             assert response.status_code == 200
 
     def test_apikey_auth_policy_vs_and_vsr(
-        self, kube_apis, crd_ingress_controller, virtual_server_setup, test_namespace
+        self, kube_apis, crd_ingress_controller, virtual_server_setup, test_namespace, e2e_run_id
     ):
         apikey_policy_details_server = self.setup_single_policy(
             kube_apis,
@@ -320,7 +323,7 @@ class TestAPIKeyAuthPolicies:
         create_v_s_route_from_yaml(kube_apis.custom_objects, vsr_2_src, virtual_server_setup.namespace)
 
         host = virtual_server_setup.vs_host
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         wait_before_test(5)
 
         # /undefined path (is not a route defined in the VirtualServer)

--- a/tests/suite/test_app_protect_agent.py
+++ b/tests/suite/test_app_protect_agent.py
@@ -1,7 +1,7 @@
 import pytest
 from kubernetes.stream import stream
 from settings import TEST_DATA
-from suite.utils.resources_utils import get_file_contents, get_first_pod_name, wait_before_test
+from suite.utils.resources_utils import get_e2e_run_selector, get_file_contents, get_first_pod_name, wait_before_test
 
 
 @pytest.mark.skip_for_nginx_oss
@@ -21,7 +21,11 @@ from suite.utils.resources_utils import get_file_contents, get_first_pod_name, w
 )
 class TestAppProtectAgentV2:
     def test_ap_agent(self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller_with_ap):
-        pod_name = get_first_pod_name(kube_apis.v1, "nginx-ingress")
+        pod_name = get_first_pod_name(
+            kube_apis.v1,
+            "nginx-ingress",
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         log = kube_apis.v1.read_namespaced_pod_log(pod_name, ingress_controller_prerequisites.namespace)
 
         command = ["/usr/bin/nginx-agent", "-v"]

--- a/tests/suite/test_app_protect_integration.py
+++ b/tests/suite/test_app_protect_integration.py
@@ -20,6 +20,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_file_contents,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
@@ -55,9 +57,10 @@ class AppProtectSetup:
         metrics_url (str):
     """
 
-    def __init__(self, req_url, metrics_url):
+    def __init__(self, req_url, metrics_url, e2e_run_id):
         self.req_url = req_url
         self.metrics_url = metrics_url
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(scope="class")
@@ -72,10 +75,11 @@ def appprotect_setup(request, kube_apis, ingress_controller_endpoint, test_names
     :return: BackendSetup
     """
     print("------------------------- Deploy simple backend application -------------------------")
-    create_example_app(kube_apis, "simple", test_namespace)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
     req_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
     metrics_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,
@@ -96,7 +100,7 @@ def appprotect_setup(request, kube_apis, ingress_controller_endpoint, test_names
 
     print("------------------------- Deploy syslog server ---------------------------")
     src_syslog_yaml = f"{TEST_DATA}/appprotect/syslog.yaml"
-    create_items_from_yaml(kube_apis, src_syslog_yaml, test_namespace)
+    create_items_from_yaml(kube_apis, src_syslog_yaml, test_namespace, e2e_run_id=e2e_run_id)
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -111,7 +115,7 @@ def appprotect_setup(request, kube_apis, ingress_controller_endpoint, test_names
 
     request.addfinalizer(fin)
 
-    return AppProtectSetup(req_url, metrics_url)
+    return AppProtectSetup(req_url, metrics_url, e2e_run_id)
 
 
 def assert_ap_crd_info(ap_crd_info, policy_name) -> None:
@@ -328,7 +332,7 @@ class TestAppProtect:
 
     @pytest.mark.flaky(max_runs=3)
     def test_ap_multi_sec_logs(
-        self, request, kube_apis, crd_ingress_controller_with_ap, appprotect_setup, test_namespace
+        self, request, kube_apis, crd_ingress_controller_with_ap, appprotect_setup, test_namespace, e2e_run_id
     ):
         """
         Test corresponding log entries with multiple log destinations (in this case, two syslog servers)
@@ -337,7 +341,7 @@ class TestAppProtect:
         log_loc = "/var/log/messages"
 
         print("Create a second syslog server")
-        create_items_from_yaml(kube_apis, src_syslog2_yaml, test_namespace)
+        create_items_from_yaml(kube_apis, src_syslog2_yaml, test_namespace, e2e_run_id=e2e_run_id)
 
         syslog_dst = f"syslog-svc.{test_namespace}"
         syslog2_dst = f"syslog2-svc.{test_namespace}"
@@ -368,8 +372,12 @@ class TestAppProtect:
         print("----------------------- Send request ----------------------")
         response = retry_get(appprotect_setup.req_url + "/<script>", ingress_host, verify=False)
         print(response.text)
-        syslog_pod = get_pod_name_that_contains(kube_apis.v1, test_namespace, "syslog-")
-        syslog2_pod = get_pod_name_that_contains(kube_apis.v1, test_namespace, "syslog2")
+        syslog_pod = get_pod_name_that_contains(
+            kube_apis.v1, test_namespace, "syslog-", get_e2e_run_selector(appprotect_setup.e2e_run_id)
+        )
+        syslog2_pod = get_pod_name_that_contains(
+            kube_apis.v1, test_namespace, "syslog2", get_e2e_run_selector(e2e_run_id)
+        )
         log_contents = ""
         log2_contents = ""
         retry = 0

--- a/tests/suite/test_app_protect_waf_bundle_source_ing.py
+++ b/tests/suite/test_app_protect_waf_bundle_source_ing.py
@@ -18,6 +18,7 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -44,10 +45,10 @@ def bundle_server(kube_apis, test_namespace) -> BundleServerSetup:
 
 
 @pytest.fixture(scope="function")
-def ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace):
+def ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, e2e_run_id):
     """Deploy a backend app and Ingress that references the WAF policy."""
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     create_items_from_yaml(kube_apis, INGRESS_SRC, test_namespace)
 
     ingress_host = get_first_ingress_host_from_yaml(INGRESS_SRC)

--- a/tests/suite/test_app_protect_waf_policies_grpc.py
+++ b/tests/suite/test_app_protect_waf_policies_grpc.py
@@ -20,6 +20,8 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_items_from_yaml,
     delete_namespace,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_file_contents,
     get_service_endpoint,
     replace_configmap_from_yaml,
@@ -64,6 +66,7 @@ def appprotect_setup(
     """
     policy_method = request.param["policy"]
     vs_or_vsr = request.param["vs_or_vsr"]
+    e2e_run_id = generate_e2e_run_id()
     vsr = None
     try:
         print("------------------------- Replace ConfigMap with HTTP2 -------------------------")
@@ -74,9 +77,11 @@ def appprotect_setup(
             cm_source,
         )
         if vs_or_vsr == "vs":
-            src_pol_name, vs_name, vs_host, vs_paths = ap_vs_setup(kube_apis, test_namespace, policy_method)
+            src_pol_name, vs_name, vs_host, vs_paths = ap_vs_setup(kube_apis, test_namespace, policy_method, e2e_run_id)
         elif vs_or_vsr == "vsr":
-            src_pol_name, vsr_ns, vs_host, vs_name, vsr = ap_vsr_setup(kube_apis, test_namespace, policy_method)
+            src_pol_name, vsr_ns, vs_host, vs_name, vsr = ap_vsr_setup(
+                kube_apis, test_namespace, policy_method, e2e_run_id
+            )
         wait_before_test(120)
     except Exception:
         cleanup(kube_apis, ingress_controller_prerequisites, src_pol_name, test_namespace, vs_or_vsr, vs_name, vsr)
@@ -93,18 +98,20 @@ def appprotect_setup(
         return VirtualServerRouteSetup(ingress_controller_endpoint, vsr_ns, vs_host, vs_name, vsr, None)
 
 
-def ap_vs_setup(kube_apis, test_namespace, policy_method) -> tuple:
-    src_pol_name, vs_name = ap_generic_setup(kube_apis, test_namespace, test_namespace, policy_method, waf_spec_vs_src)
+def ap_vs_setup(kube_apis, test_namespace, policy_method, e2e_run_id) -> tuple:
+    src_pol_name, vs_name = ap_generic_setup(
+        kube_apis, test_namespace, test_namespace, policy_method, waf_spec_vs_src, e2e_run_id
+    )
     vs_host = get_first_host_from_yaml(waf_spec_vs_src)
     vs_paths = get_paths_from_vs_yaml(waf_spec_vs_src)
     return (src_pol_name, vs_name, vs_host, vs_paths)
 
 
-def ap_vsr_setup(kube_apis, test_namespace, policy_method) -> tuple:
+def ap_vsr_setup(kube_apis, test_namespace, policy_method, e2e_run_id) -> tuple:
     print(f"------------------------- Deploy namespace ---------------------------")
     vs_routes_ns = "grpcs"
     vsr_ns = create_namespace_with_name_from_yaml(kube_apis.v1, vs_routes_ns, f"{TEST_DATA}/common/ns.yaml")
-    src_pol_name, vs_name = ap_generic_setup(kube_apis, vsr_ns, test_namespace, policy_method, vsr_vs_yaml)
+    src_pol_name, vs_name = ap_generic_setup(kube_apis, vsr_ns, test_namespace, policy_method, vsr_vs_yaml, e2e_run_id)
     vs_host = get_first_host_from_yaml(vsr_vs_yaml)
     print("------------------------- Deploy Virtual Server Route ----------------------------")
     vsr_name = create_v_s_route_from_yaml(kube_apis.custom_objects, waf_subroute_vsr_src, vsr_ns)
@@ -114,7 +121,7 @@ def ap_vsr_setup(kube_apis, test_namespace, policy_method) -> tuple:
     return (src_pol_name, vsr_ns, vs_host, vs_name, vsr)
 
 
-def ap_generic_setup(kube_apis, vs_namespace, test_namespace, policy_method, vs_yaml):
+def ap_generic_setup(kube_apis, vs_namespace, test_namespace, policy_method, vs_yaml, e2e_run_id):
     src_pol_yaml = f"{TEST_DATA}/ap-waf-grpc/policies/waf-block-{policy_method}.yaml"
     print("------------------------- Deploy logconf -----------------------------")
     global log_name
@@ -128,8 +135,8 @@ def ap_generic_setup(kube_apis, vs_namespace, test_namespace, policy_method, vs_
     wait_before_test(20)
     syslog_ep = get_service_endpoint(kube_apis, "syslog-svc", test_namespace)
     print("------------------------- Deploy App -----------------------------")
-    create_example_app(kube_apis, "grpc-vs", vs_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, vs_namespace)
+    create_example_app(kube_apis, "grpc-vs", vs_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, vs_namespace, get_e2e_run_selector(e2e_run_id))
     print("------------------------- Deploy Secret -----------------------------")
     create_secret_from_yaml(kube_apis.v1, vs_namespace, src_vs_sec_yaml)
     print(f"------------------------- Deploy policy ---------------------------")

--- a/tests/suite/test_app_protect_waf_policies_ing.py
+++ b/tests/suite/test_app_protect_waf_policies_ing.py
@@ -19,6 +19,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -42,9 +43,9 @@ def assert_waf_rejected(response):
     assert "The requested URL was rejected. Please consult with your administrator." in response.text
 
 
-def create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, ingress_src):
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+def create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, ingress_src, e2e_run_id):
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     create_items_from_yaml(kube_apis, ingress_src, test_namespace)
 
     ingress_host = get_first_ingress_host_from_yaml(ingress_src)
@@ -64,15 +65,15 @@ def cleanup_ingress_setup(kube_apis, ingress_src, test_namespace):
 
 
 @pytest.fixture(scope="function")
-def ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace):
-    setup = create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, ingress_src)
+def ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, e2e_run_id):
+    setup = create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, ingress_src, e2e_run_id)
     yield setup
     cleanup_ingress_setup(kube_apis, ingress_src, test_namespace)
 
 
 @pytest.fixture(scope="function")
-def mergeable_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace):
-    setup = create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, mergeable_ing_src)
+def mergeable_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, e2e_run_id):
+    setup = create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, mergeable_ing_src, e2e_run_id)
     yield setup
     cleanup_ingress_setup(kube_apis, mergeable_ing_src, test_namespace)
 

--- a/tests/suite/test_app_protect_wafv5_policies_ing.py
+++ b/tests/suite/test_app_protect_wafv5_policies_ing.py
@@ -9,6 +9,7 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -32,9 +33,9 @@ def assert_waf_rejected(response):
     assert "The requested URL was rejected. Please consult with your administrator." in response.text
 
 
-def create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, ingress_src):
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+def create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, ingress_src, e2e_run_id):
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     create_items_from_yaml(kube_apis, ingress_src, test_namespace)
 
     ingress_host = get_first_ingress_host_from_yaml(ingress_src)
@@ -54,15 +55,15 @@ def cleanup_ingress_setup(kube_apis, ingress_src, test_namespace):
 
 
 @pytest.fixture(scope="function")
-def ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace):
-    setup = create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, ingress_src)
+def ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, e2e_run_id):
+    setup = create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, ingress_src, e2e_run_id)
     yield setup
     cleanup_ingress_setup(kube_apis, ingress_src, test_namespace)
 
 
 @pytest.fixture(scope="function")
-def mergeable_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace):
-    setup = create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, mergeable_ing_src)
+def mergeable_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, e2e_run_id):
+    setup = create_ingress_setup(kube_apis, ingress_controller_endpoint, test_namespace, mergeable_ing_src, e2e_run_id)
     yield setup
     cleanup_ingress_setup(kube_apis, mergeable_ing_src, test_namespace)
 

--- a/tests/suite/test_app_protect_watch_namespace.py
+++ b/tests/suite/test_app_protect_watch_namespace.py
@@ -19,6 +19,8 @@ from suite.utils.resources_utils import (
     delete_namespace,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -62,15 +64,16 @@ def backend_setup(request, kube_apis, ingress_controller_endpoint) -> BackendSet
     :return: BackendSetup
     """
     policy = "file-block"
+    e2e_run_id = generate_e2e_run_id()
 
     create_namespace_with_name_from_yaml(kube_apis.v1, test_namespace, f"{TEST_DATA}/common/ns.yaml")
     print("------------------------- Deploy backend application -------------------------")
 
-    create_example_app(kube_apis, "simple", test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
     req_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
     req_url_2 = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend2"
     metrics_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/tests/suite/test_app_protect_watch_namespace_label.py
+++ b/tests/suite/test_app_protect_watch_namespace_label.py
@@ -18,6 +18,8 @@ from suite.utils.resources_utils import (
     delete_namespace,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     patch_namespace_with_label,
     retry_get_until_body_contains,
     wait_before_test,
@@ -65,15 +67,16 @@ def backend_setup(request, kube_apis, ingress_controller_endpoint) -> BackendSet
     test_namespace = f"test-namespace-{str(timestamp)}"
     policy_namespace = f"policy-test-namespace-{str(timestamp)}"
     policy = "file-block"
+    e2e_run_id = generate_e2e_run_id()
 
     create_namespace_with_name_from_yaml(kube_apis.v1, test_namespace, f"{TEST_DATA}/common/ns.yaml")
     print("------------------------- Deploy backend application -------------------------")
 
-    create_example_app(kube_apis, "simple", test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
     req_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
     req_url_2 = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend2"
     metrics_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/tests/suite/test_auth_basic_auth_mergeable.py
+++ b/tests/suite/test_auth_basic_auth_mergeable.py
@@ -12,6 +12,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     is_secret_present,
     replace_secret,
     wait_before_test,
@@ -60,14 +62,15 @@ def auth_basic_auth_setup(
     print(
         "------------------------- Deploy Auth Basic Auth Mergeable Minions Example -----------------------------------"
     )
+    e2e_run_id = generate_e2e_run_id()
     create_items_from_yaml(
         kube_apis, f"{TEST_DATA}/auth-basic-auth-mergeable/mergeable/auth-basic-auth-ingress.yaml", test_namespace
     )
     ingress_host = get_first_ingress_host_from_yaml(
         f"{TEST_DATA}/auth-basic-auth-mergeable/mergeable/auth-basic-auth-ingress.yaml"
     )
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
     )

--- a/tests/suite/test_auth_basic_secrets.py
+++ b/tests/suite/test_auth_basic_secrets.py
@@ -12,6 +12,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     is_secret_present,
     replace_secret,
     wait_before_test,
@@ -59,14 +61,15 @@ def auth_basic_secrets_setup(
     with open(f"{TEST_DATA}/auth-basic-secrets/credentials/credentials.txt") as credentials_file:
         credentials = credentials_file.read().replace("\n", "")
     print("------------------------- Deploy Auth Basic Secrets Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     create_items_from_yaml(
         kube_apis, f"{TEST_DATA}/auth-basic-secrets/{request.param}/auth-basic-secrets-ingress.yaml", test_namespace
     )
     ingress_host = get_first_ingress_host_from_yaml(
         f"{TEST_DATA}/auth-basic-secrets/{request.param}/auth-basic-secrets-ingress.yaml"
     )
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
     )

--- a/tests/suite/test_batch_reloads.py
+++ b/tests/suite/test_batch_reloads.py
@@ -26,6 +26,8 @@ from suite.utils.resources_utils import (
     delete_secret,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_last_reload_status,
     get_last_reload_time,
     get_reload_count,
@@ -77,12 +79,13 @@ def simple_ingress_setup(
     req_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
     metrics_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
 
+    e2e_run_id = generate_e2e_run_id()
     secret_name = create_secret_from_yaml(kube_apis.v1, test_namespace, f"{TEST_DATA}/smoke/smoke-secret.yaml")
-    create_example_app(kube_apis, "simple", test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
     create_items_from_yaml(kube_apis, f"{TEST_DATA}/smoke/standard/smoke-ingress.yaml", test_namespace)
 
     ingress_host = get_first_ingress_host_from_yaml(f"{TEST_DATA}/smoke/standard/smoke-ingress.yaml")
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,
@@ -167,10 +170,11 @@ def ap_ingress_setup(request, kube_apis, ingress_controller_endpoint, test_names
     :return: BackendSetup
     """
     print("------------------------- Deploy backend application -------------------------")
-    create_example_app(kube_apis, "simple", test_namespace)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
     req_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
     metrics_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/tests/suite/test_batch_startup_times.py
+++ b/tests/suite/test_batch_startup_times.py
@@ -24,6 +24,8 @@ from suite.utils.resources_utils import (
     delete_secret,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_last_reload_status,
     get_pods_amount,
     get_total_ingresses,
@@ -76,13 +78,14 @@ def simple_ingress_setup(
     """
     req_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
     metrics_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
+    e2e_run_id = generate_e2e_run_id()
 
     secret_name = create_secret_from_yaml(kube_apis.v1, test_namespace, f"{TEST_DATA}/smoke/smoke-secret.yaml")
-    create_example_app(kube_apis, "simple", test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
     create_items_from_yaml(kube_apis, f"{TEST_DATA}/smoke/standard/smoke-ingress.yaml", test_namespace)
 
     ingress_host = get_first_ingress_host_from_yaml(f"{TEST_DATA}/smoke/standard/smoke-ingress.yaml")
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,
@@ -167,10 +170,11 @@ def ap_ingress_setup(request, kube_apis, ingress_controller_endpoint, test_names
     :return: BackendSetup
     """
     print("------------------------- Deploy backend application -------------------------")
-    create_example_app(kube_apis, "simple", test_namespace)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
     req_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
     metrics_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/tests/suite/test_build_info.py
+++ b/tests/suite/test_build_info.py
@@ -5,7 +5,12 @@ import time
 import pytest
 import yaml
 from settings import HELM_CHARTS
-from suite.utils.resources_utils import get_first_pod_name, wait_before_test, wait_until_all_pods_are_ready
+from suite.utils.resources_utils import (
+    get_e2e_run_selector,
+    get_first_pod_name,
+    wait_before_test,
+    wait_until_all_pods_are_ready,
+)
 
 
 @pytest.mark.ingresses
@@ -37,8 +42,9 @@ class TestBuildVersion:
         """
         retry = 0
         ready = False
-        pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        selector = get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id)
+        pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace, selector)
+        wait_until_all_pods_are_ready(kube_apis.v1, ingress_controller_prerequisites.namespace, selector)
         while not ready:
             wait_before_test()
             try:

--- a/tests/suite/test_cache_policies_vs.py
+++ b/tests/suite/test_cache_policies_vs.py
@@ -4,7 +4,12 @@ import pytest
 import requests
 from settings import TEST_DATA
 from suite.utils.policy_resources_utils import create_policy_from_yaml, delete_policy
-from suite.utils.resources_utils import ensure_connection_to_public_endpoint, pod_restart, wait_before_test
+from suite.utils.resources_utils import (
+    ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
+    pod_restart,
+    wait_before_test,
+)
 from suite.utils.vs_vsr_resources_utils import delete_and_create_vs_from_yaml
 
 std_vs_src = f"{TEST_DATA}/virtual-server/standard/virtual-server.yaml"
@@ -119,7 +124,11 @@ class TestCachePolicies:
         )
         ns = ingress_controller_prerequisites.namespace
         # Purge all existing cache entries by removing pods
-        pod_restart(kube_apis.v1, ns)
+        pod_restart(
+            kube_apis.v1,
+            ns,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
             ingress_controller_endpoint.port,
@@ -197,7 +206,11 @@ class TestCachePolicies:
 
         ns = ingress_controller_prerequisites.namespace
         # Purge all existing cache entries by removing pods
-        pod_restart(kube_apis.v1, ns)
+        pod_restart(
+            kube_apis.v1,
+            ns,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
             ingress_controller_endpoint.port,
@@ -281,7 +294,11 @@ class TestCachePolicies:
         )
         ns = ingress_controller_prerequisites.namespace
         # Purge all existing cache entries by removing pods
-        pod_restart(kube_apis.v1, ns)
+        pod_restart(
+            kube_apis.v1,
+            ns,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
             ingress_controller_endpoint.port,

--- a/tests/suite/test_cache_policies_vsr.py
+++ b/tests/suite/test_cache_policies_vsr.py
@@ -4,7 +4,12 @@ import pytest
 import requests
 from settings import TEST_DATA
 from suite.utils.policy_resources_utils import create_policy_from_yaml, delete_policy
-from suite.utils.resources_utils import ensure_connection_to_public_endpoint, pod_restart, wait_before_test
+from suite.utils.resources_utils import (
+    ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
+    pod_restart,
+    wait_before_test,
+)
 from suite.utils.vs_vsr_resources_utils import delete_and_create_v_s_route_from_yaml, delete_and_create_vs_from_yaml
 
 std_vsr_src = f"{TEST_DATA}/virtual-server-route/route-multiple.yaml"
@@ -125,7 +130,11 @@ class TestCachePoliciesVSR:
         )
         ns = ingress_controller_prerequisites.namespace
         # Purge all existing cache entries by removing pods
-        pod_restart(kube_apis.v1, ns)
+        pod_restart(
+            kube_apis.v1,
+            ns,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
             ingress_controller_endpoint.port,
@@ -212,7 +221,11 @@ class TestCachePoliciesVSR:
         )
         ns = ingress_controller_prerequisites.namespace
         # Purge all existing cache entries by removing pods
-        pod_restart(kube_apis.v1, ns)
+        pod_restart(
+            kube_apis.v1,
+            ns,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
             ingress_controller_endpoint.port,

--- a/tests/suite/test_config_rollback_ingress.py
+++ b/tests/suite/test_config_rollback_ingress.py
@@ -19,6 +19,7 @@ from suite.utils.resources_utils import (
     delete_ingress,
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
     get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
@@ -156,11 +157,12 @@ class TestConfigRollbackIngress:
         test_namespace,
     ) -> IngressSetup:
         """Create an Ingress with a backend app for the test class."""
+        e2e_run_id = generate_e2e_run_id()
         create_items_from_yaml(kube_apis, ingress_src, test_namespace)
         ingress_name = get_name_from_yaml(ingress_src)
         ingress_host = get_first_ingress_host_from_yaml(ingress_src)
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
             ingress_controller_endpoint.port,

--- a/tests/suite/test_config_rollback_ingress.py
+++ b/tests/suite/test_config_rollback_ingress.py
@@ -19,6 +19,7 @@ from suite.utils.resources_utils import (
     delete_ingress,
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
@@ -96,7 +97,11 @@ class TestConfigRollbackIngressCreate:
         # Step 2: conf file removed — no traffic served
         assert_ingress_conf_not_exists(
             kube_apis,
-            get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace),
+            get_first_pod_name(
+                kube_apis.v1,
+                ingress_controller_prerequisites.namespace,
+                get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+            ),
             ingress_controller_prerequisites.namespace,
             test_namespace,
             ingress_name,
@@ -161,7 +166,11 @@ class TestConfigRollbackIngress:
             ingress_controller_endpoint.port,
             ingress_controller_endpoint.port_ssl,
         )
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         def fin():
             if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_config_rollback_minion.py
+++ b/tests/suite/test_config_rollback_minion.py
@@ -11,6 +11,8 @@ from suite.utils.resources_utils import (
     create_items_from_yaml,
     delete_common_app,
     delete_items_from_yaml,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
@@ -59,8 +61,9 @@ class TestConfigRollbackMinion:
         ingress_controller_endpoint,
         test_namespace,
     ):
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        e2e_run_id = generate_e2e_run_id()
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         create_items_from_yaml(
             kube_apis,
             mergeable_ingress_src,

--- a/tests/suite/test_config_rollback_minion.py
+++ b/tests/suite/test_config_rollback_minion.py
@@ -114,7 +114,11 @@ class TestConfigRollbackMinion:
         expected_nginx_error,
     ):
         """Patch a master or minion with an invalid snippet — master + minions get error events, traffic rolls back."""
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         # Step 1: both minion paths serve traffic
         wait_and_assert_status_code(

--- a/tests/suite/test_config_rollback_startup.py
+++ b/tests/suite/test_config_rollback_startup.py
@@ -23,6 +23,7 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_ingress,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
     get_default_server_conf,
     get_e2e_run_selector,
     get_events_for_object,
@@ -53,8 +54,9 @@ class TestConfigRollbackStartup:
 
     @pytest.fixture(scope="class")
     def simple_app_setup(self, request, kube_apis, test_namespace):
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        e2e_run_id = generate_e2e_run_id()
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
         def fin():
             if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_config_rollback_startup.py
+++ b/tests/suite/test_config_rollback_startup.py
@@ -24,6 +24,7 @@ from suite.utils.resources_utils import (
     delete_ingress,
     ensure_connection_to_public_endpoint,
     get_default_server_conf,
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
@@ -84,12 +85,13 @@ class TestConfigRollbackStartup:
         )
 
         print("Step 2: restart the controller pod so the startup path runs against both Ingresses")
-        old_ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace)
+        selector = get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id)
+        old_ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace, selector)
         kube_apis.v1.delete_namespaced_pod(old_ic_pod_name, ic_namespace)
         wait_before_test()
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace)
+        ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace, selector)
         assert ic_pod_name != old_ic_pod_name, "new pod did not start"
-        wait_until_all_pods_are_ready(kube_apis.v1, ic_namespace)
+        wait_until_all_pods_are_ready(kube_apis.v1, ic_namespace, selector)
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
             ingress_controller_endpoint.port,
@@ -145,12 +147,13 @@ class TestConfigRollbackStartup:
         ingress_2_name = create_ingress_from_yaml(kube_apis.networking_v1, test_namespace, ingress_2_src)
 
         print("Step 2: restart the controller pod")
-        old_ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace)
+        selector = get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id)
+        old_ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace, selector)
         kube_apis.v1.delete_namespaced_pod(old_ic_pod_name, ic_namespace)
         wait_before_test()
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace)
+        ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace, selector)
         assert ic_pod_name != old_ic_pod_name, "new pod did not start"
-        wait_until_all_pods_are_ready(kube_apis.v1, ic_namespace)
+        wait_until_all_pods_are_ready(kube_apis.v1, ic_namespace, selector)
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
             ingress_controller_endpoint.port,
@@ -203,10 +206,11 @@ class TestConfigRollbackStartup:
         )
 
         print("Step 2: restart the controller pod against the invalid Ingress")
-        old_ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace)
+        selector = get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id)
+        old_ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace, selector)
         kube_apis.v1.delete_namespaced_pod(old_ic_pod_name, ic_namespace)
         wait_before_test()
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace)
+        ic_pod_name = get_first_pod_name(kube_apis.v1, ic_namespace, selector)
         assert ic_pod_name != old_ic_pod_name
         pod = kube_apis.v1.read_namespaced_pod(ic_pod_name, ic_namespace)
 
@@ -236,7 +240,7 @@ class TestConfigRollbackStartup:
         wait_before_test()
 
         print("Step 6: pod recovers to Ready on its own; recovery log line is emitted")
-        wait_until_all_pods_are_ready(kube_apis.v1, ic_namespace)
+        wait_until_all_pods_are_ready(kube_apis.v1, ic_namespace, selector)
         recovered_pod = kube_apis.v1.read_namespaced_pod(ic_pod_name, ic_namespace)
         recovered_ready = next(
             (condition for condition in (recovered_pod.status.conditions or []) if condition.type == "Ready"),

--- a/tests/suite/test_config_rollback_ts.py
+++ b/tests/suite/test_config_rollback_ts.py
@@ -132,7 +132,11 @@ class TestConfigRollbackTSCreate:
         proxy_upload_rate (a valid stream server directive not in the TS CRD spec,
         only available via snippets) with an invalid value.
         """
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         host = ingress_controller_endpoint.public_ip
         port = getattr(ingress_controller_endpoint, traffic_port_attr)
 
@@ -263,7 +267,11 @@ class TestConfigRollbackTransportServer:
         not in the TS CRD spec, only available via snippets, and not present in the
         default template config.
         """
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         host = transport_server_setup.public_endpoint.public_ip.strip("[]")
         port = transport_server_setup.public_endpoint.tcp_server_port
 
@@ -369,7 +377,11 @@ class TestConfigRollbackTransportServer:
         - stream-log-format-escaping: unknown escape value (needs stream-log-format set too)
         All cause main config nginx -t failure → main config rollback.
         """
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         ts_host = transport_server_setup.public_endpoint.public_ip.strip("[]")
         ts_port = transport_server_setup.public_endpoint.tcp_server_port
 

--- a/tests/suite/test_config_rollback_ts.py
+++ b/tests/suite/test_config_rollback_ts.py
@@ -31,6 +31,8 @@ from suite.utils.custom_resources_utils import (
 from suite.utils.resources_utils import (
     create_items_from_yaml,
     delete_items_from_yaml,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     get_ts_nginx_template_conf,
@@ -77,11 +79,12 @@ class TestConfigRollbackTSCreate:
     @pytest.fixture(scope="class")
     def ts_create_setup(self, kube_apis, crd_ingress_controller, test_namespace):
         """Deploy GlobalConfiguration + backend apps, clean up after class."""
+        e2e_run_id = generate_e2e_run_id()
         gc_resource = create_gc_from_yaml(kube_apis.custom_objects, gc_yaml, "nginx-ingress")
-        create_items_from_yaml(kube_apis, tcp_svc_yaml, test_namespace)
+        create_items_from_yaml(kube_apis, tcp_svc_yaml, test_namespace, e2e_run_id=e2e_run_id)
         create_items_from_yaml(kube_apis, secure_app_secret_yaml, test_namespace)
-        create_items_from_yaml(kube_apis, secure_app_yaml, test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_items_from_yaml(kube_apis, secure_app_yaml, test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         yield gc_resource
         delete_items_from_yaml(kube_apis, secure_app_yaml, test_namespace)
         delete_items_from_yaml(kube_apis, secure_app_secret_yaml, test_namespace)

--- a/tests/suite/test_config_rollback_vs.py
+++ b/tests/suite/test_config_rollback_vs.py
@@ -13,6 +13,7 @@ from suite.utils.custom_assertions import (
     wait_and_assert_status_code,
 )
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     get_ts_nginx_template_conf,
@@ -85,7 +86,11 @@ class TestConfigRollbackVSCreate:
             ],
         )
         # Step 3: conf file was removed — no traffic served for this host
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         assert_vs_conf_not_exists(
             kube_apis, ic_pod, ingress_controller_prerequisites.namespace, test_namespace, vs_name
         )
@@ -172,7 +177,11 @@ class TestConfigRollbackVirtualServer:
         upstream proxy buffer fields (buffer-size alone or with incompatible buffers),
         covering nginx errors from different config directive types.
         """
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         # Step 1: valid VS serves traffic
         wait_and_assert_status_code(200, virtual_server_setup.backend_1_url, virtual_server_setup.vs_host)
         # Step 2: load VS YAML, apply invalid patch, send to cluster
@@ -264,7 +273,11 @@ class TestConfigRollbackVirtualServer:
         Note: log-format-escaping only takes effect when log-format is also set, so the
         escaping case passes both keys together.
         """
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         # Step 1: VS serves traffic, capture TS config
         wait_and_assert_status_code(200, virtual_server_setup.backend_1_url, virtual_server_setup.vs_host)
         ts_conf_before = get_ts_nginx_template_conf(
@@ -328,7 +341,11 @@ class TestConfigRollbackVirtualServer:
         """ConfigMap location-snippets invalid: consecutive VirtualServer failures trigger the
         shared-input early-exit path.
         """
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         # Step 1: create three valid VirtualServers
         wait_and_assert_status_code(200, virtual_server_setup.backend_1_url, virtual_server_setup.vs_host)

--- a/tests/suite/test_config_rollback_vsr.py
+++ b/tests/suite/test_config_rollback_vsr.py
@@ -7,6 +7,7 @@ from suite.utils.custom_assertions import (
     wait_and_assert_status_code,
 )
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_first_pod_name,
     get_vs_nginx_template_conf,
     wait_before_test,
@@ -73,7 +74,11 @@ class TestConfigRollbackVSRoute:
         expected_nginx_error,
     ):
         """Patch a VS or VSR with an invalid snippet — VS and all VSRs become Invalid, traffic rolls back."""
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_setup = v_s_route_setup
         route_m = vs_setup.route_m
         route_s = vs_setup.route_s

--- a/tests/suite/test_cors_policies_ingress.py
+++ b/tests/suite/test_cors_policies_ingress.py
@@ -9,6 +9,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -48,6 +49,7 @@ class TestCORSPoliciesIngress:
         crd_ingress_controller,
         ingress_controller_endpoint,
         test_namespace,
+        e2e_run_id,
     ):
         """
         Validate CORS policy attachment to Ingress via nginx.org/policies annotation.
@@ -56,8 +58,8 @@ class TestCORSPoliciesIngress:
         ingress_host = get_first_ingress_host_from_yaml(cors_ingress_simple_src)
         request_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}/backend1"
 
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         create_items_from_yaml(kube_apis, cors_ingress_simple_src, test_namespace)
 
         pol_name = self.setup_cors_policy(kube_apis, test_namespace, cors_pol_simple_src)
@@ -133,6 +135,7 @@ class TestCORSPoliciesIngress:
         crd_ingress_controller,
         ingress_controller_endpoint,
         test_namespace,
+        e2e_run_id,
     ):
         """
         Validate wildcard CORS policy attachment to Ingress via nginx.org/policies annotation.
@@ -141,8 +144,8 @@ class TestCORSPoliciesIngress:
         ingress_host = get_first_ingress_host_from_yaml(cors_ingress_wildcard_src)
         request_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}/backend1"
 
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         create_items_from_yaml(kube_apis, cors_ingress_wildcard_src, test_namespace)
 
         pol_name = self.setup_cors_policy(kube_apis, test_namespace, cors_pol_wildcard_src)

--- a/tests/suite/test_custom_annotations.py
+++ b/tests/suite/test_custom_annotations.py
@@ -4,6 +4,7 @@ from suite.fixtures.fixtures import PublicEndpoint
 from suite.utils.resources_utils import (
     create_items_from_yaml,
     delete_items_from_yaml,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
     replace_configmap_from_yaml,
@@ -51,7 +52,11 @@ def custom_annotations_setup(
     ingress_name = get_name_from_yaml(ing_src)
     wait_before_test(1)
 
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_custom_http_errors.py
+++ b/tests/suite/test_custom_http_errors.py
@@ -9,6 +9,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     wait_until_all_pods_are_ready,
 )
 from suite.utils.yaml_utils import get_first_ingress_host_from_yaml
@@ -46,11 +48,12 @@ def custom_http_errors_setup(
     print(
         f"------------------------- Deploy custom-http-errors example ({request.param}) -----------------------------------"
     )
+    e2e_run_id = generate_e2e_run_id()
     create_items_from_yaml(kube_apis, ingress_src, test_namespace)
     ingress_host = get_first_ingress_host_from_yaml(ingress_src)
-    create_example_app(kube_apis, "simple", test_namespace)
-    create_items_from_yaml(kube_apis, error_pages_src, test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    create_items_from_yaml(kube_apis, error_pages_src, test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/tests/suite/test_disable_ipv6.py
+++ b/tests/suite/test_disable_ipv6.py
@@ -8,6 +8,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
     get_e2e_run_selector,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
@@ -102,11 +103,12 @@ def ingress_setup(
     test_namespace,
 ) -> IngressSetup:
     print("------------------------- Deploy Disable IPV6 Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     secret_name = create_secret_from_yaml(kube_apis.v1, test_namespace, f"{TEST_DATA}/smoke/smoke-secret.yaml")
     create_items_from_yaml(kube_apis, f"{TEST_DATA}/smoke/standard/smoke-ingress.yaml", test_namespace)
     ingress_name = get_name_from_yaml(f"{TEST_DATA}/smoke/standard/smoke-ingress.yaml")
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,

--- a/tests/suite/test_disable_ipv6.py
+++ b/tests/suite/test_disable_ipv6.py
@@ -8,6 +8,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
     get_nginx_template_conf,
@@ -50,7 +51,11 @@ class TestDisableIpv6VsTs:
         transport_server_setup,
     ):
         wait_before_test()
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         nginx_config = get_nginx_template_conf(kube_apis.v1, ingress_controller_prerequisites.namespace)
         ts_config = get_ts_nginx_template_conf(
             kube_apis.v1,
@@ -108,7 +113,11 @@ def ingress_setup(
         ingress_controller_endpoint.port,
         ingress_controller_endpoint.port_ssl,
     )
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_dos.py
+++ b/tests/suite/test_dos.py
@@ -29,6 +29,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_file_contents,
     get_ingress_nginx_template_conf,
     get_nginx_template_conf,
@@ -86,6 +88,7 @@ def dos_setup(
 
     # Clean old scripts if still running
     clean_good_bad_clients()
+    e2e_run_id = generate_e2e_run_id()
 
     print(f"------------- Replace ConfigMap --------------")
     replace_configmap_from_yaml(
@@ -96,9 +99,9 @@ def dos_setup(
     )
 
     print("------------------------- Deploy Dos backend application -------------------------")
-    create_example_app(kube_apis, "dos", test_namespace)
+    create_example_app(kube_apis, "dos", test_namespace, e2e_run_id=e2e_run_id)
     req_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}/"
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/tests/suite/test_egress_mtls_ingress.py
+++ b/tests/suite/test_egress_mtls_ingress.py
@@ -11,6 +11,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
     get_reload_count,
     wait_before_test,
     wait_for_reload,
@@ -107,12 +108,12 @@ def deploy_ingress(kube_apis, ingress_controller_endpoint, test_namespace, ingre
 
 
 @pytest.fixture(scope="function")
-def backend_setup(request, kube_apis, test_namespace):
+def backend_setup(request, kube_apis, test_namespace, e2e_run_id):
     """Deploy the secure backend once per test case and clean it up afterwards."""
 
     print("------------- Deploy secure backend app --------------")
-    create_example_app(kube_apis, "secure-ca", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "secure-ca", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_empty_host_ingress.py
+++ b/tests/suite/test_empty_host_ingress.py
@@ -7,7 +7,9 @@ from suite.utils.resources_utils import (
     create_ingress_from_yaml,
     delete_common_app,
     delete_ingress,
+    generate_e2e_run_id,
     get_default_server_conf,
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
@@ -39,8 +41,9 @@ class TestEmptyHostIngressCollisionResolution:
         ingress_controller,
         test_namespace,
     ):
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        e2e_run_id = generate_e2e_run_id()
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         wait_and_assert_status_code(
             404,
             f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/",
@@ -190,8 +193,9 @@ class TestEmptyHostIngressValidation:
         ingress_controller,
         test_namespace,
     ):
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        e2e_run_id = generate_e2e_run_id()
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
         def fin():
             if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_empty_host_ingress.py
+++ b/tests/suite/test_empty_host_ingress.py
@@ -64,7 +64,11 @@ class TestEmptyHostIngressCollisionResolution:
         empty_host_apps_setup,
         test_namespace,
     ):
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}"
         health_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}"
 
@@ -237,7 +241,11 @@ class TestEmptyHostIngressValidation:
         )
         wait_before_test()
 
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         conf = get_default_server_conf(kube_apis.v1, ic_pod, ingress_controller_prerequisites.namespace)
 
         assert "backend2-svc" in conf

--- a/tests/suite/test_empty_host_ingress_mergeable.py
+++ b/tests/suite/test_empty_host_ingress_mergeable.py
@@ -39,7 +39,11 @@ class TestEmptyHostIngressMergeable:
         create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
         wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}"
         host = "anything.example.com"
 

--- a/tests/suite/test_empty_host_ingress_mergeable.py
+++ b/tests/suite/test_empty_host_ingress_mergeable.py
@@ -7,6 +7,7 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_ingress,
     get_default_server_conf,
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     wait_before_test,
@@ -33,9 +34,10 @@ class TestEmptyHostIngressMergeable:
         ingress_controller_endpoint,
         ingress_controller_prerequisites,
         test_namespace,
+        e2e_run_id,
     ):
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
         ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}"

--- a/tests/suite/test_empty_host_ingress_reload.py
+++ b/tests/suite/test_empty_host_ingress_reload.py
@@ -9,7 +9,9 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_ingress,
     delete_ingress_controller,
+    generate_e2e_run_id,
     get_default_server_conf,
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
@@ -50,8 +52,9 @@ class TestEmptyHostIngressReload:
         ingress_controller,
         test_namespace,
     ):
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        e2e_run_id = generate_e2e_run_id()
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         wait_and_assert_status_code(
             404,
             f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/",
@@ -312,8 +315,9 @@ class TestEmptyHostIngressStartupProtection:
         expect_rollback,
     ):
         print("Step 1: create the backend and an empty-host ingress that will fail during initial apply")
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        e2e_run_id = generate_e2e_run_id()
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         # This ingress exists before NIC starts. It will be accepted from the API perspective,
         # but its generated NGINX config will fail validation during initial apply.
         ingress_name = create_ingress_from_yaml(
@@ -340,6 +344,7 @@ class TestEmptyHostIngressStartupProtection:
             cli_arguments,
             ingress_controller_prerequisites.namespace,
             extra_args,
+            e2e_run_id=e2e_run_id,
         )
 
         def fin():

--- a/tests/suite/test_empty_host_ingress_reload.py
+++ b/tests/suite/test_empty_host_ingress_reload.py
@@ -76,7 +76,11 @@ class TestEmptyHostIngressReload:
         test_namespace,
         expect_rollback,
     ):
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}"
 
         print("Step 1: create a working empty-host ingress that owns _default-server.conf")
@@ -125,7 +129,11 @@ class TestEmptyHostIngressReload:
         test_namespace,
         expect_rollback,
     ):
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}"
         health_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}"
 
@@ -180,7 +188,11 @@ class TestEmptyHostIngressReload:
         test_namespace,
         expect_rollback,
     ):
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         http_request_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}"
 
         print("Step 1: create a working named-host ingress")
@@ -250,7 +262,11 @@ class TestEmptyHostIngressReload:
         test_namespace,
         expect_rollback,
     ):
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}"
 
         print("Step 1: create a working empty-host ingress")
@@ -372,7 +388,11 @@ class TestEmptyHostIngressStartupProtection:
         test_namespace,
         expect_rollback,
     ):
-        ic_pod = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}"
         health_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}"
 

--- a/tests/suite/test_external_auth_policies_ingress.py
+++ b/tests/suite/test_external_auth_policies_ingress.py
@@ -23,6 +23,7 @@ from suite.utils.policy_resources_utils import (
 from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     scale_deployment,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -312,6 +313,7 @@ class TestExternalAuthPoliciesIngress:
         test_namespace,
         ext_auth_setup,
         ext_auth_ingress,
+        e2e_run_id,
     ):
         """
         Test that the Ingress recovers after external auth backend endpoints
@@ -342,7 +344,7 @@ class TestExternalAuthPoliciesIngress:
         # Phase 3: scale back to 1 -- endpoints recover -> 200
         print("Scale external-auth deployment back to 1")
         scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "external-auth", test_namespace, 1)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         # Poll until the full auth path (backend + auth subrequest) returns 200,
         # giving NGINX time to pick up the recovered endpoints and reload.
         resp3 = None

--- a/tests/suite/test_external_auth_policies_vs.py
+++ b/tests/suite/test_external_auth_policies_vs.py
@@ -23,6 +23,7 @@ from suite.utils.policy_resources_utils import (
 from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     scale_deployment,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -287,6 +288,7 @@ class TestExternalAuthPolicies:
         test_namespace,
         ext_auth_setup,
         ext_auth_restore_vs,
+        e2e_run_id,
     ):
         """
         Test that the VirtualServer recovers after external auth backend endpoints
@@ -324,7 +326,7 @@ class TestExternalAuthPolicies:
         # Phase 3: scale back to 1 -- endpoints recover -> 200
         print("Scale external-auth deployment back to 1")
         scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "external-auth", test_namespace, 1)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
         # Poll until the full auth path (backend + auth subrequest) returns 200,
         # giving NGINX time to pick up the recovered endpoints and reload.
         resp3 = None

--- a/tests/suite/test_externalname_service.py
+++ b/tests/suite/test_externalname_service.py
@@ -13,6 +13,7 @@ from suite.utils.resources_utils import (
     delete_service,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
     replace_configmap,
@@ -86,7 +87,11 @@ def external_name_setup(
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
     )
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_hsts.py
+++ b/tests/suite/test_hsts.py
@@ -9,7 +9,9 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
     generate_ingresses_with_annotation,
+    get_e2e_run_selector,
     replace_ingress,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -47,13 +49,14 @@ def hsts_setup(
     test_namespace,
 ) -> HSTSSetup:
     print("------------------------- Deploy HSTS-Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     if request.param in ["standard-tls", "mergeable-tls"]:
         create_items_from_yaml(kube_apis, f"{TEST_DATA}/hsts/{request.param}/tls-secret.yaml", test_namespace)
     create_items_from_yaml(kube_apis, f"{TEST_DATA}/hsts/{request.param}/hsts-ingress.yaml", test_namespace)
     ingress_name = get_name_from_yaml(f"{TEST_DATA}/hsts/{request.param}/hsts-ingress.yaml")
     ingress_host = get_first_ingress_host_from_yaml(f"{TEST_DATA}/hsts/{request.param}/hsts-ingress.yaml")
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
     )

--- a/tests/suite/test_ingress_class.py
+++ b/tests/suite/test_ingress_class.py
@@ -8,6 +8,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -43,9 +45,10 @@ def backend_setup(request, kube_apis, ingress_controller_endpoint, test_namespac
     :return: BackendSetup
     """
     print("------------------------- Deploy the backend -----------------------------------")
-    create_example_app(kube_apis, "simple", test_namespace)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
     req_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}/backend1"
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/tests/suite/test_ingress_mtls_ingress.py
+++ b/tests/suite/test_ingress_mtls_ingress.py
@@ -17,6 +17,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
     retry_get_until_status_code,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -97,14 +98,15 @@ class TestIngressMTLSPoliciesIngress:
         expected_code,
         expected_text,
         exception,
+        e2e_run_id,
     ):
         """Validates that an IngressMTLS policy on a standard Ingress enforces client certificate authentication."""
 
         ingress_host = get_first_ingress_host_from_yaml(mtls_ingress_src)
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
 
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
         mtls_secret_name = ""
         tls_secret_name = ""
@@ -191,14 +193,15 @@ class TestIngressMTLSPoliciesIngress:
         crd_ingress_controller,
         ingress_controller_endpoint,
         test_namespace,
+        e2e_run_id,
     ):
         """Validates that an invalid IngressMTLS policy is rejected and results in HTTP 500."""
 
         ingress_host = get_first_ingress_host_from_yaml(mtls_ingress_src)
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
 
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
         tls_secret_name = ""
         pol_name = ""
@@ -270,14 +273,15 @@ class TestIngressMTLSPoliciesIngress:
         crd_ingress_controller,
         ingress_controller_endpoint,
         test_namespace,
+        e2e_run_id,
     ):
         """Validates that verifyDepth controls acceptance of intermediate CA certificate chains."""
 
         ingress_host = get_first_ingress_host_from_yaml(mtls_ingress_src)
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
 
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
         mtls_secret_name = ""
         tls_secret_name = ""
@@ -373,14 +377,15 @@ class TestIngressMTLSPoliciesIngress:
         crd_ingress_controller,
         ingress_controller_endpoint,
         test_namespace,
+        e2e_run_id,
     ):
         """Validates that an IngressMTLS policy referencing a non-existent secret results in HTTP 500 without invalidating the policy object."""
 
         ingress_host = get_first_ingress_host_from_yaml(mtls_ingress_src)
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
 
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
         tls_secret_name = ""
         pol_name = ""

--- a/tests/suite/test_ingress_mtls_mergeable_ingress.py
+++ b/tests/suite/test_ingress_mtls_mergeable_ingress.py
@@ -10,6 +10,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
     retry_get_until_status_code,
     wait_until_all_pods_are_ready,
 )
@@ -46,14 +47,15 @@ class TestIngressMTLSMergeableIngress:
         crd_ingress_controller,
         ingress_controller_endpoint,
         test_namespace,
+        e2e_run_id,
     ):
         """Validates that an IngressMTLS policy on a mergeable master Ingress enforces client certificate authentication across all merged paths."""
 
         ingress_host = get_first_ingress_host_from_yaml(mergeable_master_src)
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
 
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
         mtls_secret_name = ""
         tls_secret_name = ""
@@ -137,14 +139,15 @@ class TestIngressMTLSMergeableIngress:
         crd_ingress_controller,
         ingress_controller_endpoint,
         test_namespace,
+        e2e_run_id,
     ):
         """Validates that an IngressMTLS policy on a minion Ingress is rejected with HTTP 500 and must be attached to the master Ingress only."""
 
         ingress_host = get_first_ingress_host_from_yaml(mergeable_minion_src)
         request_url = f"https://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port_ssl}/backend1"
 
-        create_example_app(kube_apis, "simple", test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
         mtls_secret_name = ""
         tls_secret_name = ""

--- a/tests/suite/test_jwt_auth_mergeable.py
+++ b/tests/suite/test_jwt_auth_mergeable.py
@@ -10,6 +10,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     is_secret_present,
     replace_secret,
     wait_before_test,
@@ -42,6 +44,7 @@ class JWTAuthMergeableSetup:
 def jwt_auth_setup(
     request, kube_apis, ingress_controller_endpoint, ingress_controller, test_namespace
 ) -> JWTAuthMergeableSetup:
+    e2e_run_id = generate_e2e_run_id()
     tokens = {"master": get_token_from_file("master"), "minion": get_token_from_file("minion")}
     master_secret_name = create_secret_from_yaml(
         kube_apis.v1, test_namespace, f"{TEST_DATA}/jwt-auth-mergeable/jwt-master-secret.yaml"
@@ -52,8 +55,8 @@ def jwt_auth_setup(
     print("------------------------- Deploy JWT Auth Mergeable Minions Example -----------------------------------")
     create_items_from_yaml(kube_apis, f"{TEST_DATA}/jwt-auth-mergeable/mergeable/jwt-auth-ingress.yaml", test_namespace)
     ingress_host = get_first_ingress_host_from_yaml(f"{TEST_DATA}/jwt-auth-mergeable/mergeable/jwt-auth-ingress.yaml")
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
     )

--- a/tests/suite/test_jwt_policies_jwksuri.py
+++ b/tests/suite/test_jwt_policies_jwksuri.py
@@ -11,6 +11,8 @@ from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_common_app,
     delete_secret,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     replace_configmap_from_yaml,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -59,13 +61,14 @@ def keycloak_setup(request, kube_apis, test_namespace, ingress_controller_endpoi
 
     # Create Keycloak resources and setup Keycloak idp
 
+    e2e_run_id = generate_e2e_run_id()
     secret_name = create_secret_from_yaml(
         kube_apis.v1, test_namespace, f"{TEST_DATA}/virtual-server-tls/tls-secret.yaml"
     )
     keycloak_address = "keycloak.example.com"
-    create_example_app(kube_apis, "keycloak", test_namespace)
+    create_example_app(kube_apis, "keycloak", test_namespace, e2e_run_id=e2e_run_id)
     wait_before_test()
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     keycloak_vs_name = create_virtual_server_from_yaml(kube_apis.custom_objects, keycloak_vs_src, test_namespace)
     wait_before_test()
 

--- a/tests/suite/test_jwt_secrets.py
+++ b/tests/suite/test_jwt_secrets.py
@@ -10,6 +10,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     is_secret_present,
     replace_secret,
     wait_before_test,
@@ -53,12 +55,13 @@ def jwt_secrets_setup(
     with open(f"{TEST_DATA}/jwt-secrets/tokens/jwt-secrets-token.jwt") as token_file:
         token = token_file.read().replace("\n", "")
     print("------------------------- Deploy JWT Secrets Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     create_items_from_yaml(
         kube_apis, f"{TEST_DATA}/jwt-secrets/{request.param}/jwt-secrets-ingress.yaml", test_namespace
     )
     ingress_host = get_first_ingress_host_from_yaml(f"{TEST_DATA}/jwt-secrets/{request.param}/jwt-secrets-ingress.yaml")
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
     )

--- a/tests/suite/test_mgmt_configmap_keys.py
+++ b/tests/suite/test_mgmt_configmap_keys.py
@@ -7,6 +7,7 @@ from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     get_nginx_template_conf,
@@ -68,7 +69,11 @@ class TestMGMTConfigMap:
             ingress_controller_endpoint.port,
             ingress_controller_endpoint.port_ssl,
         )
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         metrics_url = (
             f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
         )
@@ -170,7 +175,11 @@ class TestMGMTConfigMap:
             ingress_controller_endpoint.port,
             ingress_controller_endpoint.port_ssl,
         )
-        get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         metrics_url = (
             f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
         )

--- a/tests/suite/test_multiple_ns_perf.py
+++ b/tests/suite/test_multiple_ns_perf.py
@@ -13,6 +13,8 @@ from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_ingress_controller,
     delete_namespace,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_test_file_name,
     wait_until_all_pods_are_ready,
     write_to_json,
@@ -46,11 +48,12 @@ def ingress_ns_setup(
 
     manifest = f"{TEST_DATA}/smoke/standard/smoke-ingress.yaml"
     ns_count = int(request.config.getoption("--ns-count"))
+    e2e_run_id = generate_e2e_run_id()
     multi_ns = ""
     for i in range(1, ns_count + 1):
         watched_namespace = create_namespace_with_name_from_yaml(kube_apis.v1, f"ns-{i}", f"{TEST_DATA}/common/ns.yaml")
         multi_ns = multi_ns + f"{watched_namespace},"
-        create_example_app(kube_apis, "simple", watched_namespace)
+        create_example_app(kube_apis, "simple", watched_namespace, e2e_run_id=e2e_run_id)
         create_secret_from_yaml(kube_apis.v1, watched_namespace, f"{TEST_DATA}/smoke/smoke-secret.yaml")
         with open(manifest) as f:
             doc = yaml.safe_load(f)
@@ -60,7 +63,7 @@ def ingress_ns_setup(
     global watched_namespaces
     watched_namespaces = multi_ns[:-1]
     for i in range(1, ns_count + 1):
-        wait_until_all_pods_are_ready(kube_apis.v1, f"ns-{i}")
+        wait_until_all_pods_are_ready(kube_apis.v1, f"ns-{i}", get_e2e_run_selector(e2e_run_id))
 
     def fin():
         for i in range(1, ns_count + 1):
@@ -110,11 +113,12 @@ def vs_ns_setup(
 
     manifest = f"{TEST_DATA}/virtual-server/standard/virtual-server.yaml"
     ns_count = int(request.config.getoption("--ns-count"))
+    e2e_run_id = generate_e2e_run_id()
     multi_ns = ""
     for i in range(1, ns_count + 1):
         watched_namespace = create_namespace_with_name_from_yaml(kube_apis.v1, f"ns-{i}", f"{TEST_DATA}/common/ns.yaml")
         multi_ns = multi_ns + f"{watched_namespace},"
-        create_example_app(kube_apis, "simple", watched_namespace)
+        create_example_app(kube_apis, "simple", watched_namespace, e2e_run_id=e2e_run_id)
         with open(manifest) as f:
             doc = yaml.safe_load(f)
             doc["metadata"]["name"] = f"virtual-server-{i}"
@@ -123,7 +127,7 @@ def vs_ns_setup(
     global watched_namespaces
     watched_namespaces = multi_ns[:-1]
     for i in range(1, ns_count + 1):
-        wait_until_all_pods_are_ready(kube_apis.v1, f"ns-{i}")
+        wait_until_all_pods_are_ready(kube_apis.v1, f"ns-{i}", get_e2e_run_selector(e2e_run_id))
 
     def fin():
         for i in range(1, ns_count + 1):

--- a/tests/suite/test_oidc.py
+++ b/tests/suite/test_oidc.py
@@ -15,6 +15,8 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_secret,
     delete_service,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     replace_configmap_from_yaml,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -55,6 +57,7 @@ class KeycloakSetup:
 def keycloak_setup(request, kube_apis, test_namespace, ingress_controller_endpoint, virtual_server_setup):
 
     # Create Keycloak resources and setup Keycloak idp
+    e2e_run_id = generate_e2e_run_id()
 
     vs_secret_name = create_secret_from_yaml(
         kube_apis.v1, virtual_server_setup.namespace, f"{TEST_DATA}/virtual-server-tls/tls-secret.yaml"
@@ -72,9 +75,9 @@ def keycloak_setup(request, kube_apis, test_namespace, ingress_controller_endpoi
             kube_apis.v1, test_namespace, f"{TEST_DATA}/oidc/keycloak-ca-secret.yaml"
         )
 
-    create_example_app(kube_apis, backend_app, test_namespace)
+    create_example_app(kube_apis, backend_app, test_namespace, e2e_run_id=e2e_run_id)
     wait_before_test()
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     keycloak_vs_name = create_virtual_server_from_yaml(kube_apis.custom_objects, keycloak_vs_src, test_namespace)
     wait_before_test()
 

--- a/tests/suite/test_oidc_fclo.py
+++ b/tests/suite/test_oidc_fclo.py
@@ -14,6 +14,8 @@ from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_common_app,
     delete_secret,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_pod_name_that_contains,
     replace_configmap_from_yaml,
     wait_before_test,
@@ -65,14 +67,15 @@ class KeycloakSetupForFCLO:
 def keycloak_setup(request, kube_apis, test_namespace, ingress_controller_endpoint):
 
     # Create Keycloak resources and setup Keycloak idp
+    e2e_run_id = generate_e2e_run_id()
 
     secret_name = create_secret_from_yaml(
         kube_apis.v1, test_namespace, f"{TEST_DATA}/virtual-server-tls/tls-secret.yaml"
     )
     keycloak_address = "keycloak.example.com"
-    create_example_app(kube_apis, "keycloak", test_namespace)
+    create_example_app(kube_apis, "keycloak", test_namespace, e2e_run_id=e2e_run_id)
     wait_before_test()
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     keycloak_vs_name = create_virtual_server_from_yaml(kube_apis.custom_objects, keycloak_vs_src, test_namespace)
     wait_before_test()
 

--- a/tests/suite/test_oidc_native.py
+++ b/tests/suite/test_oidc_native.py
@@ -462,7 +462,11 @@ class TestOIDCNativeTrustedCA:
             vs_patched = True
             assert_vs_status(kube_apis, test_namespace, virtual_server_setup.vs_name, "Valid")
 
-            ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+            ic_pod_name = get_first_pod_name(
+                kube_apis.v1,
+                ingress_controller_prerequisites.namespace,
+                get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+            )
             conf = get_vs_nginx_template_conf(
                 kube_apis.v1,
                 test_namespace,

--- a/tests/suite/test_oidc_native.py
+++ b/tests/suite/test_oidc_native.py
@@ -16,6 +16,8 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_secret,
     delete_service,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_vs_nginx_template_conf,
     replace_configmap_from_yaml,
@@ -61,6 +63,7 @@ class KeycloakSetup:
 def keycloak_setup(request, kube_apis, test_namespace, ingress_controller_endpoint, virtual_server_setup):
 
     # Create Keycloak resources and setup Keycloak idp
+    e2e_run_id = generate_e2e_run_id()
 
     vs_secret_name = create_secret_from_yaml(
         kube_apis.v1, virtual_server_setup.namespace, f"{TEST_DATA}/virtual-server-tls/tls-secret.yaml"
@@ -74,9 +77,9 @@ def keycloak_setup(request, kube_apis, test_namespace, ingress_controller_endpoi
         kube_apis.v1, test_namespace, f"{TEST_DATA}/oidc/keycloak-ca-secret.yaml"
     )
 
-    create_example_app(kube_apis, backend_app, test_namespace)
+    create_example_app(kube_apis, backend_app, test_namespace, e2e_run_id=e2e_run_id)
     wait_before_test()
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     keycloak_vs_name = create_virtual_server_from_yaml(kube_apis.custom_objects, keycloak_vs_src, test_namespace)
     wait_before_test()
 

--- a/tests/suite/test_oidc_native_fclo.py
+++ b/tests/suite/test_oidc_native_fclo.py
@@ -14,6 +14,8 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_items_from_yaml,
     delete_secret,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     replace_configmap_from_yaml,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -133,6 +135,7 @@ def create_native_oidc_policy(
 @pytest.fixture(scope="class")
 def keycloak_setup(request, kube_apis, test_namespace, ingress_controller_endpoint):
     """Deploy keycloak-secure and register two FCLO-enabled native OIDC clients."""
+    e2e_run_id = generate_e2e_run_id()
 
     # TLS secret shared by the webapp VirtualServers
     vs_secret_name = create_secret_from_yaml(
@@ -147,9 +150,9 @@ def keycloak_setup(request, kube_apis, test_namespace, ingress_controller_endpoi
         kube_apis.v1, test_namespace, f"{TEST_DATA}/oidc/keycloak-ca-secret.yaml"
     )
 
-    create_example_app(kube_apis, backend_app, test_namespace)
+    create_example_app(kube_apis, backend_app, test_namespace, e2e_run_id=e2e_run_id)
     wait_before_test()
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     keycloak_vs_name = create_virtual_server_from_yaml(kube_apis.custom_objects, keycloak_vs_src, test_namespace)
     wait_before_test()
 
@@ -367,6 +370,7 @@ class TestOIDCNativeFCLO:
         crd_ingress_controller,
         test_namespace,
         keycloak_setup,
+        e2e_run_id,
     ):
         """Front-channel logout across two native OIDC relying parties.
 
@@ -377,7 +381,7 @@ class TestOIDCNativeFCLO:
         5. Click logout and confirm FCLO terminated sessions on both apps.
         """
         # Deploy backend webapps (reused from NJS FCLO tests)
-        create_items_from_yaml(kube_apis, webapps_src, test_namespace)
+        create_items_from_yaml(kube_apis, webapps_src, test_namespace, e2e_run_id=e2e_run_id)
 
         secret_one_name = create_native_oidc_secret(
             kube_apis, test_namespace, keycloak_setup.secret_one, "oidc-native-secret-one"
@@ -448,6 +452,7 @@ class TestOIDCNativeFCLO:
         crd_ingress_controller,
         test_namespace,
         keycloak_setup,
+        e2e_run_id,
     ):
         """RP-initiated logout via the native OIDC logoutURI.
 
@@ -460,7 +465,7 @@ class TestOIDCNativeFCLO:
         5. Confirm the session is terminated (next access shows login form).
         """
         # Deploy backend webapps
-        create_items_from_yaml(kube_apis, webapps_src, test_namespace)
+        create_items_from_yaml(kube_apis, webapps_src, test_namespace, e2e_run_id=e2e_run_id)
 
         secret_one_name = create_native_oidc_secret(
             kube_apis, test_namespace, keycloak_setup.secret_one, "oidc-native-secret-one"

--- a/tests/suite/test_oidc_native_fclo_ingress.py
+++ b/tests/suite/test_oidc_native_fclo_ingress.py
@@ -21,6 +21,8 @@ from suite.utils.resources_utils import (
     delete_ingress,
     delete_items_from_yaml,
     delete_secret,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     replace_configmap_from_yaml,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -42,6 +44,7 @@ ingress_two_src = f"{TEST_DATA}/oidc-native-fclo/ingress/ingress-two.yaml"
 @pytest.fixture(scope="class")
 def keycloak_ingress_fclo_setup(request, kube_apis, test_namespace, ingress_controller_endpoint):
     """Deploy Keycloak via Ingress and register two FCLO-enabled native OIDC clients."""
+    e2e_run_id = generate_e2e_run_id()
     ingress_secret_name = create_secret_from_yaml(
         kube_apis.v1, test_namespace, f"{TEST_DATA}/virtual-server-tls/tls-secret.yaml"
     )
@@ -55,9 +58,9 @@ def keycloak_ingress_fclo_setup(request, kube_apis, test_namespace, ingress_cont
         kube_apis.v1, test_namespace, f"{TEST_DATA}/oidc/keycloak-ca-secret.yaml"
     )
 
-    create_example_app(kube_apis, backend_app, test_namespace)
+    create_example_app(kube_apis, backend_app, test_namespace, e2e_run_id=e2e_run_id)
     wait_before_test()
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     keycloak_ingress_name = create_ingress_from_yaml(kube_apis.networking_v1, test_namespace, keycloak_ingress_src)
     wait_before_test()
@@ -300,6 +303,7 @@ class TestOIDCNativeFCLOIngress:
         test_namespace,
         keycloak_ingress_fclo_setup,
         crd_ingress_controller,
+        e2e_run_id,
     ):
         ingress_one_name = None
         ingress_two_name = None
@@ -319,7 +323,7 @@ class TestOIDCNativeFCLOIngress:
             configmap_replaced = True
             wait_before_test()
 
-            create_items_from_yaml(kube_apis, webapps_src, test_namespace)
+            create_items_from_yaml(kube_apis, webapps_src, test_namespace, e2e_run_id=e2e_run_id)
 
             secret_one_name = create_native_oidc_secret(
                 kube_apis, test_namespace, keycloak_ingress_fclo_setup.secret_one, "oidc-native-secret-one"
@@ -389,6 +393,7 @@ class TestOIDCNativeFCLOIngress:
         test_namespace,
         keycloak_ingress_fclo_setup,
         crd_ingress_controller,
+        e2e_run_id,
     ):
         ingress_name = None
         configmap_replaced = False
@@ -404,7 +409,7 @@ class TestOIDCNativeFCLOIngress:
             configmap_replaced = True
             wait_before_test()
 
-            create_items_from_yaml(kube_apis, webapps_src, test_namespace)
+            create_items_from_yaml(kube_apis, webapps_src, test_namespace, e2e_run_id=e2e_run_id)
             secret_name = create_native_oidc_secret(
                 kube_apis, test_namespace, keycloak_ingress_fclo_setup.secret_one, "oidc-native-secret-one"
             )

--- a/tests/suite/test_oidc_native_ingress.py
+++ b/tests/suite/test_oidc_native_ingress.py
@@ -19,6 +19,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     delete_service,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     replace_configmap_from_yaml,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -86,6 +88,7 @@ def keycloak_ingress_setup(request, kube_apis, test_namespace, ingress_controlle
     """
     Sets up Keycloak IdP using purely Ingress resources (no VirtualServer).
     """
+    e2e_run_id = generate_e2e_run_id()
     ingress_secret_name = create_secret_from_yaml(
         kube_apis.v1, test_namespace, f"{TEST_DATA}/virtual-server-tls/tls-secret.yaml"
     )
@@ -99,9 +102,9 @@ def keycloak_ingress_setup(request, kube_apis, test_namespace, ingress_controlle
         kube_apis.v1, test_namespace, f"{TEST_DATA}/oidc/keycloak-ca-secret.yaml"
     )
 
-    create_example_app(kube_apis, backend_app, test_namespace)
+    create_example_app(kube_apis, backend_app, test_namespace, e2e_run_id=e2e_run_id)
     wait_before_test()
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     keycloak_ingress_name = create_ingress_from_yaml(kube_apis.networking_v1, test_namespace, keycloak_ingress_src)
     wait_before_test()
@@ -240,6 +243,7 @@ class TestOIDCNativeIngress:
         keycloak_ingress_setup,
         configmap,
         oidcYaml,
+        e2e_run_id,
     ):
         secret_name = None
         pol_name = None
@@ -263,10 +267,12 @@ class TestOIDCNativeIngress:
                 with open(svc_src) as f:
                     headless_name = yaml.safe_load(f)["metadata"]["name"]
 
-            create_items_from_yaml(kube_apis, f"{TEST_DATA}/common/backend1.yaml", test_namespace)
+            create_items_from_yaml(
+                kube_apis, f"{TEST_DATA}/common/backend1.yaml", test_namespace, e2e_run_id=e2e_run_id
+            )
             create_items_from_yaml(kube_apis, f"{TEST_DATA}/common/backend1-svc.yaml", test_namespace)
             backend_deployed = True
-            wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+            wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
             with open(oidc_native_secret_src) as f:
                 secret_data = yaml.safe_load(f)

--- a/tests/suite/test_oidc_native_scenarios.py
+++ b/tests/suite/test_oidc_native_scenarios.py
@@ -15,6 +15,7 @@ from suite.utils.resources_utils import (
     create_secret,
     delete_namespace,
     delete_secret,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_vs_nginx_template_conf,
     replace_configmap_from_yaml,
@@ -204,7 +205,11 @@ def scenario_response(endpoint, host, path="/", https=True):
 
 
 def vs_conf(kube_apis, ingress_controller_prerequisites, namespace, vs_name):
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
     return get_vs_nginx_template_conf(
         kube_apis.v1, namespace, vs_name, ic_pod_name, ingress_controller_prerequisites.namespace
     )

--- a/tests/suite/test_oidc_native_scenarios_ingress.py
+++ b/tests/suite/test_oidc_native_scenarios_ingress.py
@@ -17,6 +17,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_namespace,
     delete_secret,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
     replace_configmap_from_yaml,
@@ -198,7 +199,11 @@ def scenario_response(endpoint, host, path="/", https=True):
 
 
 def ingress_conf(kube_apis, ingress_controller_prerequisites, namespace, ingress_name):
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
     return get_ingress_nginx_template_conf(
         kube_apis.v1,
         namespace,

--- a/tests/suite/test_oidc_native_scenarios_ingress.py
+++ b/tests/suite/test_oidc_native_scenarios_ingress.py
@@ -17,6 +17,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_namespace,
     delete_secret,
+    generate_e2e_run_id,
     get_e2e_run_selector,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
@@ -216,9 +217,10 @@ def ingress_conf(kube_apis, ingress_controller_prerequisites, namespace, ingress
 @pytest.fixture(scope="class")
 def backend_setup(request, kube_apis, test_namespace):
     """Deploy backend1 once for all scenario tests."""
-    create_items_from_yaml(kube_apis, f"{TEST_DATA}/common/backend1.yaml", test_namespace)
+    e2e_run_id = generate_e2e_run_id()
+    create_items_from_yaml(kube_apis, f"{TEST_DATA}/common/backend1.yaml", test_namespace, e2e_run_id=e2e_run_id)
     create_items_from_yaml(kube_apis, f"{TEST_DATA}/common/backend1-svc.yaml", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         delete_items_from_yaml(kube_apis, f"{TEST_DATA}/common/backend1.yaml", test_namespace)

--- a/tests/suite/test_prometheus_metrics.py
+++ b/tests/suite/test_prometheus_metrics.py
@@ -19,6 +19,8 @@ from suite.utils.resources_utils import (
     ensure_connection,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -56,11 +58,12 @@ def prometheus_secret_setup(request, kube_apis, test_namespace):
 @pytest.fixture(scope="class")
 def ingress_setup(request, kube_apis, ingress_controller_endpoint, test_namespace) -> IngressSetup:
     print("------------------------- Deploy Ingress Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     secret_name = create_secret_from_yaml(kube_apis.v1, test_namespace, f"{TEST_DATA}/smoke/smoke-secret.yaml")
     create_items_from_yaml(kube_apis, f"{TEST_DATA}/smoke/standard/smoke-ingress.yaml", test_namespace)
     ingress_host = get_first_ingress_host_from_yaml(f"{TEST_DATA}/smoke/standard/smoke-ingress.yaml")
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/tests/suite/test_rewrite_target.py
+++ b/tests/suite/test_rewrite_target.py
@@ -8,6 +8,7 @@ from suite.utils.resources_utils import (
     delete_common_app,
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -42,6 +43,7 @@ def rewrite_target_setup(
     ingress_controller_endpoint,
     ingress_controller,
     test_namespace,
+    e2e_run_id,
 ) -> RewriteTargetSetup:
     print(
         "------------------------- Deploy Ingress with rewrite-target annotations -----------------------------------"
@@ -52,8 +54,8 @@ def rewrite_target_setup(
     ingress_host = get_first_ingress_host_from_yaml(src)
     request_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}/backend1"
 
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl

--- a/tests/suite/test_rewrites.py
+++ b/tests/suite/test_rewrites.py
@@ -4,6 +4,8 @@ from settings import TEST_DATA
 from suite.utils.resources_utils import (
     create_items_from_yaml,
     delete_items_from_yaml,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -19,8 +21,9 @@ hello_app_yaml = f"{TEST_DATA}/rewrites/hello.yaml"
 
 @pytest.fixture(scope="class")
 def hello_app(request, kube_apis, test_namespace):
-    create_items_from_yaml(kube_apis, hello_app_yaml, test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    e2e_run_id = generate_e2e_run_id()
+    create_items_from_yaml(kube_apis, hello_app_yaml, test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_rl_ingress.py
+++ b/tests/suite/test_rl_ingress.py
@@ -18,6 +18,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
     get_e2e_run_selector,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
@@ -72,14 +73,15 @@ def annotations_setup(
     test_namespace,
 ) -> AnnotationsSetup:
     print("------------------------- Deploy Ingress with rate-limit annotations -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     src = f"{TEST_DATA}/rate-limit/ingress/{request.param}/annotations-rl-ingress.yaml"
     create_items_from_yaml(kube_apis, src, test_namespace)
     ingress_name = get_name_from_yaml(src)
     ingress_host = get_first_ingress_host_from_yaml(src)
     request_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}/backend1"
 
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl

--- a/tests/suite/test_rl_ingress.py
+++ b/tests/suite/test_rl_ingress.py
@@ -18,6 +18,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_ingress_nginx_template_conf,
     get_pod_list,
@@ -83,7 +84,11 @@ def annotations_setup(
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
     )
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -176,7 +181,11 @@ class TestRateLimitIngressZoneSync:
         wait_before_test()
 
         print("Step 4: check if pods are ready")
-        wait_until_all_pods_are_ready(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        wait_until_all_pods_are_ready(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         print("Step 5: check plus api for zone sync")
         api_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.api_port}"
@@ -219,11 +228,19 @@ class TestRateLimitIngressScaled:
         ns = ingress_controller_prerequisites.namespace
         scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "nginx-ingress", ns, 4)
         count = 0
-        while (not are_all_pods_in_ready_state(kube_apis.v1, ns)) and count < 10:
+        while (
+            not are_all_pods_in_ready_state(
+                kube_apis.v1, ns, get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id)
+            )
+        ) and count < 10:
             count += 1
             wait_before_test()
 
-        ic_pods = get_pod_list(kube_apis.v1, ns)
+        ic_pods = get_pod_list(
+            kube_apis.v1,
+            ns,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         flag = False
         retries = 0
         while flag is False and retries < 10:
@@ -267,7 +284,11 @@ class TestRateLimitIngressScaledWithZoneSync:
         scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "nginx-ingress", ns, 2)
 
         print("Step 3: check if pods are ready")
-        wait_until_all_pods_are_ready(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        wait_until_all_pods_are_ready(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         print("Step 4: check sync in config")
         ingress_name = annotations_setup.ingress_name
@@ -282,7 +303,11 @@ class TestRateLimitIngressScaledWithZoneSync:
             f"limit_req_zone {key} zone={annotations_setup.namespace}/{ingress_name}_sync:{zone_size} rate={rate} sync;"
         )
 
-        ic_pods = get_pod_list(kube_apis.v1, ns)
+        ic_pods = get_pod_list(
+            kube_apis.v1,
+            ns,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         assert len(ic_pods) == 2, f"Expected 2 pods, but found {len(ic_pods)}"
         for i, pod in enumerate(ic_pods):
             flag = False

--- a/tests/suite/test_rl_policies.py
+++ b/tests/suite/test_rl_policies.py
@@ -19,6 +19,7 @@ from suite.utils.policy_resources_utils import (
 from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_secret,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_pod_list,
     get_vs_nginx_template_conf,
@@ -397,7 +398,11 @@ class TestRateLimitingPolicies:
             src,
         )
 
-        ic_pods = get_pod_list(kube_apis.v1, ns)
+        ic_pods = get_pod_list(
+            kube_apis.v1,
+            ns,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         for i in range(len(ic_pods)):
             conf = ""
             for attempt in range(5):
@@ -467,7 +472,11 @@ class TestRateLimitingPolicies:
         wait_before_test()
 
         print("Step 4: check if pods are ready")
-        wait_until_all_pods_are_ready(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        wait_until_all_pods_are_ready(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         print("Step 5: check plus api for zone sync")
         api_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.api_port}"
@@ -547,7 +556,11 @@ class TestRateLimitingPolicies:
         wait_before_test()
 
         print("Step 4: check if pods are ready")
-        wait_until_all_pods_are_ready(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        wait_until_all_pods_are_ready(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         print("Step 5: check plus api for zone sync")
         api_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.api_port}"
@@ -562,7 +575,11 @@ class TestRateLimitingPolicies:
         assert check_synced_zone_exists(zone_sync_url, pol_name.replace("-", "_", -1))
 
         print("Step 7: check sync in config")
-        pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,

--- a/tests/suite/test_rl_policies_vsr.py
+++ b/tests/suite/test_rl_policies_vsr.py
@@ -19,6 +19,7 @@ from suite.utils.policy_resources_utils import (
 from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_secret,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_pod_list,
     get_vs_nginx_template_conf,
@@ -445,7 +446,11 @@ class TestRateLimitingPoliciesVsr:
             src,
         )
 
-        ic_pods = get_pod_list(kube_apis.v1, ns)
+        ic_pods = get_pod_list(
+            kube_apis.v1,
+            ns,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         for i in range(len(ic_pods)):
             conf = get_vs_nginx_template_conf(
                 kube_apis.v1,
@@ -511,7 +516,11 @@ class TestRateLimitingPoliciesVsr:
         wait_before_test()
 
         print("Step 4: check if pods are ready")
-        wait_until_all_pods_are_ready(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        wait_until_all_pods_are_ready(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         print("Step 5: check plus api for zone sync")
         api_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.api_port}"
@@ -592,7 +601,11 @@ class TestRateLimitingPoliciesVsr:
         wait_before_test()
 
         print("Step 4: check if pods are ready")
-        wait_until_all_pods_are_ready(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        wait_until_all_pods_are_ready(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         print("Step 5: check plus api for zone sync")
         api_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.api_port}"
@@ -607,7 +620,11 @@ class TestRateLimitingPoliciesVsr:
         assert check_synced_zone_exists(zone_sync_url, pol_name.replace("-", "_", -1))
 
         print("Step 7: check sync in config")
-        pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vsr_config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,

--- a/tests/suite/test_smoke.py
+++ b/tests/suite/test_smoke.py
@@ -15,6 +15,8 @@ from suite.utils.resources_utils import (
     delete_secret,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_last_reload_time,
     get_pods_amount,
     get_reload_count,
@@ -47,11 +49,12 @@ class SmokeSetup:
 @pytest.fixture(scope="class", params=["standard", "mergeable", "implementation-specific-pathtype"])
 def smoke_setup(request, kube_apis, ingress_controller_endpoint, ingress_controller, test_namespace) -> SmokeSetup:
     print("------------------------- Deploy Smoke Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     secret_name = create_secret_from_yaml(kube_apis.v1, test_namespace, f"{TEST_DATA}/smoke/smoke-secret.yaml")
     create_items_from_yaml(kube_apis, f"{TEST_DATA}/smoke/{request.param}/smoke-ingress.yaml", test_namespace)
     ingress_host = get_first_ingress_host_from_yaml(f"{TEST_DATA}/smoke/{request.param}/smoke-ingress.yaml")
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/tests/suite/test_snippet_flag.py
+++ b/tests/suite/test_snippet_flag.py
@@ -6,6 +6,7 @@ from suite.utils.custom_assertions import assert_event
 from suite.utils.resources_utils import (
     create_ingress_from_yaml,
     delete_ingress,
+    get_e2e_run_selector,
     get_events,
     get_file_contents,
     get_first_pod_name,
@@ -33,7 +34,11 @@ class TestSnippetAnnotation:
         ingress_name = create_ingress_from_yaml(kube_apis.networking_v1, test_namespace, file_name)
         time.sleep(5)
         pod_namespace = ingress_controller_prerequisites.namespace
-        pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         file_path = f"/etc/nginx/conf.d/{test_namespace}-{ingress_name}.conf"
         result_conf = get_file_contents(kube_apis.v1, file_path, pod_name, pod_namespace)
         snippet_annotation = "tcp_nodelay on;"

--- a/tests/suite/test_transport_server_backup_service.py
+++ b/tests/suite/test_transport_server_backup_service.py
@@ -15,6 +15,8 @@ from suite.utils.resources_utils import (
     delete_namespace,
     ensure_connection,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_ts_nginx_template_conf,
     replace_configmap,
@@ -50,11 +52,14 @@ def ts_externalname_setup(
     request, kube_apis, ingress_controller_prerequisites, transport_server_tls_passthrough_setup, test_namespace
 ) -> ExternalNameSetup:
     print("------------------------- Deploy External-Backend -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     external_ns = create_namespace_with_name_from_yaml(kube_apis.v1, "external-ns", f"{TEST_DATA}/common/ns.yaml")
     external_svc_name = create_service_with_name(kube_apis.v1, external_ns, "external-backend-svc", 8443, 8443)
     create_secret_from_yaml(kube_apis.v1, external_ns, secure_app_secret)
     create_configmap_from_yaml(kube_apis.v1, external_ns, secure_app_config_map)
-    create_secure_app_deployment_with_name(kube_apis.apps_v1_api, external_ns, "external-backend")
+    create_secure_app_deployment_with_name(
+        kube_apis.apps_v1_api, external_ns, "external-backend", e2e_run_id=e2e_run_id
+    )
     print("------------------------- Prepare ExternalName Setup -----------------------------------")
     external_svc_src = f"{TEST_DATA}/transport-server-backup-service/backup-svc.yaml"
     external_svc_host = f"{external_svc_name}.{external_ns}.svc.cluster.local"
@@ -108,7 +113,14 @@ class TransportServerTlsSetup:
     """
 
     def __init__(
-        self, public_endpoint: PublicEndpoint, tls_passthrough_port: int, ts_resource, name, namespace, ts_host
+        self,
+        public_endpoint: PublicEndpoint,
+        tls_passthrough_port: int,
+        ts_resource,
+        name,
+        namespace,
+        ts_host,
+        e2e_run_id,
     ):
         self.public_endpoint = public_endpoint
         self.tls_passthrough_port = tls_passthrough_port
@@ -116,6 +128,7 @@ class TransportServerTlsSetup:
         self.name = name
         self.namespace = namespace
         self.ts_host = ts_host
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(scope="class")
@@ -132,17 +145,18 @@ def transport_server_tls_passthrough_setup(
     :return TransportServerTlsSetup:
     """
     print("------------------------- Deploy Transport Server with tls passthrough -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     # deploy secure_app
     secure_app_file = f"{TEST_DATA}/{request.param['example']}/standard/secure-app.yaml"
     secure_app_secret_file = f"{TEST_DATA}/{request.param['example']}/standard/secure-app-secret.yaml"
     create_items_from_yaml(kube_apis, secure_app_secret_file, test_namespace)
-    create_items_from_yaml(kube_apis, secure_app_file, test_namespace)
+    create_items_from_yaml(kube_apis, secure_app_file, test_namespace, e2e_run_id=e2e_run_id)
 
     # deploy transport server
     transport_server_std_src = f"{TEST_DATA}/{request.param['example']}/standard/transport-server.yaml"
     ts_resource = create_ts_from_yaml(kube_apis.custom_objects, transport_server_std_src, test_namespace)
     ts_host = get_first_host_from_yaml(transport_server_std_src)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -160,6 +174,7 @@ def transport_server_tls_passthrough_setup(
         ts_resource["metadata"]["name"],
         test_namespace,
         ts_host,
+        e2e_run_id,
     )
 
 
@@ -218,7 +233,10 @@ class TestTransportServerWithBackupService:
         )
 
         assert resp.status_code == 200
-        assert f"hello from pod {get_first_pod_name(kube_apis.v1, test_namespace)}" in resp.text
+        pod_name = get_first_pod_name(
+            kube_apis.v1, test_namespace, get_e2e_run_selector(transport_server_tls_passthrough_setup.e2e_run_id)
+        )
+        assert f"hello from pod {pod_name}" in resp.text
 
         result_conf = get_ts_nginx_template_conf(
             kube_apis.v1,
@@ -265,7 +283,10 @@ class TestTransportServerWithBackupService:
         )
 
         assert resp.status_code == 200
-        assert f"hello from pod {get_first_pod_name(kube_apis.v1, test_namespace)}" in resp.text
+        pod_name = get_first_pod_name(
+            kube_apis.v1, test_namespace, get_e2e_run_selector(transport_server_tls_passthrough_setup.e2e_run_id)
+        )
+        assert f"hello from pod {pod_name}" in resp.text
 
         result_conf = get_ts_nginx_template_conf(
             kube_apis.v1,

--- a/tests/suite/test_transport_server_backup_service.py
+++ b/tests/suite/test_transport_server_backup_service.py
@@ -77,7 +77,11 @@ def ts_externalname_setup(
     )
     wait_before_test(2)
     ensure_connection(req_url)
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
     ensure_response_from_backend(
         req_url,
         transport_server_tls_passthrough_setup.ts_host,

--- a/tests/suite/test_transport_server_external_name.py
+++ b/tests/suite/test_transport_server_external_name.py
@@ -7,6 +7,7 @@ from suite.utils.resources_utils import (
     create_service_from_yaml,
     delete_namespace,
     delete_service,
+    get_e2e_run_selector,
     get_events,
     get_file_contents,
     get_first_pod_name,
@@ -53,7 +54,11 @@ def ts_externalname_setup(
 
     external_svc = create_service_from_yaml(kube_apis.v1, transport_server_setup.namespace, external_svc_src)
     wait_before_test()
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_transport_server_service_insight.py
+++ b/tests/suite/test_transport_server_service_insight.py
@@ -10,6 +10,8 @@ from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_items_from_yaml,
     delete_secret,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_first_pod_name,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -30,12 +32,13 @@ class TransportServerTlsSetup:
         ts_host (str):
     """
 
-    def __init__(self, public_endpoint: PublicEndpoint, ts_resource, name, namespace, ts_host):
+    def __init__(self, public_endpoint: PublicEndpoint, ts_resource, name, namespace, ts_host, e2e_run_id):
         self.public_endpoint = public_endpoint
         self.ts_resource = ts_resource
         self.name = name
         self.namespace = namespace
         self.ts_host = ts_host
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(scope="class")
@@ -52,17 +55,18 @@ def transport_server_tls_passthrough_setup(
     :return TransportServerTlsSetup:
     """
     print("------------------------- Deploy Transport Server with tls passthrough -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     # deploy secure_app
     secure_app_file = f"{TEST_DATA}/{request.param['example']}/standard/secure-app.yaml"
     secure_app_secret_file = f"{TEST_DATA}/{request.param['example']}/standard/secure-app-secret.yaml"
     create_items_from_yaml(kube_apis, secure_app_secret_file, test_namespace)
-    create_items_from_yaml(kube_apis, secure_app_file, test_namespace)
+    create_items_from_yaml(kube_apis, secure_app_file, test_namespace, e2e_run_id=e2e_run_id)
 
     # deploy transport server
     transport_server_std_src = f"{TEST_DATA}/{request.param['example']}/standard/transport-server.yaml"
     ts_resource = create_ts_from_yaml(kube_apis.custom_objects, transport_server_std_src, test_namespace)
     ts_host = get_first_host_from_yaml(transport_server_std_src)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -79,6 +83,7 @@ def transport_server_tls_passthrough_setup(
         ts_resource["metadata"]["name"],
         test_namespace,
         ts_host,
+        e2e_run_id,
     )
 
 
@@ -124,7 +129,10 @@ class TestTransportServerTSServiceInsightHTTP:
             verify=False,
         )
         assert resp.status_code == 200
-        assert f"hello from pod {get_first_pod_name(kube_apis.v1, test_namespace)}" in resp.text
+        pod_name = get_first_pod_name(
+            kube_apis.v1, test_namespace, get_e2e_run_selector(transport_server_tls_passthrough_setup.e2e_run_id)
+        )
+        assert f"hello from pod {pod_name}" in resp.text
 
         # Service Insight test
         retry = 0

--- a/tests/suite/test_ts_tls_passthrough.py
+++ b/tests/suite/test_ts_tls_passthrough.py
@@ -7,6 +7,8 @@ from suite.utils.custom_resources_utils import create_ts_from_yaml, delete_ts, r
 from suite.utils.resources_utils import (
     create_items_from_yaml,
     delete_items_from_yaml,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_nginx_template_conf,
     replace_configmap_from_yaml,
@@ -32,7 +34,14 @@ class TransportServerTlsSetup:
     """
 
     def __init__(
-        self, public_endpoint: PublicEndpoint, tls_passthrough_port: int, ts_resource, name, namespace, ts_host
+        self,
+        public_endpoint: PublicEndpoint,
+        tls_passthrough_port: int,
+        ts_resource,
+        name,
+        namespace,
+        ts_host,
+        e2e_run_id,
     ):
         self.public_endpoint = public_endpoint
         self.tls_passthrough_port = tls_passthrough_port
@@ -40,6 +49,7 @@ class TransportServerTlsSetup:
         self.name = name
         self.namespace = namespace
         self.ts_host = ts_host
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(scope="class")
@@ -56,17 +66,18 @@ def transport_server_tls_passthrough_setup(
     :return TransportServerTlsSetup:
     """
     print("------------------------- Deploy Transport Server with tls passthrough -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     # deploy secure_app
     secure_app_file = f"{TEST_DATA}/{request.param['example']}/standard/secure-app.yaml"
     secure_app_secret_file = f"{TEST_DATA}/{request.param['example']}/standard/secure-app-secret.yaml"
     create_items_from_yaml(kube_apis, secure_app_secret_file, test_namespace)
-    create_items_from_yaml(kube_apis, secure_app_file, test_namespace)
+    create_items_from_yaml(kube_apis, secure_app_file, test_namespace, e2e_run_id=e2e_run_id)
 
     # deploy transport server
     transport_server_std_src = f"{TEST_DATA}/{request.param['example']}/standard/transport-server.yaml"
     ts_resource = create_ts_from_yaml(kube_apis.custom_objects, transport_server_std_src, test_namespace)
     ts_host = get_first_host_from_yaml(transport_server_std_src)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -84,6 +95,7 @@ def transport_server_tls_passthrough_setup(
         ts_resource["metadata"]["name"],
         test_namespace,
         ts_host,
+        e2e_run_id,
     )
 
 
@@ -154,7 +166,10 @@ class TestTransportServerTlsPassthrough:
             verify=False,
         )
         assert resp.status_code == 200
-        assert f"hello from pod {get_first_pod_name(kube_apis.v1, test_namespace)}" in resp.text
+        pod_name = get_first_pod_name(
+            kube_apis.v1, test_namespace, get_e2e_run_selector(transport_server_tls_passthrough_setup.e2e_run_id)
+        )
+        assert f"hello from pod {pod_name}" in resp.text
 
     def test_tls_passthrough_proxy_protocol_config(
         self,

--- a/tests/suite/test_udp_http_listeners_together.py
+++ b/tests/suite/test_udp_http_listeners_together.py
@@ -10,6 +10,7 @@ from suite.utils.custom_resources_utils import (
     read_ts,
 )
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_first_pod_name,
     get_ts_nginx_template_conf,
     get_vs_nginx_template_conf,
@@ -64,7 +65,11 @@ class TestUDPandHTTPListenersTogether:
         )
         wait_before_test()
 
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         ts_config = get_ts_nginx_template_conf(
             kube_apis.v1,
             transport_server_setup.namespace,

--- a/tests/suite/test_v_s_route.py
+++ b/tests/suite/test_v_s_route.py
@@ -13,6 +13,7 @@ from suite.utils.custom_assertions import (
 from suite.utils.resources_utils import (
     create_service_with_name,
     delete_service,
+    get_e2e_run_selector,
     get_events,
     get_events_for_object,
     get_first_pod_name,
@@ -77,7 +78,11 @@ class TestVirtualServerRoute:
         )
 
         req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}"
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_name = f"{v_s_route_setup.namespace}/{v_s_route_setup.vs_name}"
         vsr_1_name = f"{v_s_route_setup.namespace}/{v_s_route_setup.route_m.name}"
         vsr_2_name = f"{v_s_route_setup.route_s.namespace}/{v_s_route_setup.route_s.name}"
@@ -338,7 +343,11 @@ class TestVirtualServerRouteValidation:
     def test_vsr_without_vs(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup, test_namespace
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vsr_name = create_v_s_route_from_yaml(
             kube_apis.custom_objects, f"{TEST_DATA}/virtual-server-route/route-orphan.yaml", test_namespace
         )
@@ -369,7 +378,11 @@ class TestVirtualServerRouteValidation:
     def test_make_existing_vsr_invalid(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup, route_yaml
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         patch_v_s_route_from_yaml(
             kube_apis.custom_objects, v_s_route_setup.route_s.name, route_yaml, v_s_route_setup.route_s.namespace
         )
@@ -399,7 +412,11 @@ class TestVirtualServerRouteValidation:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config_old = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -439,7 +456,11 @@ class TestCreateInvalidVirtualServerRoute:
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup
     ):
         route_yaml = f"{TEST_DATA}/virtual-server-route/route-single-duplicate-path.yaml"
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         text = f"{v_s_route_setup.route_s.namespace}/{v_s_route_setup.route_s.name}"
         vs_event_text = f"Configuration for {v_s_route_setup.namespace}/{v_s_route_setup.vs_name} was added or updated with warning(s)"
         vsr_event_text = (
@@ -507,7 +528,11 @@ class TestVirtualServerRouteSelector:
         )
 
         req_url = f"http://{v_s_route_selector_setup.public_endpoint.public_ip}:{v_s_route_selector_setup.public_endpoint.port}"
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_name = f"{v_s_route_selector_setup.namespace}/{v_s_route_selector_setup.vs_name}"
         vsr_1_name = f"{v_s_route_selector_setup.route_m.namespace}/{v_s_route_selector_setup.route_m.name}"
         vsr_2_name = f"{v_s_route_selector_setup.route_s.namespace}/{v_s_route_selector_setup.route_s.name}"

--- a/tests/suite/test_v_s_route_advanced_routing.py
+++ b/tests/suite/test_v_s_route_advanced_routing.py
@@ -9,6 +9,8 @@ from suite.utils.resources_utils import (
     create_namespace_with_name_from_yaml,
     delete_namespace,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -51,12 +53,13 @@ class VSRAdvancedRoutingSetup:
         backends_url (str): backend url
     """
 
-    def __init__(self, namespace, vs_host, vs_name, route: VirtualServerRoute, backends_url):
+    def __init__(self, namespace, vs_host, vs_name, route: VirtualServerRoute, backends_url, e2e_run_id):
         self.namespace = namespace
         self.vs_host = vs_host
         self.vs_name = vs_name
         self.route = route
         self.backends_url = backends_url
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(scope="class")
@@ -93,8 +96,9 @@ def vsr_adv_routing_setup(
     backends_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}{vsr_paths[0]}"
 
     print("---------------------- Deploy advanced-routing app ----------------------------")
-    create_example_app(kube_apis, "advanced-routing", ns_1)
-    wait_until_all_pods_are_ready(kube_apis.v1, ns_1)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "advanced-routing", ns_1, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, ns_1, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -103,7 +107,7 @@ def vsr_adv_routing_setup(
 
     request.addfinalizer(fin)
 
-    return VSRAdvancedRoutingSetup(ns_1, vs_host, vs_name, route, backends_url)
+    return VSRAdvancedRoutingSetup(ns_1, vs_host, vs_name, route, backends_url, e2e_run_id)
 
 
 @pytest.mark.vsr

--- a/tests/suite/test_v_s_route_canned_responses.py
+++ b/tests/suite/test_v_s_route_canned_responses.py
@@ -11,6 +11,7 @@ from suite.utils.custom_assertions import (
     wait_and_assert_status_code,
 )
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -34,7 +35,11 @@ from suite.utils.vs_vsr_resources_utils import patch_v_s_route_from_yaml
 class TestVSRCannedResponses:
     def test_config(self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup):
         wait_before_test(1)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -139,7 +144,11 @@ class TestVSRCannedResponses:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config_old = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,

--- a/tests/suite/test_v_s_route_error_pages.py
+++ b/tests/suite/test_v_s_route_error_pages.py
@@ -6,6 +6,7 @@ from kubernetes.client.rest import ApiException
 from settings import TEST_DATA
 from suite.utils.custom_assertions import assert_event_starts_with_text_and_contains_errors, wait_and_assert_status_code
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -112,7 +113,11 @@ class TestVSRErrorPages:
             v_s_route_setup.route_m.namespace,
         )
         wait_before_test(2)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -130,7 +135,11 @@ class TestVSRErrorPages:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config_old = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,

--- a/tests/suite/test_v_s_route_externalname.py
+++ b/tests/suite/test_v_s_route_externalname.py
@@ -15,6 +15,7 @@ from suite.utils.resources_utils import (
     create_service_with_name,
     delete_namespace,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -154,7 +155,11 @@ class TestVSRWithExternalNameService:
     def test_template_config(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, vsr_externalname_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         initial_config = get_vs_nginx_template_conf(
             kube_apis.v1,
             vsr_externalname_setup.namespace,

--- a/tests/suite/test_v_s_route_focused_canary.py
+++ b/tests/suite/test_v_s_route_focused_canary.py
@@ -8,6 +8,8 @@ from suite.utils.resources_utils import (
     create_namespace_with_name_from_yaml,
     delete_namespace,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     wait_until_all_pods_are_ready,
 )
 from suite.utils.vs_vsr_resources_utils import create_v_s_route_from_yaml, create_virtual_server_from_yaml
@@ -59,12 +61,13 @@ class VSRAdvancedRoutingSetup:
         backends_url (str): backend url
     """
 
-    def __init__(self, namespace, vs_host, vs_name, route: VirtualServerRoute, backends_url):
+    def __init__(self, namespace, vs_host, vs_name, route: VirtualServerRoute, backends_url, e2e_run_id):
         self.namespace = namespace
         self.vs_host = vs_host
         self.vs_name = vs_name
         self.route = route
         self.backends_url = backends_url
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(scope="class")
@@ -101,8 +104,9 @@ def vsr_canary_setup(
     backends_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}{vsr_paths[0]}"
 
     print("---------------------- Deploy simple app ----------------------------")
-    create_example_app(kube_apis, "simple", ns_1)
-    wait_until_all_pods_are_ready(kube_apis.v1, ns_1)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "simple", ns_1, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, ns_1, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -111,7 +115,7 @@ def vsr_canary_setup(
 
     request.addfinalizer(fin)
 
-    return VSRAdvancedRoutingSetup(ns_1, vs_host, vs_name, route, backends_url)
+    return VSRAdvancedRoutingSetup(ns_1, vs_host, vs_name, route, backends_url, e2e_run_id)
 
 
 @pytest.mark.flaky(max_runs=3)

--- a/tests/suite/test_v_s_route_grpc.py
+++ b/tests/suite/test_v_s_route_grpc.py
@@ -22,7 +22,7 @@ from suite.utils.vs_vsr_resources_utils import patch_v_s_route_from_yaml
 
 
 @pytest.fixture(scope="function")
-def backend_setup(request, kube_apis, ingress_controller_prerequisites, test_namespace):
+def backend_setup(request, kube_apis, ingress_controller_prerequisites, test_namespace, e2e_run_id):
     """
     Replace the ConfigMap and deploy the secret.
 
@@ -42,8 +42,8 @@ def backend_setup(request, kube_apis, ingress_controller_prerequisites, test_nam
         )
         print("------------------------- Deploy App -----------------------------")
         app_name = request.param.get("app_type")
-        create_example_app(kube_apis, app_name, test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, app_name, test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     except Exception:
         print("Failed to complete setup, cleaning up..")
         replace_configmap_from_yaml(

--- a/tests/suite/test_v_s_route_grpc.py
+++ b/tests/suite/test_v_s_route_grpc.py
@@ -10,6 +10,7 @@ from suite.utils.resources_utils import (
     create_example_app,
     create_secret_from_yaml,
     delete_common_app,
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -105,7 +106,11 @@ class TestVirtualServerRouteGrpc:
     ):
         self.deploy_tls_secrets(kube_apis, v_s_route_setup)
         print("\nStep 1: assert config")
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -120,7 +125,11 @@ class TestVirtualServerRouteGrpc:
     def test_config_after_enable_tls(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, backend_setup, v_s_route_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         patch_v_s_route_from_yaml(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.name,
@@ -170,7 +179,11 @@ class TestVirtualServerRouteGrpc:
             v_s_route_setup.route_m.namespace,
         )
         wait_before_test()
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,

--- a/tests/suite/test_v_s_route_multiple_regex.py
+++ b/tests/suite/test_v_s_route_multiple_regex.py
@@ -13,6 +13,7 @@ from settings import TEST_DATA
 from suite.utils.custom_assertions import assert_event, wait_and_assert_status_code
 from suite.utils.custom_resources_utils import read_custom_resource
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -183,7 +184,11 @@ class TestVSRMultipleRegexPaths:
     ):
         """Generated nginx config should contain a location block for every routed path."""
         setup = multi_regex_vsr_setup
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             setup.namespace,

--- a/tests/suite/test_v_s_route_redirects.py
+++ b/tests/suite/test_v_s_route_redirects.py
@@ -9,6 +9,7 @@ from suite.utils.custom_assertions import (
     wait_and_assert_status_code,
 )
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -32,7 +33,11 @@ from suite.utils.vs_vsr_resources_utils import patch_v_s_route_from_yaml
 class TestVSRRedirects:
     def test_config(self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup):
         wait_before_test(1)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -104,7 +109,11 @@ class TestVSRRedirects:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config_old = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,

--- a/tests/suite/test_v_s_route_regexp_location.py
+++ b/tests/suite/test_v_s_route_regexp_location.py
@@ -5,6 +5,7 @@ from suite.utils.custom_assertions import assert_event, assert_vs_conf_not_exist
 from suite.utils.resources_utils import (
     create_example_app,
     ensure_response_from_backend,
+    generate_e2e_run_id,
     get_e2e_run_selector,
     get_events,
     get_first_pod_name,
@@ -187,10 +188,11 @@ class VSRRegexpSetup:
         vs_name (str):
     """
 
-    def __init__(self, namespace, vs_host, vs_name):
+    def __init__(self, namespace, vs_host, vs_name, e2e_run_id):
         self.namespace = namespace
         self.vs_host = vs_host
         self.vs_name = vs_name
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(scope="class")
@@ -223,10 +225,11 @@ def vsr_regexp_setup(
         )
 
     print("---------------------- Deploy simple app ----------------------------")
-    create_example_app(kube_apis, "extended", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "extended", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
-    return VSRRegexpSetup(test_namespace, vs_host, vs_name)
+    return VSRRegexpSetup(test_namespace, vs_host, vs_name, e2e_run_id)
 
 
 @pytest.mark.vsr
@@ -487,10 +490,11 @@ class VSRRegexpSetup:
         vs_name (str):
     """
 
-    def __init__(self, namespace, vs_host, vs_name):
+    def __init__(self, namespace, vs_host, vs_name, e2e_run_id):
         self.namespace = namespace
         self.vs_host = vs_host
         self.vs_name = vs_name
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(scope="class")
@@ -525,10 +529,11 @@ def vsr_selector_regexp_setup(
         )
 
     print("---------------------- Deploy simple app ----------------------------")
-    create_example_app(kube_apis, "extended", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "extended", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
-    return VSRRegexpSetup(test_namespace, vs_host, vs_name)
+    return VSRRegexpSetup(test_namespace, vs_host, vs_name, e2e_run_id)
 
 
 @pytest.mark.vsr

--- a/tests/suite/test_v_s_route_regexp_location.py
+++ b/tests/suite/test_v_s_route_regexp_location.py
@@ -5,6 +5,7 @@ from suite.utils.custom_assertions import assert_event, assert_vs_conf_not_exist
 from suite.utils.resources_utils import (
     create_example_app,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -107,7 +108,11 @@ class TestRegexpLocation:
     def test_flow_for_invalid_vs(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup, v_s_route_app_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         text_vs = f"{v_s_route_setup.namespace}/{v_s_route_setup.vs_name}"
         vs_event_text = (
             f"VirtualServer {text_vs} was rejected with error: "
@@ -135,7 +140,11 @@ class TestRegexpLocation:
     def test_flow_for_invalid_vsr(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup, v_s_route_app_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         text_vs = f"{v_s_route_setup.namespace}/{v_s_route_setup.vs_name}"
         text_vsr_s = f"{v_s_route_setup.route_m.namespace}/{v_s_route_setup.route_m.name}"
         vs_event_text = f"Configuration for {text_vs} was added or updated with warning(s)"
@@ -389,7 +398,11 @@ class TestVSRSelectorRegexpLocation:
         v_s_route_selector_setup,
         v_s_route_selector_app_setup,
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         text_vs = f"{v_s_route_selector_setup.namespace}/{v_s_route_selector_setup.vs_name}"
         vs_event_text = (
             f"VirtualServer {text_vs} was rejected with error: "
@@ -422,7 +435,11 @@ class TestVSRSelectorRegexpLocation:
         v_s_route_selector_setup,
         v_s_route_selector_app_setup,
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         text_vs = f"{v_s_route_selector_setup.namespace}/{v_s_route_selector_setup.vs_name}"
         text_vsr_s = f"{v_s_route_selector_setup.route_m.namespace}/{v_s_route_selector_setup.route_m.name}"
         vs_event_text = f"Configuration for {text_vs} was added or updated with warning(s)"

--- a/tests/suite/test_v_s_route_upstream_options.py
+++ b/tests/suite/test_v_s_route_upstream_options.py
@@ -12,6 +12,7 @@ from suite.utils.custom_assertions import (
 )
 from suite.utils.custom_resources_utils import generate_item_with_upstream_options
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -41,7 +42,11 @@ class TestVSRouteUpstreamOptions:
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup, v_s_route_app_setup
     ):
         print("Case 1: no ConfigMap keys, no options in VS")
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -186,7 +191,11 @@ class TestVSRouteUpstreamOptions:
             kube_apis.custom_objects, v_s_route_setup.route_s.name, v_s_route_setup.route_s.namespace, new_body_s
         )
         wait_before_test(1)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -281,7 +290,11 @@ class TestVSRouteUpstreamOptions:
             kube_apis.v1, config_map_name, ingress_controller_prerequisites.namespace, config_map_file
         )
         wait_before_test()
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -396,7 +409,11 @@ class TestVSRouteUpstreamOptions:
             f"{TEST_DATA}/virtual-server-route-upstream-options/configmap-with-keys.yaml",
         )
         wait_before_test()
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -512,7 +529,11 @@ class TestVSRouteUpstreamOptionsValidation:
             v_s_route_setup.route_m.namespace,
         )
         wait_before_test(2)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -530,7 +551,11 @@ class TestVSRouteUpstreamOptionsValidation:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         invalid_fields = [
             "lb-method",
             "fail-timeout",
@@ -689,7 +714,11 @@ class TestOptionsSpecificForPlus:
             kube_apis.custom_objects, v_s_route_setup.route_s.name, v_s_route_setup.route_s.namespace, new_body_s
         )
         wait_before_test(1)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -718,7 +747,11 @@ class TestOptionsSpecificForPlus:
         v_s_route_app_setup,
         options,
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         text_s = f"{v_s_route_setup.route_s.namespace}/{v_s_route_setup.route_s.name}"
         text_m = f"{v_s_route_setup.route_m.namespace}/{v_s_route_setup.route_m.name}"
         vsr_s_event_text = (
@@ -822,7 +855,11 @@ class TestOptionsSpecificForPlus:
             v_s_route_setup.route_m.namespace,
         )
         wait_before_test(2)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -840,7 +877,11 @@ class TestOptionsSpecificForPlus:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, v_s_route_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         invalid_fields = [
             "healthCheck.enable",
             "healthCheck.path",

--- a/tests/suite/test_v_s_route_upstream_tls.py
+++ b/tests/suite/test_v_s_route_upstream_tls.py
@@ -13,6 +13,7 @@ from suite.utils.resources_utils import (
     create_items_from_yaml,
     delete_items_from_yaml,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -89,7 +90,11 @@ class TestVSRouteUpstreamTls:
         v_s_route_setup,
         v_s_route_secure_app_setup,
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             v_s_route_setup.namespace,
@@ -143,7 +148,11 @@ class TestVSRouteUpstreamTls:
         v_s_route_setup,
         v_s_route_secure_app_setup,
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         initial_events_ns_m = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
         initial_events_ns_s = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
         with pytest.raises(ApiException) as exc_info:
@@ -193,7 +202,11 @@ class TestVSRouteUpstreamTls:
         v_s_route_setup,
         v_s_route_secure_app_setup,
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         text_s = f"{v_s_route_setup.route_s.namespace}/{v_s_route_setup.route_s.name}"
         text_m = f"{v_s_route_setup.route_m.namespace}/{v_s_route_setup.route_m.name}"
         text_vs = f"{v_s_route_setup.namespace}/{v_s_route_setup.vs_name}"

--- a/tests/suite/test_v_s_route_upstream_tls.py
+++ b/tests/suite/test_v_s_route_upstream_tls.py
@@ -13,6 +13,7 @@ from suite.utils.resources_utils import (
     create_items_from_yaml,
     delete_items_from_yaml,
     ensure_response_from_backend,
+    generate_e2e_run_id,
     get_e2e_run_selector,
     get_events,
     get_first_pod_name,
@@ -37,19 +38,26 @@ def v_s_route_secure_app_setup(request, kube_apis, v_s_route_setup) -> None:
     :return:
     """
     print("---------------------- Deploy a VS Route Example Application ----------------------------")
+    e2e_run_id = generate_e2e_run_id()
     create_items_from_yaml(
-        kube_apis, f"{TEST_DATA}/common/app/vsr/secure/multiple.yaml", v_s_route_setup.route_m.namespace
+        kube_apis,
+        f"{TEST_DATA}/common/app/vsr/secure/multiple.yaml",
+        v_s_route_setup.route_m.namespace,
+        e2e_run_id=e2e_run_id,
     )
 
     create_items_from_yaml(
         kube_apis, f"{TEST_DATA}/common/app/secure/app-tls-secret.yaml", v_s_route_setup.route_s.namespace
     )
     create_items_from_yaml(
-        kube_apis, f"{TEST_DATA}/common/app/vsr/secure/single.yaml", v_s_route_setup.route_s.namespace
+        kube_apis,
+        f"{TEST_DATA}/common/app/vsr/secure/single.yaml",
+        v_s_route_setup.route_s.namespace,
+        e2e_run_id=e2e_run_id,
     )
 
-    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_setup.route_m.namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_setup.route_s.namespace)
+    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_setup.route_m.namespace, get_e2e_run_selector(e2e_run_id))
+    wait_until_all_pods_are_ready(kube_apis.v1, v_s_route_setup.route_s.namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_v_s_route_weight_changes_dynamic_reload.py
+++ b/tests/suite/test_v_s_route_weight_changes_dynamic_reload.py
@@ -7,6 +7,8 @@ from suite.utils.resources_utils import (
     create_namespace_with_name_from_yaml,
     delete_namespace,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_reload_count,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -33,13 +35,14 @@ class VSRWeightChangesDynamicReloadSetup:
         backends_url (str): backend url
     """
 
-    def __init__(self, namespace, vs_host, vs_name, route: VirtualServerRoute, backends_url, metrics_url):
+    def __init__(self, namespace, vs_host, vs_name, route: VirtualServerRoute, backends_url, metrics_url, e2e_run_id):
         self.namespace = namespace
         self.vs_host = vs_host
         self.vs_name = vs_name
         self.route = route
         self.backends_url = backends_url
         self.metrics_url = metrics_url
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(scope="class")
@@ -78,8 +81,9 @@ def vsr_weight_changes_dynamic_reload_setup(
     backends_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}{vsr_paths[0]}"
 
     print("---------------------- Deploy weight changes without reload vsr app ----------------------------")
-    create_example_app(kube_apis, "weight-changes-dynamic-reload-vsr", ns_1)
-    wait_until_all_pods_are_ready(kube_apis.v1, ns_1)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "weight-changes-dynamic-reload-vsr", ns_1, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, ns_1, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -88,7 +92,7 @@ def vsr_weight_changes_dynamic_reload_setup(
 
     request.addfinalizer(fin)
 
-    return VSRWeightChangesDynamicReloadSetup(ns_1, vs_host, vs_name, route, backends_url, metrics_url)
+    return VSRWeightChangesDynamicReloadSetup(ns_1, vs_host, vs_name, route, backends_url, metrics_url, e2e_run_id)
 
 
 @pytest.mark.vsr

--- a/tests/suite/test_v_s_route_weight_changes_dynamic_reload_many_splits.py
+++ b/tests/suite/test_v_s_route_weight_changes_dynamic_reload_many_splits.py
@@ -7,6 +7,8 @@ from suite.utils.resources_utils import (
     create_namespace_with_name_from_yaml,
     delete_namespace,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     replace_configmap,
     replace_configmap_from_yaml,
     wait_before_test,
@@ -34,13 +36,14 @@ class VSRWeightChangesDynamicReloadManySplitsSetup:
         backends_url (str): backend url
     """
 
-    def __init__(self, namespace, vs_host, vs_name, route: VirtualServerRoute, backends_url, metrics_url):
+    def __init__(self, namespace, vs_host, vs_name, route: VirtualServerRoute, backends_url, metrics_url, e2e_run_id):
         self.namespace = namespace
         self.vs_host = vs_host
         self.vs_name = vs_name
         self.route = route
         self.backends_url = backends_url
         self.metrics_url = metrics_url
+        self.e2e_run_id = e2e_run_id
 
 
 @pytest.fixture(scope="class")
@@ -94,8 +97,9 @@ def vsr_weight_changes_dynamic_reload_many_splits_setup(
     )
 
     print("---------------------- Deploy weight changes dynamic reload vsr app ----------------------------")
-    create_example_app(kube_apis, "weight-changes-dynamic-reload-vsr-many-splits", ns_1)
-    wait_until_all_pods_are_ready(kube_apis.v1, ns_1)
+    e2e_run_id = generate_e2e_run_id()
+    create_example_app(kube_apis, "weight-changes-dynamic-reload-vsr-many-splits", ns_1, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, ns_1, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -110,7 +114,9 @@ def vsr_weight_changes_dynamic_reload_many_splits_setup(
 
     request.addfinalizer(fin)
 
-    return VSRWeightChangesDynamicReloadManySplitsSetup(ns_1, vs_host, vs_name, route, backends_url, metrics_url)
+    return VSRWeightChangesDynamicReloadManySplitsSetup(
+        ns_1, vs_host, vs_name, route, backends_url, metrics_url, e2e_run_id
+    )
 
 
 @pytest.mark.vsr

--- a/tests/suite/test_virtual_server.py
+++ b/tests/suite/test_virtual_server.py
@@ -5,6 +5,7 @@ from suite.utils.custom_resources_utils import create_crd_from_yaml, delete_crd
 from suite.utils.resources_utils import (
     create_service_from_yaml,
     delete_service,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_vs_nginx_template_conf,
     patch_rbac,
@@ -183,7 +184,11 @@ class TestVirtualServer:
 
         print("Step 2: verify gunzip directive is present")
 
-        pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         confFile = get_vs_nginx_template_conf(
             kube_apis.v1,

--- a/tests/suite/test_virtual_server_backup_service.py
+++ b/tests/suite/test_virtual_server_backup_service.py
@@ -9,6 +9,7 @@ from suite.utils.resources_utils import (
     delete_namespace,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_vs_nginx_template_conf,
     replace_configmap,
@@ -85,7 +86,11 @@ def vs_externalname_setup(
         virtual_server_setup.public_endpoint.port,
         virtual_server_setup.public_endpoint.port_ssl,
     )
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
     ensure_response_from_backend(virtual_server_setup.backend_1_url, virtual_server_setup.vs_host)
 
     def fin():

--- a/tests/suite/test_virtual_server_canned_responses.py
+++ b/tests/suite/test_virtual_server_canned_responses.py
@@ -11,6 +11,7 @@ from suite.utils.custom_assertions import (
     wait_and_assert_status_code,
 )
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -33,7 +34,11 @@ from suite.utils.vs_vsr_resources_utils import patch_virtual_server_from_yaml
 )
 class TestVSCannedResponse:
     def test_config(self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -130,7 +135,11 @@ class TestVSCannedResponse:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config_old = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,

--- a/tests/suite/test_virtual_server_configmap_keys.py
+++ b/tests/suite/test_virtual_server_configmap_keys.py
@@ -1,6 +1,7 @@
 import pytest
 from settings import DEPLOYMENTS, TEST_DATA
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events,
     get_events_for_object,
     get_file_contents,
@@ -202,8 +203,16 @@ class TestVirtualServerConfigMapNoTls:
         virtual_server_setup,
         clean_up,
     ):
-        ic_pods_amount = get_pods_amount(kube_apis.v1, ingress_controller_prerequisites.namespace)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pods_amount = get_pods_amount(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         initial_list = get_events(kube_apis.v1, virtual_server_setup.namespace)
 
         print("Step 1: update ConfigMap with valid keys without validation rules")
@@ -317,8 +326,16 @@ class TestVirtualServerConfigMapNoTls:
         clean_up,
     ):
         wait_before_test(1)
-        ic_pods_amount = get_pods_amount(kube_apis.v1, ingress_controller_prerequisites.namespace)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pods_amount = get_pods_amount(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         initial_list = get_events(kube_apis.v1, virtual_server_setup.namespace)
         data_file = f"{TEST_DATA}/virtual-server-configmap-keys/configmap-validation-keys.yaml"
         data_file_invalid = f"{TEST_DATA}/virtual-server-configmap-keys/configmap-validation-keys-invalid.yaml"
@@ -396,7 +413,11 @@ class TestVirtualServerConfigMapWithTls:
         virtual_server_setup,
         clean_up,
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         initial_list = get_events(kube_apis.v1, virtual_server_setup.namespace)
 
         print("Step 1: update ConfigMap with valid ssl keys")

--- a/tests/suite/test_virtual_server_custom_ip_listeners.py
+++ b/tests/suite/test_virtual_server_custom_ip_listeners.py
@@ -7,6 +7,7 @@ from suite.utils.custom_resources_utils import create_gc_from_yaml, delete_gc
 from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_secret,
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -144,7 +145,11 @@ class TestVirtualServerCustomListeners:
         wait_before_test(30)
 
         print("\nStep 3: Test generated VS configs")
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,

--- a/tests/suite/test_virtual_server_custom_listeners.py
+++ b/tests/suite/test_virtual_server_custom_listeners.py
@@ -8,6 +8,7 @@ from suite.utils.custom_resources_utils import create_gc_from_yaml, delete_gc, p
 from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_secret,
+    get_e2e_run_selector,
     get_events_for_object,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -225,7 +226,11 @@ class TestVirtualServerCustomListeners:
         wait_before_test()
 
         print("\nStep 3: Test generated VS configs")
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -426,7 +431,11 @@ class TestVirtualServerCustomListeners:
         wait_before_test()
 
         print("\nStep 4: Test generated VS configs")
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,

--- a/tests/suite/test_virtual_server_dos.py
+++ b/tests/suite/test_virtual_server_dos.py
@@ -24,6 +24,8 @@ from suite.utils.resources_utils import (
     create_example_app,
     delete_common_app,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_file_contents,
     get_vs_nginx_template_conf,
     nginx_reload,
@@ -57,14 +59,15 @@ class VirtualServerSetupDos:
 @pytest.fixture(scope="class")
 def virtual_server_setup_dos(request, kube_apis, ingress_controller_endpoint, test_namespace) -> VirtualServerSetupDos:
     print("------------------------- Deploy Virtual Server Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     vs_source = f"{TEST_DATA}/virtual-server-dos/virtual-server.yaml"
     vs_name = create_virtual_server_from_yaml(kube_apis.custom_objects, vs_source, test_namespace)
     vs_host = get_first_host_from_yaml(vs_source)
     vs_paths = get_paths_from_vs_yaml(vs_source)
     vs_paths[0] += f"good_path.html"
     if request.param["app_type"]:
-        create_example_app(kube_apis, request.param["app_type"], test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, request.param["app_type"], test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":

--- a/tests/suite/test_virtual_server_error_pages.py
+++ b/tests/suite/test_virtual_server_error_pages.py
@@ -10,6 +10,7 @@ from suite.utils.custom_assertions import (
     wait_and_assert_status_code,
 )
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -100,7 +101,11 @@ class TestVSErrorPages:
             kube_apis.custom_objects, virtual_server_setup.vs_name, vs_file, virtual_server_setup.namespace
         )
         wait_before_test(2)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_events = get_events(kube_apis.v1, virtual_server_setup.namespace)
 
         assert_event_starts_with_text_and_contains_errors(vs_event_text, vs_events, invalid_fields)
@@ -115,7 +120,11 @@ class TestVSErrorPages:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config_old = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,

--- a/tests/suite/test_virtual_server_external_name.py
+++ b/tests/suite/test_virtual_server_external_name.py
@@ -15,6 +15,7 @@ from suite.utils.resources_utils import (
     delete_namespace,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -65,7 +66,11 @@ def vs_externalname_setup(
         virtual_server_setup.public_endpoint.port,
         virtual_server_setup.public_endpoint.port_ssl,
     )
-    ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ic_pod_name = get_first_pod_name(
+        kube_apis.v1,
+        ingress_controller_prerequisites.namespace,
+        get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+    )
     ensure_response_from_backend(virtual_server_setup.backend_1_url, virtual_server_setup.vs_host)
 
     def fin():

--- a/tests/suite/test_virtual_server_externaldns.py
+++ b/tests/suite/test_virtual_server_externaldns.py
@@ -6,7 +6,6 @@ from suite.utils.resources_utils import (
     get_events,
     patch_namespace_with_label,
     wait_before_test,
-    wait_until_all_pods_are_ready,
 )
 from suite.utils.vs_vsr_resources_utils import patch_virtual_server_from_yaml
 from suite.utils.yaml_utils import get_name_from_yaml, get_namespace_from_yaml
@@ -44,7 +43,6 @@ class TestExternalDNSVirtualServer:
         assert dep is True
         print("\nStep 2: Verify external-dns picked up the record")
         pod_ns = get_namespace_from_yaml(f"{TEST_DATA}/virtual-server-external-dns/external-dns.yaml")
-        wait_until_all_pods_are_ready(kube_apis.v1, pod_ns)
         pod_name = kube_apis.v1.list_namespaced_pod(pod_ns).items[0].metadata.name
         log_contents = kube_apis.v1.read_namespaced_pod_log(pod_name, pod_ns)
         wanted_string = "CREATE: virtual-server.example.com 0 IN A"
@@ -146,7 +144,6 @@ class TestExternalDNSVirtualServerWatchLabel:
         assert dep is True
         print("\nStep 2: Verify external-dns picked up the record")
         pod_ns = get_namespace_from_yaml(f"{TEST_DATA}/virtual-server-external-dns/external-dns.yaml")
-        wait_until_all_pods_are_ready(kube_apis.v1, pod_ns)
         pod_name = kube_apis.v1.list_namespaced_pod(pod_ns).items[0].metadata.name
         log_contents = kube_apis.v1.read_namespaced_pod_log(pod_name, pod_ns)
         wanted_string = "CREATE: virtual-server.example.com 0 IN A"

--- a/tests/suite/test_virtual_server_foreign_upstream.py
+++ b/tests/suite/test_virtual_server_foreign_upstream.py
@@ -262,7 +262,11 @@ class TestVirtualServerForeignUpstream:
         crd_ingress_controller,
         virtual_server_foreign_upstream_app_setup,
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         upstream_name = f"upstream vs_{virtual_server_foreign_upstream_app_setup.namespace}_{virtual_server_foreign_upstream_app_setup.vs_name}_backend2"
         original_server_count = 1
         scaled_server_count = 3
@@ -353,7 +357,11 @@ class TestVirtualServerForeignUpstream:
         crd_ingress_controller,
         virtual_server_foreign_upstream_app_setup,
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_source = f"{TEST_DATA}/virtual-server-foreign-upstream/standard/virtual-server-vsr.yaml"
         original_server_count = 1
         scaled_server_count = 3

--- a/tests/suite/test_virtual_server_foreign_upstream.py
+++ b/tests/suite/test_virtual_server_foreign_upstream.py
@@ -10,6 +10,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_namespace,
     extract_block,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_vs_nginx_template_conf,
     scale_deployment,
@@ -51,6 +53,7 @@ def virtual_server_foreign_upstream_app_setup(
     :return: VirtualServerSetup
     """
     vs_source = f"{TEST_DATA}/{request.param['example']}/standard/virtual-server.yaml"
+    e2e_run_id = generate_e2e_run_id()
     upstream_namespaces = get_upstream_namespace_from_vs_yaml(vs_source, test_namespace)
     print(f"Upstream namespaces detected in the VS yaml: {upstream_namespaces}")
     ns_1 = (
@@ -64,11 +67,15 @@ def virtual_server_foreign_upstream_app_setup(
         else test_namespace
     )
     print("------------------------- Deploy Virtual Server Example -----------------------------------")
-    create_items_from_yaml(kube_apis, f"{TEST_DATA}/common/app/{request.param['app_type']}/backend1.yaml", ns_1)
-    create_items_from_yaml(kube_apis, f"{TEST_DATA}/common/app/{request.param['app_type']}/backend2.yaml", ns_2)
+    create_items_from_yaml(
+        kube_apis, f"{TEST_DATA}/common/app/{request.param['app_type']}/backend1.yaml", ns_1, e2e_run_id=e2e_run_id
+    )
+    create_items_from_yaml(
+        kube_apis, f"{TEST_DATA}/common/app/{request.param['app_type']}/backend2.yaml", ns_2, e2e_run_id=e2e_run_id
+    )
 
-    wait_until_all_pods_are_ready(kube_apis.v1, ns_1)
-    wait_until_all_pods_are_ready(kube_apis.v1, ns_2)
+    wait_until_all_pods_are_ready(kube_apis.v1, ns_1, get_e2e_run_selector(e2e_run_id))
+    wait_until_all_pods_are_ready(kube_apis.v1, ns_2, get_e2e_run_selector(e2e_run_id))
 
     vs_name = create_virtual_server_from_yaml(kube_apis.custom_objects, vs_source, test_namespace)
     vs_host = get_first_host_from_yaml(vs_source)

--- a/tests/suite/test_virtual_server_grpc.py
+++ b/tests/suite/test_virtual_server_grpc.py
@@ -15,6 +15,7 @@ from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_common_app,
     delete_items_from_yaml,
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -106,7 +107,11 @@ class TestVirtualServerGrpc:
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, backend_setup, virtual_server_setup
     ):
         print("\nStep 1: assert config")
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -191,7 +196,11 @@ class TestVirtualServerGrpc:
                 print(e.details())
                 pytest.fail("RPC error was not expected during call, exiting...")
         # Assert grpc_status is in the logs. The gRPC response in a successful call is 0.
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         log_contents = kube_apis.v1.read_namespaced_pod_log(ic_pod_name, ingress_controller_prerequisites.namespace)
         retry = 0
         while '"POST /helloworld.Greeter/SayHello HTTP/2.0" 200 0' not in log_contents and retry <= 60:
@@ -215,7 +224,11 @@ class TestVirtualServerGrpc:
             except grpc.RpcError as e:
                 print(e)
         # Assert the grpc_status is also in the logs.
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         wait_before_test()
         # Need to get full log because of a race condition on the last log entry.
         log_contents = kube_apis.v1.read_namespaced_pod_log(ic_pod_name, ingress_controller_prerequisites.namespace)
@@ -248,7 +261,11 @@ class TestVirtualServerGrpc:
     def test_config_after_enable_tls(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, backend_setup, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         patch_virtual_server_from_yaml(
             kube_apis.custom_objects,
             virtual_server_setup.vs_name,
@@ -280,7 +297,11 @@ class TestVirtualServerGrpcHealthCheck:
     def test_config_after_enable_healthcheck(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, backend_setup, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         patch_virtual_server_from_yaml(
             kube_apis.custom_objects,
             virtual_server_setup.vs_name,
@@ -322,7 +343,11 @@ class TestVirtualServerGrpcHealthCheck:
             virtual_server_setup.namespace,
         )
         wait_before_test(2)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_events = get_events(kube_apis.v1, virtual_server_setup.namespace)
         assert_event_starts_with_text_and_contains_errors(vs_event_text, vs_events, invalid_fields)
         assert_vs_conf_not_exists(
@@ -337,7 +362,11 @@ class TestVirtualServerGrpcHealthCheck:
     def test_grpc_healthcheck_send_hello(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, backend_setup, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         patch_virtual_server_from_yaml(
             kube_apis.custom_objects,
             virtual_server_setup.vs_name,

--- a/tests/suite/test_virtual_server_grpc.py
+++ b/tests/suite/test_virtual_server_grpc.py
@@ -29,7 +29,7 @@ from suite.utils.vs_vsr_resources_utils import patch_virtual_server_from_yaml
 
 
 @pytest.fixture(scope="function")
-def backend_setup(request, kube_apis, ingress_controller_prerequisites, test_namespace):
+def backend_setup(request, kube_apis, ingress_controller_prerequisites, test_namespace, e2e_run_id):
     """
     Replace the ConfigMap and deploy the secret.
 
@@ -52,8 +52,8 @@ def backend_setup(request, kube_apis, ingress_controller_prerequisites, test_nam
         create_secret_from_yaml(kube_apis.v1, test_namespace, src_sec_yaml)
         print("------------------------- Deploy App -----------------------------")
         app_name = request.param.get("app_type")
-        create_example_app(kube_apis, app_name, test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, app_name, test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     except Exception:
         print("Failed to complete setup, cleaning up..")
         delete_items_from_yaml(kube_apis, src_sec_yaml, test_namespace)

--- a/tests/suite/test_virtual_server_mixed_grpc.py
+++ b/tests/suite/test_virtual_server_mixed_grpc.py
@@ -23,7 +23,7 @@ from suite.utils.ssl_utils import get_certificate
 
 
 @pytest.fixture(scope="function")
-def backend_setup(request, kube_apis, ingress_controller_prerequisites, test_namespace):
+def backend_setup(request, kube_apis, ingress_controller_prerequisites, test_namespace, e2e_run_id):
     """
     Replace the ConfigMap and deploy the secret.
 
@@ -46,8 +46,8 @@ def backend_setup(request, kube_apis, ingress_controller_prerequisites, test_nam
         create_secret_from_yaml(kube_apis.v1, test_namespace, src_sec_yaml)
         print("------------------------- Deploy App -----------------------------")
         app_name = request.param.get("app_type")
-        create_example_app(kube_apis, app_name, test_namespace)
-        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+        create_example_app(kube_apis, app_name, test_namespace, e2e_run_id=e2e_run_id)
+        wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
     except Exception:
         print("Failed to complete setup, cleaning up..")
         delete_items_from_yaml(kube_apis, src_sec_yaml, test_namespace)

--- a/tests/suite/test_virtual_server_mixed_grpc.py
+++ b/tests/suite/test_virtual_server_mixed_grpc.py
@@ -13,6 +13,7 @@ from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_common_app,
     delete_items_from_yaml,
+    get_e2e_run_selector,
     get_first_pod_name,
     get_vs_nginx_template_conf,
     replace_configmap_from_yaml,
@@ -89,7 +90,11 @@ class TestVirtualServerMixedUpstreamType:
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, backend_setup, virtual_server_setup
     ):
         print("\nStep 1: assert config")
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,

--- a/tests/suite/test_virtual_server_redirects.py
+++ b/tests/suite/test_virtual_server_redirects.py
@@ -9,6 +9,7 @@ from suite.utils.custom_assertions import (
     wait_and_assert_status_code,
 )
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -31,7 +32,11 @@ from suite.utils.vs_vsr_resources_utils import patch_virtual_server_from_yaml
 )
 class TestVSRedirects:
     def test_config(self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -104,7 +109,11 @@ class TestVSRedirects:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config_old = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,

--- a/tests/suite/test_virtual_server_tls_redirect.py
+++ b/tests/suite/test_virtual_server_tls_redirect.py
@@ -2,7 +2,12 @@ import pytest
 import requests
 from kubernetes.client.rest import ApiException
 from settings import TEST_DATA
-from suite.utils.resources_utils import get_first_pod_name, get_vs_nginx_template_conf, wait_before_test
+from suite.utils.resources_utils import (
+    get_e2e_run_selector,
+    get_first_pod_name,
+    get_vs_nginx_template_conf,
+    wait_before_test,
+)
 from suite.utils.vs_vsr_resources_utils import patch_virtual_server_from_yaml
 
 
@@ -30,7 +35,11 @@ class TestVirtualServerTLSRedirect:
         )
         wait_before_test(1)
 
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -74,7 +83,11 @@ class TestVirtualServerTLSRedirect:
         )
         wait_before_test(1)
 
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -150,7 +163,11 @@ class TestVirtualServerTLSRedirect:
         )
         wait_before_test(1)
 
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -192,7 +209,11 @@ class TestVirtualServerTLSRedirect:
         )
         wait_before_test(1)
 
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -261,7 +282,11 @@ class TestVirtualServerTLSRedirect:
     def test_tls_redirect_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config_old = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,

--- a/tests/suite/test_virtual_server_upstream_options.py
+++ b/tests/suite/test_virtual_server_upstream_options.py
@@ -12,6 +12,7 @@ from suite.utils.custom_assertions import (
 )
 from suite.utils.custom_resources_utils import generate_item_with_upstream_options
 from suite.utils.resources_utils import (
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -41,7 +42,11 @@ class TestVirtualServerUpstreamOptions:
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
         print("Case 1: no ConfigMap key, no options in VS")
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -209,7 +214,11 @@ class TestVirtualServerUpstreamOptions:
             kube_apis.custom_objects, virtual_server_setup.vs_name, virtual_server_setup.namespace, new_body
         )
         wait_before_test(1)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -289,7 +298,11 @@ class TestVirtualServerUpstreamOptions:
             kube_apis.v1, config_map_name, ingress_controller_prerequisites.namespace, config_map_file
         )
         wait_before_test(1)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -390,7 +403,11 @@ class TestVirtualServerUpstreamOptions:
             f"{TEST_DATA}/virtual-server-upstream-options/configmap-with-keys.yaml",
         )
         wait_before_test(1)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -473,7 +490,11 @@ class TestVirtualServerUpstreamOptionValidation:
             kube_apis.custom_objects, virtual_server_setup.vs_name, vs_file, virtual_server_setup.namespace
         )
         wait_before_test(2)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_events = get_events(kube_apis.v1, virtual_server_setup.namespace)
 
         assert_event_starts_with_text_and_contains_errors(vs_event_text, vs_events, invalid_fields)
@@ -488,7 +509,11 @@ class TestVirtualServerUpstreamOptionValidation:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         invalid_fields = [
             "lb-method",
             "fail-timeout",
@@ -642,7 +667,11 @@ class TestOptionsSpecificForPlus:
             kube_apis.custom_objects, virtual_server_setup.vs_name, virtual_server_setup.namespace, new_body
         )
         wait_before_test(1)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -663,7 +692,11 @@ class TestOptionsSpecificForPlus:
     def test_slow_start_warning(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup, options
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         text = f"{virtual_server_setup.namespace}/{virtual_server_setup.vs_name}"
         vs_event_text = f"Configuration for {text} was added or updated ; with warning(s): Slow start will be disabled"
         print(f"Case 0: verify a warning")
@@ -733,7 +766,11 @@ class TestOptionsSpecificForPlus:
             kube_apis.custom_objects, virtual_server_setup.vs_name, vs_file, virtual_server_setup.namespace
         )
         wait_before_test(2)
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         vs_events = get_events(kube_apis.v1, virtual_server_setup.namespace)
 
         assert_event_starts_with_text_and_contains_errors(vs_event_text, vs_events, invalid_fields)
@@ -748,7 +785,11 @@ class TestOptionsSpecificForPlus:
     def test_openapi_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         invalid_fields = [
             "healthCheck.enable",
             "healthCheck.path",

--- a/tests/suite/test_virtual_server_upstream_tls.py
+++ b/tests/suite/test_virtual_server_upstream_tls.py
@@ -11,6 +11,7 @@ from suite.utils.custom_assertions import (
 )
 from suite.utils.resources_utils import (
     ensure_response_from_backend,
+    get_e2e_run_selector,
     get_events,
     get_first_pod_name,
     get_vs_nginx_template_conf,
@@ -35,7 +36,11 @@ class TestVirtualServerUpstreamTls:
     def test_responses_and_config_after_setup(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         config = get_vs_nginx_template_conf(
             kube_apis.v1,
             virtual_server_setup.namespace,
@@ -65,7 +70,11 @@ class TestVirtualServerUpstreamTls:
     def test_validation_flow(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         initial_events_vs = get_events(kube_apis.v1, virtual_server_setup.namespace)
         with pytest.raises(ApiException) as exc_info:
             patch_virtual_server_from_yaml(
@@ -100,7 +109,11 @@ class TestVirtualServerUpstreamTls:
     def test_responses_and_config_after_disable_tls(
         self, kube_apis, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
         text = f"{virtual_server_setup.namespace}/{virtual_server_setup.vs_name}"
         vs_event_text = f"Configuration for {text} was added or updated"
         initial_events_vs = get_events(kube_apis.v1, virtual_server_setup.namespace)

--- a/tests/suite/test_virtual_server_use_cluster_ip_reloads.py
+++ b/tests/suite/test_virtual_server_use_cluster_ip_reloads.py
@@ -1,5 +1,5 @@
 import pytest
-from suite.utils.resources_utils import get_reload_count, scale_deployment, wait_until_all_pods_are_ready
+from suite.utils.resources_utils import get_reload_count, scale_deployment
 
 from tests.suite.utils.custom_assertions import assert_pods_scaled_to_count
 
@@ -27,7 +27,6 @@ class TestVSUseClusterIP:
     def test_use_cluster_ip_reloads(
         self, kube_apis, ingress_controller_endpoint, crd_ingress_controller, virtual_server_setup
     ):
-        wait_until_all_pods_are_ready(kube_apis.v1, virtual_server_setup.namespace)
         print("Step 1: get initial reload count")
         initial_reload_count = get_reload_count(virtual_server_setup.metrics_url)
 

--- a/tests/suite/test_virtual_server_validation.py
+++ b/tests/suite/test_virtual_server_validation.py
@@ -1,7 +1,7 @@
 import pytest
 from settings import TEST_DATA
 from suite.utils.custom_assertions import assert_vs_conf_exists, assert_vs_conf_not_exists, wait_and_assert_status_code
-from suite.utils.resources_utils import get_events, get_first_pod_name, wait_before_test
+from suite.utils.resources_utils import get_e2e_run_selector, get_events, get_first_pod_name, wait_before_test
 from suite.utils.vs_vsr_resources_utils import (
     create_virtual_server_from_yaml,
     delete_virtual_server,
@@ -50,7 +50,11 @@ class TestVirtualServerValidation:
     def test_virtual_server_behavior(
         self, kube_apis, cli_arguments, ingress_controller_prerequisites, crd_ingress_controller, virtual_server_setup
     ):
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        ic_pod_name = get_first_pod_name(
+            kube_apis.v1,
+            ingress_controller_prerequisites.namespace,
+            get_e2e_run_selector(ingress_controller_prerequisites.e2e_run_id),
+        )
 
         print("Step 1: initial check")
         assert_vs_conf_exists(

--- a/tests/suite/test_watch_namespace.py
+++ b/tests/suite/test_watch_namespace.py
@@ -10,6 +10,8 @@ from suite.utils.resources_utils import (
     delete_namespace,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -40,6 +42,7 @@ def backend_setup(request, kube_apis, ingress_controller_endpoint) -> BackendSet
     :param ingress_controller_endpoint: public endpoint
     :return: BackendSetup
     """
+    e2e_run_id = generate_e2e_run_id()
     watched_namespace = create_namespace_with_name_from_yaml(kube_apis.v1, f"watched-ns", f"{TEST_DATA}/common/ns.yaml")
     foreign_namespace = create_namespace_with_name_from_yaml(kube_apis.v1, f"foreign-ns", f"{TEST_DATA}/common/ns.yaml")
     watched_namespace2 = create_namespace_with_name_from_yaml(
@@ -49,13 +52,13 @@ def backend_setup(request, kube_apis, ingress_controller_endpoint) -> BackendSet
     ingress_hosts = {}
     for ns in [watched_namespace, foreign_namespace, watched_namespace2]:
         print(f"------------------------- Deploy the backend in {ns} -----------------------------------")
-        create_example_app(kube_apis, "simple", ns)
+        create_example_app(kube_apis, "simple", ns, e2e_run_id=e2e_run_id)
         src_ing_yaml = f"{TEST_DATA}/watch-namespace/{ns}-ingress.yaml"
         create_items_from_yaml(kube_apis, src_ing_yaml, ns)
         ingress_host = get_first_ingress_host_from_yaml(src_ing_yaml)
         ingress_hosts[f"{ns}-ingress"] = ingress_host
         req_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}/backend1"
-        wait_until_all_pods_are_ready(kube_apis.v1, ns)
+        wait_until_all_pods_are_ready(kube_apis.v1, ns, get_e2e_run_selector(e2e_run_id))
         ensure_connection_to_public_endpoint(
             ingress_controller_endpoint.public_ip,
             ingress_controller_endpoint.port,

--- a/tests/suite/test_watch_namespace_label.py
+++ b/tests/suite/test_watch_namespace_label.py
@@ -7,6 +7,8 @@ from suite.utils.resources_utils import (
     delete_namespace,
     ensure_connection_to_public_endpoint,
     ensure_response_from_backend,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     patch_namespace_with_label,
     retry_get_until_status_code,
     wait_until_all_pods_are_ready,
@@ -41,8 +43,9 @@ def backend_setup(request, kube_apis, ingress_controller_endpoint) -> BackendSet
     """
     resource_hosts = {}
     namespaces = []
+    e2e_run_id = generate_e2e_run_id()
     for ns in ["watched-ns", "foreign-ns", "watched-ns2"]:
-        namespace, ingress_host = create_and_setup_namespace(kube_apis, ingress_controller_endpoint, ns)
+        namespace, ingress_host = create_and_setup_namespace(kube_apis, ingress_controller_endpoint, ns, e2e_run_id)
         resource_hosts[f"{ns}-ingress"] = ingress_host
         namespaces.append(namespace)
 
@@ -74,8 +77,11 @@ def backend_setup_vs(request, kube_apis, ingress_controller_endpoint) -> Backend
     """
     resource_hosts = {}
     namespaces = []
+    e2e_run_id = generate_e2e_run_id()
     for ns in ["watched-ns", "foreign-ns", "watched-ns2"]:
-        namespace, vs_host = create_and_setup_namespace(kube_apis, ingress_controller_endpoint, ns, is_vs=True)
+        namespace, vs_host = create_and_setup_namespace(
+            kube_apis, ingress_controller_endpoint, ns, e2e_run_id, is_vs=True
+        )
         resource_hosts[f"{ns}-vs"] = vs_host
         namespaces.append(namespace)
 
@@ -95,10 +101,10 @@ def backend_setup_vs(request, kube_apis, ingress_controller_endpoint) -> Backend
     return BackendSetup(req_url, resource_hosts)
 
 
-def create_and_setup_namespace(kube_apis, ingress_controller_endpoint, ns_name, is_vs=False):
+def create_and_setup_namespace(kube_apis, ingress_controller_endpoint, ns_name, e2e_run_id, is_vs=False):
     ns = create_namespace_with_name_from_yaml(kube_apis.v1, ns_name, f"{TEST_DATA}/common/ns.yaml")
     print(f"------------------------- Deploy the backend in {ns} -----------------------------------")
-    create_example_app(kube_apis, "simple", ns)
+    create_example_app(kube_apis, "simple", ns, e2e_run_id=e2e_run_id)
     src_ing_yaml = f"{TEST_DATA}/watch-namespace/{ns}-ingress.yaml"
     src_vs_yaml = f"{TEST_DATA}/watch-namespace/{ns}-virtual-server.yaml"
     if not is_vs:
@@ -108,7 +114,7 @@ def create_and_setup_namespace(kube_apis, ingress_controller_endpoint, ns_name, 
         create_virtual_server_from_yaml(kube_apis.custom_objects, src_vs_yaml, ns)
         ingress_host = get_first_host_from_yaml(src_vs_yaml)
     req_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}/backend1"
-    wait_until_all_pods_are_ready(kube_apis.v1, ns)
+    wait_until_all_pods_are_ready(kube_apis.v1, ns, get_e2e_run_selector(e2e_run_id))
     ensure_connection_to_public_endpoint(
         ingress_controller_endpoint.public_ip,
         ingress_controller_endpoint.port,

--- a/tests/suite/test_wildcard_tls_secret.py
+++ b/tests/suite/test_wildcard_tls_secret.py
@@ -12,6 +12,8 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_connection_to_public_endpoint,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     is_secret_present,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -56,12 +58,13 @@ def wildcard_tls_secret_setup(
 ) -> WildcardTLSSecretSetup:
     ing_type = request.param
     print("------------------------- Deploy Wildcard-Tls-Secret-Example -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     create_items_from_yaml(
         kube_apis, f"{TEST_DATA}/wildcard-tls-secret/{ing_type}/wildcard-secret-ingress.yaml", test_namespace
     )
     host = get_first_ingress_host_from_yaml(f"{TEST_DATA}/wildcard-tls-secret/{ing_type}/wildcard-secret-ingress.yaml")
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id=e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     def fin():
         if request.config.getoption("--skip-fixture-teardown") == "no":
@@ -91,11 +94,14 @@ def wildcard_tls_secret_ingress_controller(
     """
     namespace = ingress_controller_prerequisites.namespace
     print("------------------------- Create IC and wildcard secret -----------------------------------")
+    e2e_run_id = generate_e2e_run_id()
     secret_name = create_secret_from_yaml(
         kube_apis.v1, namespace, f"{TEST_DATA}/wildcard-tls-secret/wildcard-tls-secret.yaml"
     )
     extra_args = [f"-wildcard-tls-secret={namespace}/{secret_name}", "-enable-custom-resources=false"]
-    name = create_ingress_controller(kube_apis.v1, kube_apis.apps_v1_api, cli_arguments, namespace, extra_args)
+    name = create_ingress_controller(
+        kube_apis.v1, kube_apis.apps_v1_api, cli_arguments, namespace, extra_args, e2e_run_id=e2e_run_id
+    )
     ensure_connection_to_public_endpoint(
         wildcard_tls_secret_setup.public_endpoint.public_ip,
         wildcard_tls_secret_setup.public_endpoint.port,

--- a/tests/suite/utils/bundle_source_utils.py
+++ b/tests/suite/utils/bundle_source_utils.py
@@ -17,6 +17,8 @@ from suite.utils.resources_utils import (
     create_secret_from_yaml,
     delete_items_from_yaml,
     delete_secret,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     wait_before_test,
     wait_until_all_pods_are_ready,
 )
@@ -60,7 +62,7 @@ def create_bundle_server_secrets(v1: CoreV1Api, namespace: str) -> None:
         create_secret_from_yaml(v1, namespace, yaml_path)
 
 
-def deploy_bundle_server(kube_apis, namespace: str) -> None:
+def deploy_bundle_server(kube_apis, namespace: str, e2e_run_id: str) -> None:
     """Deploy the HTTPS bundle server and copy the WAF bundle into it.
 
     Applies bundle-server.yaml (ConfigMap + Deployment + Services), waits
@@ -68,14 +70,16 @@ def deploy_bundle_server(kube_apis, namespace: str) -> None:
 
     :param kube_apis: KubeApis fixture object
     :param namespace: target namespace
+    :param e2e_run_id: run ID applied to the bundle server workload
     """
     print("Deploy bundle server")
-    create_items_from_yaml(kube_apis, BUNDLE_SERVER_YAML, namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, namespace)
-    _copy_bundle_to_pod(kube_apis.v1, namespace)
+    create_items_from_yaml(kube_apis, BUNDLE_SERVER_YAML, namespace, e2e_run_id)
+    selector = get_e2e_run_selector(e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, namespace, selector)
+    _copy_bundle_to_pod(kube_apis.v1, namespace, selector)
 
 
-def _copy_bundle_to_pod(v1: CoreV1Api, namespace: str) -> None:
+def _copy_bundle_to_pod(v1: CoreV1Api, namespace: str, selector: str) -> None:
     """Copy the pre-compiled WAF bundle into the bundle-server pod.
 
     Uses kubectl cp which handles buffering and EOF signaling reliably,
@@ -85,7 +89,7 @@ def _copy_bundle_to_pod(v1: CoreV1Api, namespace: str) -> None:
     if not os.path.exists(WAF_BUNDLE_PATH):
         raise FileNotFoundError(f"WAF bundle not found: {WAF_BUNDLE_PATH}")
 
-    pod_name = _get_bundle_server_pod(v1, namespace)
+    pod_name = _get_bundle_server_pod(v1, namespace, selector)
     dest_path = "/www/bundles/wafv5.tgz"
     print(f"Copy WAF bundle to bundle-server pod {pod_name}")
 
@@ -100,9 +104,9 @@ def _copy_bundle_to_pod(v1: CoreV1Api, namespace: str) -> None:
     print("WAF bundle copied to bundle-server pod")
 
 
-def _get_bundle_server_pod(v1: CoreV1Api, namespace: str) -> str:
+def _get_bundle_server_pod(v1: CoreV1Api, namespace: str, selector: str) -> str:
     """Return the name of the bundle-server pod."""
-    pods = v1.list_namespaced_pod(namespace, label_selector="app=bundle-server")
+    pods = v1.list_namespaced_pod(namespace, label_selector=f"app=bundle-server,{selector}")
     if not pods.items:
         raise RuntimeError(f"No bundle-server pod found in namespace {namespace}")
     return pods.items[0].metadata.name
@@ -255,8 +259,9 @@ def setup_bundle_server(kube_apis, namespace: str) -> BundleServerSetup:
     :param namespace: target namespace
     :return: BundleServerSetup with URLs and secret names
     """
+    e2e_run_id = generate_e2e_run_id()
     create_bundle_server_secrets(kube_apis.v1, namespace)
-    deploy_bundle_server(kube_apis, namespace)
+    deploy_bundle_server(kube_apis, namespace, e2e_run_id)
     # Allow time for service endpoints to fully propagate (especially mTLS on port 443).
     wait_before_test(5)
 

--- a/tests/suite/utils/custom_assertions.py
+++ b/tests/suite/utils/custom_assertions.py
@@ -305,7 +305,9 @@ def assert_proxy_entries_exist(config) -> None:
     assert "proxy_next_upstream_tries 0;" in config
 
 
-def assert_pods_scaled_to_count(apps_v1_api, v1, deployment_name, namespace, expected_count, timeout=60, interval=1):
+def assert_pods_scaled_to_count(
+    apps_v1_api, v1, deployment_name, namespace, expected_count, timeout=60, interval=1, label_selector=None
+):
     """
     Check if the number of pods for a given deployment has scaled down to the expected count.
 
@@ -327,6 +329,8 @@ def assert_pods_scaled_to_count(apps_v1_api, v1, deployment_name, namespace, exp
                 ).spec.selector.match_labels.items()
             ]
         )
+        if label_selector:
+            selector = f"{selector},{label_selector}"
         pods = v1.list_namespaced_pod(namespace, label_selector=selector)
         pod_count = len(pods.items)
         if pod_count == expected_count:

--- a/tests/suite/utils/external_auth_utils.py
+++ b/tests/suite/utils/external_auth_utils.py
@@ -14,6 +14,8 @@ from suite.utils.resources_utils import (
     create_items_from_yaml,
     delete_common_app,
     delete_items_from_yaml,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
     get_reload_count,
     wait_for_reload,
     wait_until_all_pods_are_ready,
@@ -89,14 +91,15 @@ def create_ingress_setup(
     ingress_controller_prerequisites,
     test_namespace,
     ingress_src,
+    e2e_run_id,
 ):
     """Deploy the backend app and create the Ingress, returning an IngressSetup."""
-    create_example_app(kube_apis, "simple", test_namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace)
+    create_example_app(kube_apis, "simple", test_namespace, e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, test_namespace, get_e2e_run_selector(e2e_run_id))
 
     metrics_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
     count_before = get_reload_count(metrics_url)
-    create_items_from_yaml(kube_apis, ingress_src, test_namespace)
+    create_items_from_yaml(kube_apis, ingress_src, test_namespace, e2e_run_id)
 
     ingress_host = get_first_ingress_host_from_yaml(ingress_src)
     request_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}/backend1"
@@ -177,6 +180,7 @@ def setup_ext_auth(
     policy_yamls,
     vs_host,
     *,
+    e2e_run_id=None,
     tls=False,
     validate_policies=True,
 ):
@@ -188,12 +192,14 @@ def setup_ext_auth(
         credentials: Path to credentials file, or None for no-auth requests.
         policy_yamls: List of policy YAML file paths (1 or more).
         vs_host: The VirtualServer/VSR host header value.
+        e2e_run_id: Run ID applied to the external auth backend workload.
         tls: If True, deploy TLS backend with server TLS and CA secrets.
         validate_policies: If True, wait for each policy to reach Valid state.
 
     Returns:
         (secret_names: list[str], policy_names: list[str], headers: dict)
     """
+    e2e_run_id = e2e_run_id or generate_e2e_run_id()
     if tls:
         secret_yamls = [
             ext_auth_backend_secret_src,
@@ -211,6 +217,7 @@ def setup_ext_auth(
         secret_yamls=secret_yamls,
         backend_yaml=backend_yaml,
         policy_yamls=policy_yamls,
+        e2e_run_id=e2e_run_id,
         validate_policies=validate_policies,
         wait_for_service="external-auth-svc",
     )
@@ -243,7 +250,7 @@ def teardown_ext_auth(kube_apis, namespace, secret_names, policy_names, *, tls=F
 
 
 @pytest.fixture
-def ext_auth_setup(request, kube_apis, test_namespace):
+def ext_auth_setup(request, kube_apis, test_namespace, e2e_run_id):
     """Parametrized fixture that deploys the external auth backend and policies.
 
     ``request.param`` is a tuple: ``(policy_yamls[, tls[, validate_policies]])``.
@@ -278,6 +285,7 @@ def ext_auth_setup(request, kube_apis, test_namespace):
         secret_yamls=secret_yamls,
         backend_yaml=backend_yaml,
         policy_yamls=policy_yamls,
+        e2e_run_id=e2e_run_id,
         validate_policies=validate_policies,
         wait_for_service="external-auth-svc",
     )
@@ -299,6 +307,7 @@ def ext_auth_ingress(
     ingress_controller_endpoint,
     ingress_controller_prerequisites,
     test_namespace,
+    e2e_run_id,
 ):
     """Parametrized fixture that creates an Ingress with guaranteed teardown.
 
@@ -316,6 +325,7 @@ def ext_auth_ingress(
         ingress_controller_prerequisites,
         test_namespace,
         request.param,
+        e2e_run_id,
     )
 
     def fin():

--- a/tests/suite/utils/policy_resources_utils.py
+++ b/tests/suite/utils/policy_resources_utils.py
@@ -12,6 +12,7 @@ from suite.utils.resources_utils import (
     delete_items_from_yaml,
     delete_secret,
     ensure_item_removal,
+    get_e2e_run_selector,
     get_service_endpoint,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -90,7 +91,15 @@ def apply_and_wait_for_valid_policy(kube_apis, namespace, policy_yaml, retry_cou
 
 
 def setup_policy_backend(
-    kube_apis, namespace, *, secret_yamls, backend_yaml, policy_yamls, validate_policies=True, wait_for_service=None
+    kube_apis,
+    namespace,
+    *,
+    secret_yamls,
+    backend_yaml,
+    policy_yamls,
+    e2e_run_id,
+    validate_policies=True,
+    wait_for_service=None,
 ):
     """Deploy a backend with secrets and create policies.
 
@@ -103,6 +112,7 @@ def setup_policy_backend(
         secret_yamls: List of YAML file paths for secrets to create.
         backend_yaml: YAML file path for backend deployment (ConfigMap + Deployment + Service).
         policy_yamls: List of YAML file paths for policies to create.
+        e2e_run_id: Run ID applied to the backend workload and used for readiness checks.
         validate_policies: If True (default), wait for each policy to reach Valid state.
             Set to False for tests that expect the policy to be Invalid/Rejected.
         wait_for_service: If set, wait for this service name's endpoints to be registered
@@ -119,8 +129,8 @@ def setup_policy_backend(
         secret_names.append(name)
 
     print(f"Deploy backend from {backend_yaml}")
-    create_items_from_yaml(kube_apis, backend_yaml, namespace)
-    wait_until_all_pods_are_ready(kube_apis.v1, namespace)
+    create_items_from_yaml(kube_apis, backend_yaml, namespace, e2e_run_id)
+    wait_until_all_pods_are_ready(kube_apis.v1, namespace, get_e2e_run_selector(e2e_run_id))
 
     if wait_for_service:
         print(f"Waiting for endpoints of service '{wait_for_service}' to be ready...")

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -337,7 +337,7 @@ class PodNotReadyException(Exception):
         super().__init__(self.message)
 
 
-def wait_until_all_pods_are_ready(v1: CoreV1Api, namespace, label_selector=None, timeout=600) -> None:
+def wait_until_all_pods_are_ready(v1: CoreV1Api, namespace, label_selector, timeout=600) -> None:
     """
     Wait for all the pods to be 'Ready'.
 
@@ -384,7 +384,7 @@ def get_first_pod_name(v1: CoreV1Api, namespace, label_selector=None) -> str:
     return resp.items[0].metadata.name
 
 
-def are_all_pods_in_ready_state(v1: CoreV1Api, namespace, label_selector=None) -> bool:
+def are_all_pods_in_ready_state(v1: CoreV1Api, namespace, label_selector) -> bool:
     """
     Check if all the pods have Ready condition.
 

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -268,6 +268,9 @@ def scale_deployment(v1: CoreV1Api, apps_v1_api: AppsV1Api, name, namespace, val
     :param value: int
     :return: original: int the original amount of replicas
     """
+    deployment = apps_v1_api.read_namespaced_deployment(name, namespace)
+    e2e_run_id = deployment.spec.template.metadata.labels[E2E_RUN_ID_LABEL]
+    selector = get_e2e_run_selector(e2e_run_id)
     body = apps_v1_api.read_namespaced_deployment_scale(name, namespace)
     original = body.spec.replicas
     print(f"Original number of replicas is {original}")
@@ -276,7 +279,7 @@ def scale_deployment(v1: CoreV1Api, apps_v1_api: AppsV1Api, name, namespace, val
     apps_v1_api.patch_namespaced_deployment_scale(name, namespace, body)
     if value != 0:
         now = time.time()
-        wait_until_all_pods_are_ready(v1, namespace)
+        wait_until_all_pods_are_ready(v1, namespace, selector)
         later = time.time()
         print(f"All pods came up in {int(later - now)} seconds")
 

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -334,27 +334,31 @@ class PodNotReadyException(Exception):
         super().__init__(self.message)
 
 
-def wait_until_all_pods_are_ready(v1: CoreV1Api, namespace, timeout=600) -> None:
+def wait_until_all_pods_are_ready(v1: CoreV1Api, namespace, label_selector=None, timeout=600) -> None:
     """
     Wait for all the pods to be 'Ready'.
 
     :param v1: CoreV1Api
     :param namespace: namespace of a pod
+    :param label_selector: Kubernetes label selector for pods required by the test
     :param timeout: maximum seconds to wait before raising (default 600)
     :return:
     """
-    print("Start waiting for all pods in a namespace to be Ready")
+    print(f"Start waiting for pods matching '{label_selector}' in namespace '{namespace}' to be Ready")
     counter = 0
-    while not are_all_pods_in_ready_state(v1, namespace):
+    while not are_all_pods_in_ready_state(v1, namespace, label_selector):
         print("There are pods that are not Ready. Wait ...")
         wait_before_test()
         counter = counter + 1
         if counter * 3 >= timeout:
-            raise Exception(f"Timed out after {timeout}s waiting for all pods in namespace '{namespace}' to be Ready")
+            raise Exception(
+                f"Timed out after {timeout}s waiting for pods matching '{label_selector}' "
+                f"in namespace '{namespace}' to be Ready"
+            )
     print("All pods are Ready")
 
 
-def get_pod_list(v1: CoreV1Api, namespace) -> []:
+def get_pod_list(v1: CoreV1Api, namespace, label_selector=None) -> []:
     """
     Get a list of pods in a namespace.
 
@@ -362,10 +366,10 @@ def get_pod_list(v1: CoreV1Api, namespace) -> []:
     :param namespace: namespace
     :return: []
     """
-    return v1.list_namespaced_pod(namespace).items
+    return v1.list_namespaced_pod(namespace, label_selector=label_selector).items
 
 
-def get_first_pod_name(v1: CoreV1Api, namespace) -> str:
+def get_first_pod_name(v1: CoreV1Api, namespace, label_selector=None) -> str:
     """
     Return 1st pod_name in a list of pods in a namespace.
 
@@ -373,23 +377,25 @@ def get_first_pod_name(v1: CoreV1Api, namespace) -> str:
     :param namespace:
     :return: str
     """
-    resp = v1.list_namespaced_pod(namespace)
+    resp = v1.list_namespaced_pod(namespace, label_selector=label_selector)
     return resp.items[0].metadata.name
 
 
-def are_all_pods_in_ready_state(v1: CoreV1Api, namespace) -> bool:
+def are_all_pods_in_ready_state(v1: CoreV1Api, namespace, label_selector=None) -> bool:
     """
     Check if all the pods have Ready condition.
 
     :param v1: CoreV1Api
     :param namespace: namespace
+    :param label_selector: Kubernetes label selector for pods required by the test
     :return: bool
     """
-    pods = v1.list_namespaced_pod(namespace)
-    if not pods.items:
+    pods = v1.list_namespaced_pod(namespace, label_selector=label_selector)
+    active_pods = [pod for pod in pods.items if pod.metadata.deletion_timestamp is None]
+    if not active_pods:
         return False
     pod_ready_amount = 0
-    for pod in pods.items:
+    for pod in active_pods:
         print(f"Pod {pod.metadata.name} has image {pod.spec.containers[0].image}")
         if pod.status.conditions is None:
             return False
@@ -397,10 +403,10 @@ def are_all_pods_in_ready_state(v1: CoreV1Api, namespace) -> bool:
             if condition.type == "Ready" and condition.status == "True":
                 pod_ready_amount = pod_ready_amount + 1
                 break
-    return pod_ready_amount == len(pods.items)
+    return pod_ready_amount == len(active_pods)
 
 
-def get_pods_amount(v1: CoreV1Api, namespace) -> int:
+def get_pods_amount(v1: CoreV1Api, namespace, label_selector=None) -> int:
     """
     Get an amount of pods.
 
@@ -408,11 +414,11 @@ def get_pods_amount(v1: CoreV1Api, namespace) -> int:
     :param namespace: namespace
     :return: int
     """
-    pods = v1.list_namespaced_pod(namespace)
+    pods = v1.list_namespaced_pod(namespace, label_selector=label_selector)
     return 0 if not pods.items else len(pods.items)
 
 
-def get_pods_amount_with_name(v1: CoreV1Api, namespace, name) -> int:
+def get_pods_amount_with_name(v1: CoreV1Api, namespace, name, label_selector=None) -> int:
     """
     Get an amount of pods.
 
@@ -421,7 +427,7 @@ def get_pods_amount_with_name(v1: CoreV1Api, namespace, name) -> int:
     :param name: name
     :return: int
     """
-    pods = v1.list_namespaced_pod(namespace)
+    pods = v1.list_namespaced_pod(namespace, label_selector=label_selector)
     count = 0
     if pods and pods.items:
         for item in pods.items:
@@ -430,7 +436,7 @@ def get_pods_amount_with_name(v1: CoreV1Api, namespace, name) -> int:
     return count
 
 
-def get_pod_name_that_contains(v1: CoreV1Api, namespace, contains_string) -> str:
+def get_pod_name_that_contains(v1: CoreV1Api, namespace, contains_string, label_selector=None) -> str:
     """
     Get an amount of pods.
 
@@ -439,7 +445,7 @@ def get_pod_name_that_contains(v1: CoreV1Api, namespace, contains_string) -> str
     :param contains_string: string to search on
     :return: string
     """
-    for item in v1.list_namespaced_pod(namespace).items:
+    for item in v1.list_namespaced_pod(namespace, label_selector=label_selector).items:
         if contains_string in item.metadata.name:
             return item.metadata.name
     return ""
@@ -2286,18 +2292,22 @@ def get_last_log_entry(kube_apis, pod_name, namespace) -> str:
     return logs.split("\n")[-2]
 
 
-def get_resource_metrics(kube_apis, plural, namespace="nginx-ingress") -> str:
+def get_resource_metrics(kube_apis, plural, namespace="nginx-ingress", label_selector=None) -> str:
     """
     :param kube_apis: kube apis
     :param namespace: the namespace
     :param plural: the plural of the resource
     """
     if plural == "pods":
-        metrics = kube_apis.list_namespaced_custom_object("metrics.k8s.io", "v1beta1", namespace, plural)
+        metrics = kube_apis.list_namespaced_custom_object(
+            "metrics.k8s.io", "v1beta1", namespace, plural, label_selector=label_selector
+        )
         while metrics["items"] == []:
             wait_before_test()
             try:
-                metrics = kube_apis.list_namespaced_custom_object("metrics.k8s.io", "v1beta1", namespace, plural)
+                metrics = kube_apis.list_namespaced_custom_object(
+                    "metrics.k8s.io", "v1beta1", namespace, plural, label_selector=label_selector
+                )
             except ApiException as e:
                 print(f"Error: {e}")
     elif plural == "nodes":

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -1314,7 +1314,7 @@ def create_ingress_controller(
     else:
         raise ValueError(f"Unknown deployment-type: {cli_arguments['deployment-type']}")
     before = time.time()
-    wait_until_all_pods_are_ready(v1, namespace)
+    wait_until_all_pods_are_ready(v1, namespace, get_e2e_run_selector(e2e_run_id) if e2e_run_id else None)
     after = time.time()
     print(f"All pods came up in {int(after - before)} seconds")
     print(f"Ingress Controller was created with name '{name}'")
@@ -1530,7 +1530,7 @@ def create_ingress_controller_wafv5(
     else:
         raise ValueError(f"Unknown deployment-type: {cli_arguments['deployment-type']}")
     before = time.time()
-    wait_until_all_pods_are_ready(v1, namespace)
+    wait_until_all_pods_are_ready(v1, namespace, get_e2e_run_selector(e2e_run_id) if e2e_run_id else None)
     after = time.time()
     print(f"All pods came up in {int(after - before)} seconds")
     print(f"Ingress Controller was created with name '{name}'")
@@ -1577,7 +1577,7 @@ def create_dos_arbitrator(
     name = create_deployment(apps_v1_api, namespace, dep, e2e_run_id)
 
     before = time.time()
-    wait_until_all_pods_are_ready(v1, namespace)
+    wait_until_all_pods_are_ready(v1, namespace, get_e2e_run_selector(e2e_run_id) if e2e_run_id else None)
     after = time.time()
     print(f"All pods came up in {int(after - before)} seconds")
     print(f"Dos arbitrator was created with name '{name}'")
@@ -2375,12 +2375,12 @@ def read_ingress(v1: NetworkingV1Api, name, namespace) -> V1Ingress:
     return v1.read_namespaced_ingress(name, namespace)
 
 
-def pod_restart(v1: CoreV1Api, namespace):
+def pod_restart(v1: CoreV1Api, namespace, label_selector=None):
     """
     Restart all pods in a deployment.
     """
     try:
-        pods = v1.list_namespaced_pod(namespace=namespace)
+        pods = v1.list_namespaced_pod(namespace=namespace, label_selector=label_selector)
 
         print(f"Found {len(pods.items)} pods to restart")
 
@@ -2389,7 +2389,7 @@ def pod_restart(v1: CoreV1Api, namespace):
             print(f"Deleting pod {pod.metadata.name}")
             v1.delete_namespaced_pod(name=pod.metadata.name, namespace=namespace)
 
-        wait_until_all_pods_are_ready(v1, namespace)
+        wait_until_all_pods_are_ready(v1, namespace, label_selector)
         print("Pod restart complete")
 
     except Exception as e:

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import time
+import uuid
 from unittest import mock
 
 import pytest
@@ -27,6 +28,27 @@ from kubernetes.stream import stream
 from more_itertools import first
 from settings import DEPLOYMENTS, NGX_REG, PROJECT_ROOT, RECONFIGURATION_DELAY, TEST_DATA, WAF_V5_VERSION
 from suite.utils.ssl_utils import create_sni_session
+
+E2E_RUN_ID_LABEL = "e2e.nginx.org/run-id"
+
+
+def generate_e2e_run_id() -> str:
+    """Generate a Kubernetes-label-safe identifier for one e2e test invocation."""
+    return uuid.uuid4().hex
+
+
+def get_e2e_run_selector(e2e_run_id: str) -> str:
+    """Return the pod label selector for an e2e run."""
+    return f"{E2E_RUN_ID_LABEL}={e2e_run_id}"
+
+
+def add_e2e_run_id_to_workload(workload: dict, e2e_run_id: str) -> None:
+    """Add an e2e run ID only to a workload's pod template."""
+    if workload["kind"] not in {"Deployment", "DaemonSet", "StatefulSet"}:
+        raise ValueError(f"Unsupported workload kind: {workload['kind']}")
+
+    labels = workload["spec"]["template"].setdefault("metadata", {}).setdefault("labels", {})
+    labels[E2E_RUN_ID_LABEL] = e2e_run_id
 
 
 class RBACAuthorization:

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -177,7 +177,7 @@ def cleanup_rbac(rbac_v1: RbacAuthorizationV1Api, rbac: RBACAuthorization) -> No
     rbac_v1.delete_cluster_role(rbac.role)
 
 
-def create_deployment_from_yaml(apps_v1_api: AppsV1Api, namespace, yaml_manifest) -> str:
+def create_deployment_from_yaml(apps_v1_api: AppsV1Api, namespace, yaml_manifest, e2e_run_id=None) -> str:
     """
     Create a deployment based on yaml file.
 
@@ -189,7 +189,7 @@ def create_deployment_from_yaml(apps_v1_api: AppsV1Api, namespace, yaml_manifest
     print(f"Load {yaml_manifest}")
     with open(yaml_manifest) as f:
         dep = yaml.safe_load(f)
-    return create_deployment(apps_v1_api, namespace, dep)
+    return create_deployment(apps_v1_api, namespace, dep, e2e_run_id)
 
 
 def patch_deployment_from_yaml(apps_v1_api: AppsV1Api, namespace, yaml_manifest) -> str:
@@ -222,7 +222,7 @@ def patch_deployment(apps_v1_api: AppsV1Api, namespace, body) -> str:
     return body["metadata"]["name"]
 
 
-def create_deployment(apps_v1_api: AppsV1Api, namespace, body) -> str:
+def create_deployment(apps_v1_api: AppsV1Api, namespace, body, e2e_run_id=None) -> str:
     """
     Create a deployment based on a dict.
 
@@ -231,13 +231,15 @@ def create_deployment(apps_v1_api: AppsV1Api, namespace, body) -> str:
     :param body: dict
     :return: str
     """
+    if e2e_run_id:
+        add_e2e_run_id_to_workload(body, e2e_run_id)
     print("Create a deployment:")
     apps_v1_api.create_namespaced_deployment(namespace, body)
     print(f"Deployment created with name '{body['metadata']['name']}'")
     return body["metadata"]["name"]
 
 
-def create_deployment_with_name(apps_v1_api: AppsV1Api, namespace, name) -> str:
+def create_deployment_with_name(apps_v1_api: AppsV1Api, namespace, name, e2e_run_id=None) -> str:
     """
     Create a deployment with a specific name based on common yaml file.
 
@@ -253,7 +255,7 @@ def create_deployment_with_name(apps_v1_api: AppsV1Api, namespace, name) -> str:
         dep["spec"]["selector"]["matchLabels"]["app"] = name
         dep["spec"]["template"]["metadata"]["labels"]["app"] = name
         dep["spec"]["template"]["spec"]["containers"][0]["name"] = name
-        return create_deployment(apps_v1_api, namespace, dep)
+        return create_deployment(apps_v1_api, namespace, dep, e2e_run_id)
 
 
 def scale_deployment(v1: CoreV1Api, apps_v1_api: AppsV1Api, name, namespace, value) -> int:
@@ -292,7 +294,7 @@ def scale_deployment(v1: CoreV1Api, apps_v1_api: AppsV1Api, name, namespace, val
     return original
 
 
-def create_daemon_set(apps_v1_api: AppsV1Api, namespace, body) -> str:
+def create_daemon_set(apps_v1_api: AppsV1Api, namespace, body, e2e_run_id=None) -> str:
     """
     Create a daemon-set based on a dict.
 
@@ -301,13 +303,15 @@ def create_daemon_set(apps_v1_api: AppsV1Api, namespace, body) -> str:
     :param body: dict
     :return: str
     """
+    if e2e_run_id:
+        add_e2e_run_id_to_workload(body, e2e_run_id)
     print("Create a daemon-set:")
     apps_v1_api.create_namespaced_daemon_set(namespace, body)
     print(f"Daemon-Set created with name '{body['metadata']['name']}'")
     return body["metadata"]["name"]
 
 
-def create_stateful_set(apps_v1_api, namespace, body) -> str:
+def create_stateful_set(apps_v1_api, namespace, body, e2e_run_id=None) -> str:
     """
     Create a stateful-set based on a dict.
 
@@ -316,6 +320,8 @@ def create_stateful_set(apps_v1_api, namespace, body) -> str:
     :param body: dict
     :return: str
     """
+    if e2e_run_id:
+        add_e2e_run_id_to_workload(body, e2e_run_id)
     print("Create a statefulset:")
     apps_v1_api.create_namespaced_stateful_set(namespace, body)
     print(f"StatefulSet created with name '{body['metadata']['name']}'")
@@ -488,7 +494,7 @@ def create_service_with_name(v1: CoreV1Api, namespace, name, port=80, targetPort
         return create_service(v1, namespace, dep)
 
 
-def create_secure_app_deployment_with_name(apps_v1_api: AppsV1Api, namespace, name) -> str:
+def create_secure_app_deployment_with_name(apps_v1_api: AppsV1Api, namespace, name, e2e_run_id=None) -> str:
     """
     Deploys app in /common/app/secure in the configured name and namespace
 
@@ -504,7 +510,7 @@ def create_secure_app_deployment_with_name(apps_v1_api: AppsV1Api, namespace, na
         dep["spec"]["selector"]["matchLabels"]["app"] = name
         dep["spec"]["template"]["metadata"]["labels"]["app"] = name
         dep["spec"]["template"]["spec"]["containers"][0]["name"] = name
-        return create_deployment(apps_v1_api, namespace, dep)
+        return create_deployment(apps_v1_api, namespace, dep, e2e_run_id)
 
 
 def get_service_node_ports(v1: CoreV1Api, name, namespace) -> (int, int, int, int, int, int, int):
@@ -1124,7 +1130,7 @@ def extract_block(nginx_config, block_name):
     return nginx_config[start:end]
 
 
-def create_example_app(kube_apis, app_type, namespace) -> None:
+def create_example_app(kube_apis, app_type, namespace, e2e_run_id=None) -> None:
     """
     Create a backend application.
 
@@ -1140,7 +1146,7 @@ def create_example_app(kube_apis, app_type, namespace) -> None:
         if is_secret_present(kube_apis.v1, secret_name, namespace):
             delete_secret(kube_apis.v1, secret_name, namespace)
         create_secret_from_yaml(kube_apis.v1, namespace, f"{TEST_DATA}/common/app/{app_type}/app-tls-secret.yaml")
-    create_items_from_yaml(kube_apis, f"{TEST_DATA}/common/app/{app_type}/app.yaml", namespace)
+    create_items_from_yaml(kube_apis, f"{TEST_DATA}/common/app/{app_type}/app.yaml", namespace, e2e_run_id)
 
 
 def delete_common_app(kube_apis, app_type, namespace) -> None:
@@ -1265,7 +1271,9 @@ def wait_for_event_increment(kube_apis, namespace, event_count, offset) -> bool:
         return False
 
 
-def create_ingress_controller(v1: CoreV1Api, apps_v1_api: AppsV1Api, cli_arguments, namespace, args=None) -> str:
+def create_ingress_controller(
+    v1: CoreV1Api, apps_v1_api: AppsV1Api, cli_arguments, namespace, args=None, e2e_run_id=None
+) -> str:
     """
     Create an Ingress Controller according to the params.
 
@@ -1292,11 +1300,11 @@ def create_ingress_controller(v1: CoreV1Api, apps_v1_api: AppsV1Api, cli_argumen
     if args is not None:
         dep["spec"]["template"]["spec"]["containers"][0]["args"].extend(args)
     if cli_arguments["deployment-type"] == "deployment":
-        name = create_deployment(apps_v1_api, namespace, dep)
+        name = create_deployment(apps_v1_api, namespace, dep, e2e_run_id)
     elif cli_arguments["deployment-type"] == "daemon-set":
-        name = create_daemon_set(apps_v1_api, namespace, dep)
+        name = create_daemon_set(apps_v1_api, namespace, dep, e2e_run_id)
     elif cli_arguments["deployment-type"] == "stateful-set":
-        name = create_stateful_set(apps_v1_api, namespace, dep)
+        name = create_stateful_set(apps_v1_api, namespace, dep, e2e_run_id)
     else:
         raise ValueError(f"Unknown deployment-type: {cli_arguments['deployment-type']}")
     before = time.time()
@@ -1308,7 +1316,14 @@ def create_ingress_controller(v1: CoreV1Api, apps_v1_api: AppsV1Api, cli_argumen
 
 
 def create_ingress_controller_wafv5(
-    v1: CoreV1Api, apps_v1_api: AppsV1Api, cli_arguments, namespace, reg_secret, args=None, rorfs=False
+    v1: CoreV1Api,
+    apps_v1_api: AppsV1Api,
+    cli_arguments,
+    namespace,
+    reg_secret,
+    args=None,
+    rorfs=False,
+    e2e_run_id=None,
 ) -> str:
     """
     Create an Ingress Controller according to the params.
@@ -1501,11 +1516,11 @@ def create_ingress_controller_wafv5(
     if args is not None:
         dep["spec"]["template"]["spec"]["containers"][0]["args"].extend(args)
     if cli_arguments["deployment-type"] == "deployment":
-        name = create_deployment(apps_v1_api, namespace, dep)
+        name = create_deployment(apps_v1_api, namespace, dep, e2e_run_id)
     elif cli_arguments["deployment-type"] == "daemon-set":
-        name = create_daemon_set(apps_v1_api, namespace, dep)
+        name = create_daemon_set(apps_v1_api, namespace, dep, e2e_run_id)
     elif cli_arguments["deployment-type"] == "stateful-set":
-        name = create_stateful_set(apps_v1_api, namespace, dep)
+        name = create_stateful_set(apps_v1_api, namespace, dep, e2e_run_id)
     else:
         raise ValueError(f"Unknown deployment-type: {cli_arguments['deployment-type']}")
     before = time.time()
@@ -1537,7 +1552,7 @@ def delete_ingress_controller(apps_v1_api: AppsV1Api, name, dep_type, namespace)
 
 
 def create_dos_arbitrator(
-    v1: CoreV1Api, apps_v1_api: AppsV1Api, namespace, deployment_yaml_manifest, svc_yaml_manifest
+    v1: CoreV1Api, apps_v1_api: AppsV1Api, namespace, deployment_yaml_manifest, svc_yaml_manifest, e2e_run_id=None
 ) -> str:
     """
     Create dos arbitrator according to the params.
@@ -1553,7 +1568,7 @@ def create_dos_arbitrator(
     with open(deployment_yaml_manifest) as f:
         dep = yaml.safe_load(f)
 
-    name = create_deployment(apps_v1_api, namespace, dep)
+    name = create_deployment(apps_v1_api, namespace, dep, e2e_run_id)
 
     before = time.time()
     wait_until_all_pods_are_ready(v1, namespace)
@@ -1606,7 +1621,7 @@ def create_ns_and_sa_from_yaml(v1: CoreV1Api, yaml_manifest) -> str:
     return res["namespace"]
 
 
-def create_items_from_yaml(kube_apis, yaml_manifest, namespace) -> {}:
+def create_items_from_yaml(kube_apis, yaml_manifest, namespace, e2e_run_id=None) -> {}:
     """
     Apply yaml manifest with multiple items.
 
@@ -1630,11 +1645,11 @@ def create_items_from_yaml(kube_apis, yaml_manifest, namespace) -> {}:
                 elif doc["kind"] == "Service":
                     res["Service"] = create_service(kube_apis.v1, namespace, doc)
                 elif doc["kind"] == "Deployment":
-                    res["Deployment"] = create_deployment(kube_apis.apps_v1_api, namespace, doc)
+                    res["Deployment"] = create_deployment(kube_apis.apps_v1_api, namespace, doc, e2e_run_id)
                 elif doc["kind"] == "DaemonSet":
-                    res["DaemonSet"] = create_daemon_set(kube_apis.apps_v1_api, namespace, doc)
+                    res["DaemonSet"] = create_daemon_set(kube_apis.apps_v1_api, namespace, doc, e2e_run_id)
                 elif doc["kind"] == "StatefulSet":
-                    res["StatefulSet"] = create_stateful_set(kube_apis.apps_v1_api, namespace, doc)
+                    res["StatefulSet"] = create_stateful_set(kube_apis.apps_v1_api, namespace, doc, e2e_run_id)
                 elif doc["kind"] == "Namespace":
                     res["Namespace"] = create_namespace(kube_apis.v1, doc)
 

--- a/tests/suite/utils/test_e2e_run_id.py
+++ b/tests/suite/utils/test_e2e_run_id.py
@@ -1,9 +1,16 @@
 import re
+import tempfile
+from unittest.mock import Mock, patch
 
 import pytest
+import yaml
+from suite.fixtures.fixtures import create_generic_from_yaml
 from suite.utils.resources_utils import (
     E2E_RUN_ID_LABEL,
     add_e2e_run_id_to_workload,
+    create_daemon_set,
+    create_deployment,
+    create_stateful_set,
     generate_e2e_run_id,
     get_e2e_run_selector,
 )
@@ -40,3 +47,49 @@ def test_e2e_run_id_is_label_safe_and_formats_a_selector():
 def test_add_e2e_run_id_to_workload_rejects_non_workloads():
     with pytest.raises(ValueError, match="Unsupported workload kind: Service"):
         add_e2e_run_id_to_workload({"kind": "Service"}, "run-id")
+
+
+@pytest.mark.parametrize(
+    ("creator", "api_method", "kind"),
+    [
+        (create_deployment, "create_namespaced_deployment", "Deployment"),
+        (create_daemon_set, "create_namespaced_daemon_set", "DaemonSet"),
+        (create_stateful_set, "create_namespaced_stateful_set", "StatefulSet"),
+    ],
+)
+def test_workload_creators_add_the_supplied_run_id(creator, api_method, kind):
+    workload = {
+        "kind": kind,
+        "metadata": {"name": "workload"},
+        "spec": {"template": {"metadata": {"labels": {}}}},
+    }
+    api = Mock()
+
+    creator(api, "test-namespace", workload, "run-id")
+
+    assert workload["spec"]["template"]["metadata"]["labels"][E2E_RUN_ID_LABEL] == "run-id"
+    getattr(api, api_method).assert_called_once_with("test-namespace", workload)
+
+
+def test_generic_apply_labels_workloads_in_memory():
+    docs = [
+        {"kind": "Service", "metadata": {"name": "service"}},
+        {
+            "kind": "Deployment",
+            "metadata": {"name": "deployment"},
+            "spec": {"template": {"metadata": {"labels": {}}}},
+        },
+    ]
+    request = Mock()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as manifest:
+        yaml.safe_dump_all(docs, manifest)
+        manifest.flush()
+        with patch("suite.fixtures.fixtures.subprocess.run") as run:
+            create_generic_from_yaml(manifest.name, request, "run-id")
+
+    command = run.call_args.args[0]
+    kwargs = run.call_args.kwargs
+    assert command == ["kubectl", "apply", "-f", "-"]
+    applied_docs = list(yaml.safe_load_all(kwargs["input"]))
+    assert E2E_RUN_ID_LABEL not in applied_docs[0].get("metadata", {}).get("labels", {})
+    assert applied_docs[1]["spec"]["template"]["metadata"]["labels"][E2E_RUN_ID_LABEL] == "run-id"

--- a/tests/suite/utils/test_e2e_run_id.py
+++ b/tests/suite/utils/test_e2e_run_id.py
@@ -1,0 +1,42 @@
+import re
+
+import pytest
+from suite.utils.resources_utils import (
+    E2E_RUN_ID_LABEL,
+    add_e2e_run_id_to_workload,
+    generate_e2e_run_id,
+    get_e2e_run_selector,
+)
+
+
+@pytest.mark.parametrize("kind", ["Deployment", "DaemonSet", "StatefulSet"])
+def test_add_e2e_run_id_to_workload_updates_only_pod_template(kind):
+    workload = {
+        "kind": kind,
+        "metadata": {"labels": {"top-level": "unchanged"}},
+        "spec": {
+            "selector": {"matchLabels": {"app": "backend"}},
+            "template": {"metadata": {"labels": {"app": "backend"}}},
+        },
+    }
+
+    add_e2e_run_id_to_workload(workload, "run-id")
+
+    assert workload["metadata"]["labels"] == {"top-level": "unchanged"}
+    assert workload["spec"]["selector"] == {"matchLabels": {"app": "backend"}}
+    assert workload["spec"]["template"]["metadata"]["labels"] == {
+        "app": "backend",
+        E2E_RUN_ID_LABEL: "run-id",
+    }
+
+
+def test_e2e_run_id_is_label_safe_and_formats_a_selector():
+    e2e_run_id = generate_e2e_run_id()
+
+    assert re.fullmatch(r"[0-9a-f]{32}", e2e_run_id)
+    assert get_e2e_run_selector(e2e_run_id) == f"{E2E_RUN_ID_LABEL}={e2e_run_id}"
+
+
+def test_add_e2e_run_id_to_workload_rejects_non_workloads():
+    with pytest.raises(ValueError, match="Unsupported workload kind: Service"):
+        add_e2e_run_id_to_workload({"kind": "Service"}, "run-id")

--- a/tests/suite/utils/test_e2e_run_id.py
+++ b/tests/suite/utils/test_e2e_run_id.py
@@ -1,5 +1,6 @@
 import re
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -8,6 +9,7 @@ from suite.fixtures.fixtures import create_generic_from_yaml
 from suite.utils.resources_utils import (
     E2E_RUN_ID_LABEL,
     add_e2e_run_id_to_workload,
+    are_all_pods_in_ready_state,
     create_daemon_set,
     create_deployment,
     create_stateful_set,
@@ -93,3 +95,21 @@ def test_generic_apply_labels_workloads_in_memory():
     applied_docs = list(yaml.safe_load_all(kwargs["input"]))
     assert E2E_RUN_ID_LABEL not in applied_docs[0].get("metadata", {}).get("labels", {})
     assert applied_docs[1]["spec"]["template"]["metadata"]["labels"][E2E_RUN_ID_LABEL] == "run-id"
+
+
+def test_ready_check_ignores_terminating_pods_and_uses_the_run_selector():
+    ready_pod = SimpleNamespace(
+        metadata=SimpleNamespace(name="current", deletion_timestamp=None),
+        spec=SimpleNamespace(containers=[SimpleNamespace(image="backend")]),
+        status=SimpleNamespace(conditions=[SimpleNamespace(type="Ready", status="True")]),
+    )
+    terminating_pod = SimpleNamespace(
+        metadata=SimpleNamespace(name="previous", deletion_timestamp="2026-09-11T00:00:00Z"),
+        spec=SimpleNamespace(containers=[SimpleNamespace(image="backend")]),
+        status=SimpleNamespace(conditions=[SimpleNamespace(type="Ready", status="False")]),
+    )
+    v1 = Mock()
+    v1.list_namespaced_pod.return_value = SimpleNamespace(items=[ready_pod, terminating_pod])
+
+    assert are_all_pods_in_ready_state(v1, "test-namespace", "e2e.nginx.org/run-id=run-id")
+    v1.list_namespaced_pod.assert_called_once_with("test-namespace", label_selector="e2e.nginx.org/run-id=run-id")


### PR DESCRIPTION
### Proposed changes

Each individual test gets a run id. That run id gets passed to the various functions that create pods/deployments/services/whatever and they apply that id as a label called `e2e.nginx.org/run-id`, so the necessary functions that fetch, wait for, and delete resources are properly limited to workloads for that individual test.

Fixture scoped resources get their own id, so they aren't scooped up in the queries from above.

This is a required, but insufficient part of eventually parallelising python tests.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
